### PR TITLE
fix(email): fail fast when required env vars are unset

### DIFF
--- a/internal/envresolve/envresolve.go
+++ b/internal/envresolve/envresolve.go
@@ -5,6 +5,7 @@
 package envresolve
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -23,6 +24,16 @@ func Config(cfg *config.Config) {
 // SecureString resolves a single env://VAR_NAME reference in-place.
 func SecureString(s *config.SecureString) {
 	resolveSecureString(s)
+}
+
+// SecureStringRequired resolves a single env://VAR_NAME reference in-place and
+// returns an error if the referenced environment variable is not set.
+func SecureStringRequired(s *config.SecureString) error {
+	resolveSecureString(s)
+	if varName, ok := strings.CutPrefix(s.String(), "env://"); ok {
+		return fmt.Errorf("env var %s is not set", varName)
+	}
+	return nil
 }
 
 func resolveSecureString(s *config.SecureString) {

--- a/internal/envresolve/envresolve_test.go
+++ b/internal/envresolve/envresolve_test.go
@@ -2,6 +2,7 @@ package envresolve_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/sipeed/picoclaw/pkg/audio/asr"
@@ -57,6 +58,35 @@ func TestConfig_MissingEnvVar_LeavesUnchanged(t *testing.T) {
 	got := cfg.ModelList[0].APIKey()
 	if got != "env://MISSING_VAR" {
 		t.Errorf("APIKey() = %q, want %q (unresolved)", got, "env://MISSING_VAR")
+	}
+}
+
+func TestSecureStringRequired_MissingVar_ReturnsError(t *testing.T) {
+	_ = os.Unsetenv("REQUIRED_MISSING")
+
+	var s config.SecureString
+	s.Set("env://REQUIRED_MISSING")
+
+	err := envresolve.SecureStringRequired(&s)
+	if err == nil {
+		t.Fatal("SecureStringRequired() = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "REQUIRED_MISSING") {
+		t.Errorf("error %q does not mention var name", err.Error())
+	}
+}
+
+func TestSecureStringRequired_SetVar_ReturnsNil(t *testing.T) {
+	t.Setenv("REQUIRED_PRESENT", "myvalue")
+
+	var s config.SecureString
+	s.Set("env://REQUIRED_PRESENT")
+
+	if err := envresolve.SecureStringRequired(&s); err != nil {
+		t.Fatalf("SecureStringRequired() = %v, want nil", err)
+	}
+	if s.String() != "myvalue" {
+		t.Errorf("s.String() = %q, want %q", s.String(), "myvalue")
 	}
 }
 

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sushi30/sushiclaw/internal/envresolve"
+	"github.com/sushi30/sushiclaw/pkg/channels/email"
 
 	"github.com/sipeed/picoclaw/pkg/agent"
 	"github.com/sipeed/picoclaw/pkg/audio/asr"
@@ -96,6 +97,14 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	cm, err := channels.NewManager(cfg, msgBus, mediaStore)
 	if err != nil {
 		return fmt.Errorf("error creating channel manager: %w", err)
+	}
+
+	emailCh, err := email.InitChannel(msgBus)
+	if err != nil {
+		return fmt.Errorf("email channel: %w", err)
+	}
+	if emailCh != nil {
+		cm.RegisterChannel("email", emailCh)
 	}
 
 	agentLoop.SetChannelManager(cm)

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sushi30/sushiclaw/internal/gateway"
 
 	// Register owned channel implementations.
-	_ "github.com/sushi30/sushiclaw/pkg/channels/email"
 	_ "github.com/sushi30/sushiclaw/pkg/channels/telegram"
 	_ "github.com/sushi30/sushiclaw/pkg/channels/whatsapp_native"
 )

--- a/pkg/channels/email/email_test.go
+++ b/pkg/channels/email/email_test.go
@@ -191,6 +191,67 @@ func TestLoadEmailConfig_ResolvesEnvSecureStrings(t *testing.T) {
 	}
 }
 
+func writeConfigFile(t *testing.T, raw map[string]any) string {
+	t.Helper()
+	data, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.CreateTemp(t.TempDir(), "config*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return f.Name()
+}
+
+func TestInitChannel_Disabled_ReturnsNil(t *testing.T) {
+	raw := map[string]any{
+		"channels": map[string]any{
+			"email": map[string]any{"enabled": false},
+		},
+	}
+	t.Setenv("SUSHICLAW_CONFIG", writeConfigFile(t, raw))
+
+	ch, err := InitChannel(bus.NewMessageBus())
+	if err != nil {
+		t.Fatalf("InitChannel() error = %v, want nil", err)
+	}
+	if ch != nil {
+		t.Errorf("InitChannel() = %v, want nil for disabled channel", ch)
+	}
+}
+
+func TestInitChannel_MissingRequiredEnvVar_ReturnsError(t *testing.T) {
+	_ = os.Unsetenv("MISSING_IMAP_USER")
+	raw := map[string]any{
+		"channels": map[string]any{
+			"email": map[string]any{
+				"enabled":       true,
+				"smtp_host":     "smtp.example.com",
+				"smtp_from":     "bot@example.com",
+				"imap_host":     "imap.example.com",
+				"imap_user":     "env://MISSING_IMAP_USER",
+				"imap_password": "env://MISSING_IMAP_USER",
+			},
+		},
+	}
+	t.Setenv("SUSHICLAW_CONFIG", writeConfigFile(t, raw))
+
+	_, err := InitChannel(bus.NewMessageBus())
+	if err == nil {
+		t.Fatal("InitChannel() = nil error, want error for missing env var")
+	}
+	if !strings.Contains(err.Error(), "MISSING_IMAP_USER") {
+		t.Errorf("error %q does not mention var name", err.Error())
+	}
+}
+
 func TestExtractPlainText(t *testing.T) {
 	plainMIME := "MIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nHello, world!"
 	htmlMIME := "MIME-Version: 1.0\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<html><body>Hi</body></html>"

--- a/pkg/channels/email/init.go
+++ b/pkg/channels/email/init.go
@@ -7,25 +7,25 @@ import (
 
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/channels"
-	"github.com/sipeed/picoclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/internal/envresolve"
 )
 
-func init() {
-	channels.RegisterFactory("email", func(cfg *config.Config, b *bus.MessageBus) (channels.Channel, error) {
-		emailCfg, err := loadEmailConfig()
-		if err != nil {
-			return nil, err
-		}
-		if !emailCfg.Enabled {
-			return nil, nil
-		}
-		return NewEmailChannel(emailCfg, b)
-	})
+// InitChannel loads email config, resolves env vars, and returns an initialized
+// EmailChannel. Returns (nil, nil) if email is disabled in config.
+// Returns an error if email is enabled but a required env var is unset.
+func InitChannel(b *bus.MessageBus) (channels.Channel, error) {
+	emailCfg, err := loadEmailConfig()
+	if err != nil {
+		return nil, err
+	}
+	if !emailCfg.Enabled {
+		return nil, nil
+	}
+	return NewEmailChannel(emailCfg, b)
 }
 
-// loadEmailConfig reads the "channels.email" section from the config file.
-// Mirrors gateway.GetConfigPath() priority: SUSHICLAW_CONFIG > PICOCLAW_CONFIG > ~/.picoclaw/config.json
+// loadEmailConfig reads the "channels.email" section from the config file and
+// resolves env:// references. Required fields return an error if unresolved.
 func loadEmailConfig() (EmailConfig, error) {
 	path := configFilePath()
 	data, err := os.ReadFile(path)
@@ -42,11 +42,25 @@ func loadEmailConfig() (EmailConfig, error) {
 		return EmailConfig{}, err
 	}
 	cfg := raw.Channels.Email
-	envresolve.SecureString(&cfg.SMTPFrom)
+	if !cfg.Enabled {
+		return cfg, nil
+	}
+
+	// Optional fields — resolve silently, leave unresolved if env var missing.
 	envresolve.SecureString(&cfg.SMTPUser)
 	envresolve.SecureString(&cfg.SMTPPassword)
-	envresolve.SecureString(&cfg.IMAPUser)
-	envresolve.SecureString(&cfg.IMAPPassword)
+
+	// Required fields — return an error if the env var is not set.
+	if err := envresolve.SecureStringRequired(&cfg.SMTPFrom); err != nil {
+		return EmailConfig{}, err
+	}
+	if err := envresolve.SecureStringRequired(&cfg.IMAPUser); err != nil {
+		return EmailConfig{}, err
+	}
+	if err := envresolve.SecureStringRequired(&cfg.IMAPPassword); err != nil {
+		return EmailConfig{}, err
+	}
+
 	return cfg, nil
 }
 
@@ -68,3 +82,4 @@ func configFilePath() string {
 	}
 	return filepath.Join(home, "config.json")
 }
+


### PR DESCRIPTION
## Summary

- Email channel was silently absent at startup: picoclaw's `initChannels` never invokes the email factory because `email` is not in `ChannelsConfig`. Even if it did, unresolved `env://VAR` literals passed `NewEmailChannel`'s empty-string validation silently.
- Replace `init()`-based factory registration with an exported `InitChannel` called explicitly from `gateway.go` via `cm.RegisterChannel`
- Add `SecureStringRequired` to `envresolve`: resolves `env://VAR` and returns a named error if the var is unset
- `smtp_from`, `imap_user`, `imap_password` are now required; `smtp_user` and `smtp_password` remain optional

Closes #9

## Test plan

- [ ] `make test` — all packages pass
- [ ] `make lint` — 0 issues
- [ ] New unit tests: `TestSecureStringRequired_MissingVar_ReturnsError`, `TestSecureStringRequired_SetVar_ReturnsNil`
- [ ] New integration tests: `TestInitChannel_Disabled_ReturnsNil`, `TestInitChannel_MissingRequiredEnvVar_ReturnsError`
- [ ] Manual: start gateway with a required env var unset → startup fails with `email channel: env var <VAR> is not set`
- [ ] Manual: start gateway with all env vars set → email appears in enabled channels list