### PR TITLE
fix(email): handle html-only inbound messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.mau.fi/whatsmeow v0.0.0-20260219150138-7ae702b1eed4
+	golang.org/x/net v0.52.0
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.47.0
 )
@@ -94,7 +95,6 @@ require (
 	golang.org/x/arch v0.24.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
-	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/pkg/channels/email/email.go
+++ b/pkg/channels/email/email.go
@@ -1,6 +1,7 @@
 package email
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	imap "github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapclient"
 	gomail "github.com/emersion/go-message/mail"
+	"golang.org/x/net/html"
 
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/channels"
@@ -295,28 +297,10 @@ func (c *EmailChannel) pollIMAP() {
 		if envelope == nil || bodySectionData == nil {
 			continue
 		}
-
-		fromAddr := extractFrom(envelope)
-		if fromAddr == "" {
+		processed, _ := c.processEmail(c.ctx, envelope, bodySectionData.Literal)
+		if !processed {
 			continue
 		}
-
-		messageID := envelope.MessageID
-		plainText := extractPlainText(bodySectionData.Literal)
-
-		sender := bus.SenderInfo{
-			Platform:    "email",
-			PlatformID:  fromAddr,
-			CanonicalID: "email:" + fromAddr,
-			DisplayName: displayName(envelope),
-		}
-
-		c.HandleMessage(c.ctx,
-			bus.Peer{Kind: "direct", ID: fromAddr},
-			messageID, fromAddr, fromAddr, plainText,
-			nil, nil,
-			sender,
-		)
 
 		// Mark message as \Seen
 		storeSeq := imap.SeqSetNum(seqNum)
@@ -333,6 +317,39 @@ func (c *EmailChannel) pollIMAP() {
 	if err := fetchCmd.Close(); err != nil {
 		logger.WarnCF("email", "IMAP FETCH close error", map[string]any{"err": err})
 	}
+}
+
+func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope, bodyLiteral io.Reader) (bool, string) {
+	fromAddr := extractFrom(envelope)
+	if fromAddr == "" {
+		return false, ""
+	}
+
+	plainText := extractPlainText(bodyLiteral)
+	if strings.TrimSpace(plainText) == "" {
+		return false, ""
+	}
+
+	logger.DebugCF("email", "Email received", map[string]any{
+		"from":    fromAddr,
+		"subject": envelope.Subject,
+	})
+
+	sender := bus.SenderInfo{
+		Platform:    "email",
+		PlatformID:  fromAddr,
+		CanonicalID: "email:" + fromAddr,
+		DisplayName: displayName(envelope),
+	}
+
+	c.HandleMessage(ctx,
+		bus.Peer{Kind: "direct", ID: fromAddr},
+		envelope.MessageID, fromAddr, fromAddr, plainText,
+		nil, nil,
+		sender,
+	)
+
+	return true, plainText
 }
 
 func extractFrom(env *imap.Envelope) string {
@@ -357,14 +374,20 @@ func displayName(env *imap.Envelope) string {
 }
 
 // extractPlainText reads the message body and returns the first text/plain part.
+// If only HTML is available, it extracts visible text from text/html instead.
 // Falls back to the raw body if parsing fails.
 func extractPlainText(r io.Reader) string {
-	mr, err := gomail.CreateReader(r)
+	raw, err := io.ReadAll(r)
 	if err != nil {
-		// Fallback: read raw bytes
-		b, _ := io.ReadAll(r)
-		return strings.TrimSpace(string(b))
+		return ""
 	}
+
+	mr, err := gomail.CreateReader(bytes.NewReader(raw))
+	if err != nil {
+		return strings.TrimSpace(string(raw))
+	}
+
+	var htmlFallback string
 
 	for {
 		p, err := mr.NextPart()
@@ -385,7 +408,50 @@ func extractPlainText(r io.Reader) string {
 			if text != "" {
 				return text
 			}
+			continue
+		}
+		if ct == "text/html" && htmlFallback == "" {
+			b, _ := io.ReadAll(p.Body)
+			htmlFallback = stripHTMLText(string(b))
 		}
 	}
+
+	if htmlFallback != "" {
+		return htmlFallback
+	}
+
 	return ""
+}
+
+func stripHTMLText(src string) string {
+	doc, err := html.Parse(strings.NewReader(src))
+	if err != nil {
+		return strings.TrimSpace(src)
+	}
+
+	var b strings.Builder
+	var walk func(*html.Node, bool)
+	walk = func(n *html.Node, hidden bool) {
+		if n == nil {
+			return
+		}
+		if n.Type == html.ElementNode {
+			switch n.Data {
+			case "script", "style", "head":
+				hidden = true
+			case "br", "p", "div", "li", "tr", "td", "th":
+				b.WriteByte(' ')
+			}
+		}
+		if n.Type == html.TextNode && !hidden {
+			b.WriteString(n.Data)
+			b.WriteByte(' ')
+		}
+		for child := n.FirstChild; child != nil; child = child.NextSibling {
+			walk(child, hidden)
+		}
+	}
+	walk(doc, false)
+
+	return strings.Join(strings.Fields(b.String()), " ")
 }

--- a/pkg/channels/email/email_test.go
+++ b/pkg/channels/email/email_test.go
@@ -1,14 +1,17 @@
 package email
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	imap "github.com/emersion/go-imap/v2"
 
 	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/channels"
 	"github.com/sipeed/picoclaw/pkg/config"
 )
 
@@ -219,7 +222,7 @@ func TestExtractPlainText(t *testing.T) {
 		{
 			name:  "html-only MIME",
 			input: htmlMIME,
-			want:  "",
+			want:  "Hi",
 		},
 		{
 			name:  "multipart with text/plain",
@@ -228,11 +231,138 @@ func TestExtractPlainText(t *testing.T) {
 		},
 	}
 
+	multipartHTMLOnlyMIME := strings.Join([]string{
+		"MIME-Version: 1.0",
+		`Content-Type: multipart/alternative; boundary="boundary"`,
+		"",
+		"--boundary",
+		"Content-Type: text/html; charset=utf-8",
+		"",
+		"<html><head><style>.x{}</style></head><body><p>Hello <b>there</b></p></body></html>",
+		"--boundary--",
+	}, "\r\n")
+	multipartPlainWinsMIME := strings.Join([]string{
+		"MIME-Version: 1.0",
+		`Content-Type: multipart/alternative; boundary="boundary"`,
+		"",
+		"--boundary",
+		"Content-Type: text/plain; charset=utf-8",
+		"",
+		"Preferred plain text",
+		"--boundary",
+		"Content-Type: text/html; charset=utf-8",
+		"",
+		"<html><body>Ignored HTML</body></html>",
+		"--boundary--",
+	}, "\r\n")
+
+	tests = append(tests,
+		struct {
+			name  string
+			input string
+			want  string
+		}{"multipart/alternative html-only", multipartHTMLOnlyMIME, "Hello there"},
+		struct {
+			name  string
+			input string
+			want  string
+		}{"multipart/alternative plain wins over html", multipartPlainWinsMIME, "Preferred plain text"},
+	)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := extractPlainText(strings.NewReader(tt.input))
 			if got != tt.want {
 				t.Errorf("extractPlainText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProcessEmail_TextInteraction(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	ch := &EmailChannel{
+		BaseChannel: channels.NewBaseChannel("email", EmailConfig{}, messageBus, nil),
+	}
+
+	envelope := &imap.Envelope{
+		From:      []imap.Address{{Mailbox: "test", Host: "example.com", Name: "Test Sender"}},
+		Subject:   "HTML only",
+		MessageID: "mid-1",
+	}
+	body := strings.NewReader("MIME-Version: 1.0\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<html><body><p>Hello from email</p></body></html>")
+
+	processed, got := ch.processEmail(context.Background(), envelope, body)
+	if !processed {
+		t.Fatal("processEmail() reported skipped message")
+	}
+	if got != "Hello from email" {
+		t.Fatalf("processEmail() = %q, want %q", got, "Hello from email")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for inbound message")
+	case inbound, ok := <-messageBus.InboundChan():
+		if !ok {
+			t.Fatal("expected inbound message")
+		}
+		if inbound.Channel != "email" {
+			t.Fatalf("channel=%q", inbound.Channel)
+		}
+		if strings.TrimSpace(inbound.Content) == "" {
+			t.Fatal("expected non-empty content")
+		}
+		if inbound.Content != "Hello from email" {
+			t.Fatalf("content=%q", inbound.Content)
+		}
+	}
+}
+
+func TestProcessEmail_SkipsEmptyOrSenderlessMessages(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	ch := &EmailChannel{
+		BaseChannel: channels.NewBaseChannel("email", EmailConfig{}, messageBus, nil),
+	}
+
+	tests := []struct {
+		name     string
+		envelope *imap.Envelope
+		body     string
+	}{
+		{
+			name:     "missing sender",
+			envelope: &imap.Envelope{Subject: "No sender", MessageID: "mid-2"},
+			body:     "MIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nHello",
+		},
+		{
+			name: "empty extracted text",
+			envelope: &imap.Envelope{
+				From:      []imap.Address{{Mailbox: "test", Host: "example.com"}},
+				Subject:   "Whitespace only",
+				MessageID: "mid-3",
+			},
+			body: "MIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n   \r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processed, got := ch.processEmail(context.Background(), tt.envelope, strings.NewReader(tt.body))
+			if processed {
+				t.Fatal("expected processEmail() to skip message")
+			}
+			if got != "" {
+				t.Fatalf("processEmail() text = %q, want empty", got)
+			}
+
+			select {
+			case inbound := <-messageBus.InboundChan():
+				t.Fatalf("unexpected inbound message: %+v", inbound)
+			default:
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Port [`sushi30/picoclaw fix/email3`](https://github.com/sushi30/picoclaw/tree/fix/email3) into the owned email channel
- `extractPlainText` now buffers the raw body and falls back to HTML text extraction when no `text/plain` part exists
- New `stripHTMLText` helper uses `golang.org/x/net/html` to extract visible text (strips `<script>`, `<style>`, `<head>`)
- Refactors the IMAP poll loop's inline message-handling into `processEmail()`, which also skips messages with an empty body or missing sender
- `golang.org/x/net` promoted from indirect to direct dependency

## Test plan
- [x] `TestExtractPlainText` — updated html-only case now expects extracted text (`"Hi"`); added multipart/alternative html-only and plain-wins cases
- [x] `TestProcessEmail_TextInteraction` — verifies html-only email is processed and dispatched on the inbound channel
- [x] `TestProcessEmail_SkipsEmptyOrSenderlessMessages` — verifies skip logic for missing sender and whitespace-only body
- [x] All tests pass: `go test ./...`
- [x] Build clean: `make build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)