### PR TITLE
fix(whatsapp): skip history-sync messages on reconnect

### DIFF
--- a/pkg/channels/whatsapp_native/whatsapp_native.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native.go
@@ -61,6 +61,7 @@ type WhatsAppNativeChannel struct {
 	reconnecting bool
 	stopping     atomic.Bool    // set once Stop begins; prevents new wg.Add calls
 	wg           sync.WaitGroup // tracks background goroutines (QR handler, reconnect)
+	startTime    time.Time      // used to filter history-sync messages on reconnect
 }
 
 // NewWhatsAppNativeChannel creates a WhatsApp channel that uses whatsmeow for connection.
@@ -134,6 +135,7 @@ func (c *WhatsAppNativeChannel) Start(ctx context.Context) error {
 	// goroutines so that Stop() can cancel them at any time, including during
 	// the QR-login flow.
 	c.runCtx, c.runCancel = context.WithCancel(ctx)
+	c.startTime = time.Now()
 
 	client.AddEventHandler(c.eventHandler)
 
@@ -347,6 +349,18 @@ func (c *WhatsAppNativeChannel) reconnectWithBackoff() {
 }
 
 func (c *WhatsAppNativeChannel) handleIncoming(evt *events.Message) {
+	// Skip own messages (bot's outgoing replayed on reconnect).
+	if evt.Info.IsFromMe {
+		return
+	}
+	// Skip history-sync messages delivered on reconnect.
+	if evt.SourceWebMsg != nil {
+		return
+	}
+	// Defense-in-depth: skip anything older than channel start.
+	if evt.Info.Timestamp.Before(c.startTime) {
+		return
+	}
 	if evt.Message == nil {
 		return
 	}

--- a/pkg/channels/whatsapp_native/whatsapp_native_sushi30_test.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native_sushi30_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"go.mau.fi/whatsmeow/proto/waE2E"
+	"go.mau.fi/whatsmeow/proto/waWeb"
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	"google.golang.org/protobuf/proto"
@@ -27,6 +28,7 @@ func makeTestChannel(store media.MediaStore) (*WhatsAppNativeChannel, *bus.Messa
 	ch := &WhatsAppNativeChannel{
 		BaseChannel: bc,
 		runCtx:      context.Background(),
+		startTime:   time.Now(),
 	}
 	return ch, mb
 }
@@ -57,8 +59,9 @@ func TestHandleIncoming_ImageWithCaption_UsesCaption(t *testing.T) {
 				Sender: types.NewJID("1001", types.DefaultUserServer),
 				Chat:   types.NewJID("1001", types.DefaultUserServer),
 			},
-			ID:       "mid-img",
-			PushName: "Bob",
+			ID:        "mid-img",
+			PushName:  "Bob",
+			Timestamp: time.Now().Add(1 * time.Second),
 		},
 		Message: &waE2E.Message{
 			ImageMessage: &waE2E.ImageMessage{
@@ -91,8 +94,9 @@ func TestHandleIncoming_MediaOnly_Dropped_WithoutStoreAndNoCaption(t *testing.T)
 				Sender: types.NewJID("1001", types.DefaultUserServer),
 				Chat:   types.NewJID("1001", types.DefaultUserServer),
 			},
-			ID:       "mid-notext",
-			PushName: "Carol",
+			ID:        "mid-notext",
+			PushName:  "Carol",
+			Timestamp: time.Now().Add(1 * time.Second),
 		},
 		Message: &waE2E.Message{
 			ImageMessage: &waE2E.ImageMessage{
@@ -111,5 +115,117 @@ func TestHandleIncoming_MediaOnly_Dropped_WithoutStoreAndNoCaption(t *testing.T)
 		// correct: message was dropped because no content and no media refs
 	case <-mb.InboundChan():
 		t.Fatal("expected message to be dropped, but it was forwarded")
+	}
+}
+
+// TestHandleIncoming_IsFromMe_Skipped verifies that messages sent by the bot
+// itself (IsFromMe=true) are skipped to prevent echo loops on reconnect.
+func TestHandleIncoming_IsFromMe_Skipped(t *testing.T) {
+	ch, mb := makeTestChannel(nil)
+
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				IsFromMe: true,
+				Sender:   types.NewJID("1001", types.DefaultUserServer),
+				Chat:     types.NewJID("1001", types.DefaultUserServer),
+			},
+			ID: "mid-self",
+		},
+		Message: &waE2E.Message{
+			Conversation: proto.String("self message"),
+		},
+	}
+
+	ch.handleIncoming(evt)
+
+	assertNoMessage(t, mb, "expected IsFromMe message to be skipped")
+}
+
+// TestHandleIncoming_SourceWebMsg_Skipped verifies that history-sync messages
+// (SourceWebMsg != nil) are skipped to prevent reprocessing on reconnect.
+func TestHandleIncoming_SourceWebMsg_Skipped(t *testing.T) {
+	ch, mb := makeTestChannel(nil)
+
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Sender: types.NewJID("1001", types.DefaultUserServer),
+				Chat:   types.NewJID("1001", types.DefaultUserServer),
+			},
+			ID: "mid-history",
+		},
+		SourceWebMsg: &waWeb.WebMessageInfo{},
+		Message: &waE2E.Message{
+			Conversation: proto.String("history sync message"),
+		},
+	}
+
+	ch.handleIncoming(evt)
+
+	assertNoMessage(t, mb, "expected history-sync message to be skipped")
+}
+
+// TestHandleIncoming_StaleTimestamp_Skipped verifies that messages with
+// timestamps older than the channel start time are skipped.
+func TestHandleIncoming_StaleTimestamp_Skipped(t *testing.T) {
+	ch, mb := makeTestChannel(nil)
+
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Sender: types.NewJID("1001", types.DefaultUserServer),
+				Chat:   types.NewJID("1001", types.DefaultUserServer),
+			},
+			ID:        "mid-stale",
+			Timestamp: time.Now().Add(-1 * time.Hour),
+		},
+		Message: &waE2E.Message{
+			Conversation: proto.String("stale message"),
+		},
+	}
+
+	ch.handleIncoming(evt)
+
+	assertNoMessage(t, mb, "expected stale message to be skipped")
+}
+
+// TestHandleIncoming_RecentMessage_Processed verifies that a valid recent
+// message passes all guards and is processed normally.
+func TestHandleIncoming_RecentMessage_Processed(t *testing.T) {
+	ch, mb := makeTestChannel(nil)
+
+	content := "hello world"
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Sender: types.NewJID("1001", types.DefaultUserServer),
+				Chat:   types.NewJID("1001", types.DefaultUserServer),
+			},
+			ID:        "mid-recent",
+			Timestamp: time.Now().Add(1 * time.Second),
+		},
+		Message: &waE2E.Message{
+			Conversation: proto.String(content),
+		},
+	}
+
+	ch.handleIncoming(evt)
+
+	msg := receiveInbound(t, mb)
+	if msg.Content != content {
+		t.Fatalf("expected content=%q, got %q", content, msg.Content)
+	}
+}
+
+func assertNoMessage(t *testing.T, mb *bus.MessageBus, msg string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		// correct: no message was forwarded
+	case <-mb.InboundChan():
+		t.Fatal(msg)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a bug where WhatsApp channel re-processes all historical messages on container restart, sending responses to every past chat.

When whatsmeow reconnects to WhatsApp servers, the server pushes a history sync containing all queued/missed messages. These are dispatched as `events.Message` exactly like live messages, but can be identified by:
- `evt.Info.IsFromMe` — bot's own sent messages
- `evt.SourceWebMsg != nil` — message came from history sync
- `evt.Info.Timestamp` — older than channel start time

## Changes

1. Added `startTime` field to `WhatsAppNativeChannel` struct
2. Set `startTime` in `Start()` before connecting
3. Added three guards at the top of `handleIncoming()` to skip:
   - Own messages (bot's outgoing replayed on reconnect)
   - History-sync messages (SourceWebMsg != nil)
   - Stale timestamps (older than channel start)

## Test plan

- [x] `go build -tags whatsapp_native ./...` — compiles
- [x] `make lint` — 0 issues
- [x] `make test` — all tests pass