### PR TITLE
ci: validate docker build on pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,3 +37,24 @@ jobs:
 
       - name: Run tests
         run: go test ./...
+
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Adds a `docker-build` job to `pr.yml` that builds the Docker image (no push) on every pull request
- Guards with `if: github.event_name == 'pull_request'` so it doesn't duplicate the post-merge push in `docker.yml`
- Builds `linux/amd64` only (sufficient for correctness validation); uses GHA cache to warm layers for the post-merge push

Closes #2

## Test plan
- [ ] Open a PR and confirm the "Docker Build" check appears and passes
- [ ] Merge and confirm `ghcr.io/sushi30/sushiclaw:latest` is updated via `docker.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)