### PR TITLE
fix: resolve env:// references in email channel config

### DIFF
--- a/internal/envresolve/envresolve.go
+++ b/internal/envresolve/envresolve.go
@@ -20,6 +20,11 @@ func Config(cfg *config.Config) {
 	}
 }
 
+// SecureString resolves a single env://VAR_NAME reference in-place.
+func SecureString(s *config.SecureString) {
+	resolveSecureString(s)
+}
+
 func resolveSecureString(s *config.SecureString) {
 	if s == nil {
 		return

--- a/pkg/channels/email/email_test.go
+++ b/pkg/channels/email/email_test.go
@@ -1,6 +1,8 @@
 package email
 
 import (
+	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -135,6 +137,54 @@ func TestDisplayName(t *testing.T) {
 				t.Errorf("displayName() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestLoadEmailConfig_ResolvesEnvSecureStrings(t *testing.T) {
+	t.Setenv("EMAIL_SMTP_PASS", "secret-smtp-pass")
+	t.Setenv("EMAIL_IMAP_PASS", "secret-imap-pass")
+
+	raw := map[string]any{
+		"channels": map[string]any{
+			"email": map[string]any{
+				"enabled":   true,
+				"smtp_host": "smtp.example.com",
+				"smtp_from": "bot@example.com",
+				"smtp_password": "env://EMAIL_SMTP_PASS",
+				"imap_host": "imap.example.com",
+				"imap_user": "bot@example.com",
+				"imap_password": "env://EMAIL_IMAP_PASS",
+			},
+		},
+	}
+	data, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), "config*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("SUSHICLAW_CONFIG", f.Name())
+
+	cfg, err := loadEmailConfig()
+	if err != nil {
+		t.Fatalf("loadEmailConfig() error: %v", err)
+	}
+
+	if got := cfg.SMTPPassword.String(); got != "secret-smtp-pass" {
+		t.Errorf("SMTPPassword = %q, want %q", got, "secret-smtp-pass")
+	}
+	if got := cfg.IMAPPassword.String(); got != "secret-imap-pass" {
+		t.Errorf("IMAPPassword = %q, want %q", got, "secret-imap-pass")
 	}
 }
 

--- a/pkg/channels/email/init.go
+++ b/pkg/channels/email/init.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/channels"
 	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/internal/envresolve"
 )
 
 func init() {
@@ -40,7 +41,13 @@ func loadEmailConfig() (EmailConfig, error) {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return EmailConfig{}, err
 	}
-	return raw.Channels.Email, nil
+	cfg := raw.Channels.Email
+	envresolve.SecureString(&cfg.SMTPFrom)
+	envresolve.SecureString(&cfg.SMTPUser)
+	envresolve.SecureString(&cfg.SMTPPassword)
+	envresolve.SecureString(&cfg.IMAPUser)
+	envresolve.SecureString(&cfg.IMAPPassword)
+	return cfg, nil
 }
 
 func configFilePath() string {


### PR DESCRIPTION
## Summary

- `envresolve.SecureString` exported as a public API for resolving individual fields
- `loadEmailConfig` now resolves all five `SecureString` fields (`SMTPFrom`, `SMTPUser`, `SMTPPassword`, `IMAPUser`, `IMAPPassword`) after JSON unmarshalling
- Without this fix, `env://VAR_NAME` values reached `smtp.PlainAuth` as literal strings, causing auth failures

## Test plan

- [ ] `TestLoadEmailConfig_ResolvesEnvSecureStrings` — new test: writes a temp config with `env://` values, asserts they resolve correctly
- [ ] Full suite: `go test ./...` — all pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)