### PR TITLE
feat(gateway): retry once on empty LLM response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,7 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -78,6 +78,8 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 		cfg.Agents.Defaults.ModelName = modelID
 	}
 
+	provider = wrapWithRetryEmpty(provider)
+
 	msgBus := bus.NewMessageBus()
 	agentLoop := agent.NewAgentLoop(cfg, msgBus, provider)
 

--- a/internal/gateway/retry_provider.go
+++ b/internal/gateway/retry_provider.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/providers"
 )
 
-const retryEmptyPrompt = "Please provide your response to my previous message."
+const retryEmptyPrompt = "Provide your response to my previous message."
 
 type retryEmptyProvider struct {
 	inner providers.LLMProvider

--- a/internal/gateway/retry_provider.go
+++ b/internal/gateway/retry_provider.go
@@ -1,0 +1,71 @@
+package gateway
+
+import (
+	"context"
+
+	"github.com/sipeed/picoclaw/pkg/providers"
+)
+
+const retryEmptyPrompt = "Please provide your response to my previous message."
+
+type retryEmptyProvider struct {
+	inner providers.LLMProvider
+}
+
+func isEmptyResponse(resp *providers.LLMResponse) bool {
+	return resp.Content == "" && len(resp.ToolCalls) == 0 && resp.ReasoningContent == ""
+}
+
+func (p *retryEmptyProvider) Chat(
+	ctx context.Context,
+	messages []providers.Message,
+	tools []providers.ToolDefinition,
+	model string,
+	options map[string]any,
+) (*providers.LLMResponse, error) {
+	resp, err := p.inner.Chat(ctx, messages, tools, model, options)
+	if err != nil {
+		return resp, err
+	}
+
+	if !isEmptyResponse(resp) {
+		return resp, nil
+	}
+
+	extended := make([]providers.Message, len(messages), len(messages)+2)
+	copy(extended, messages)
+	extended = append(extended, providers.Message{
+		Role:    "assistant",
+		Content: "",
+	})
+	extended = append(extended, providers.Message{
+		Role:    "user",
+		Content: retryEmptyPrompt,
+	})
+
+	retryResp, retryErr := p.inner.Chat(ctx, extended, tools, model, options)
+	if retryErr != nil {
+		return resp, nil
+	}
+	if isEmptyResponse(retryResp) {
+		return resp, nil
+	}
+	return retryResp, nil
+}
+
+func (p *retryEmptyProvider) GetDefaultModel() string {
+	return p.inner.GetDefaultModel()
+}
+
+func (p *retryEmptyProvider) Close() {
+	if cp, ok := p.inner.(providers.StatefulProvider); ok {
+		cp.Close()
+	}
+}
+
+func wrapWithRetryEmpty(provider providers.LLMProvider) providers.LLMProvider {
+	if _, ok := provider.(*startupBlockedProvider); ok {
+		return provider
+	}
+	return &retryEmptyProvider{inner: provider}
+}

--- a/internal/gateway/retry_provider_test.go
+++ b/internal/gateway/retry_provider_test.go
@@ -5,161 +5,129 @@ import (
 	"testing"
 
 	"github.com/sipeed/picoclaw/pkg/providers"
+	"github.com/stretchr/testify/assert"
+	testifymock "github.com/stretchr/testify/mock"
 )
 
 type mockProvider struct {
-	responses []*providers.LLMResponse
-	errors    []error
-	callCount int
-	lastMsgs  []providers.Message
+	testifymock.Mock
 }
 
-func (m *mockProvider) Chat(_ context.Context, messages []providers.Message, _ []providers.ToolDefinition, _ string, _ map[string]any) (*providers.LLMResponse, error) {
-	idx := m.callCount
-	m.callCount++
-	m.lastMsgs = messages
-	if idx < len(m.responses) {
-		if idx < len(m.errors) && m.errors[idx] != nil {
-			return m.responses[idx], m.errors[idx]
-		}
-		return m.responses[idx], nil
+func (m *mockProvider) Chat(ctx context.Context, messages []providers.Message, tools []providers.ToolDefinition, model string, options map[string]any) (*providers.LLMResponse, error) {
+	args := m.Called(ctx, messages, tools, model, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
 	}
-	return &providers.LLMResponse{}, nil
+	return args.Get(0).(*providers.LLMResponse), args.Error(1)
 }
 
-func (m *mockProvider) GetDefaultModel() string { return "mock" }
+func (m *mockProvider) GetDefaultModel() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+type mockStatefulProvider struct {
+	mockProvider
+}
+
+func (m *mockStatefulProvider) Close() {
+	m.Called()
+}
 
 func TestRetryEmpty_NonEmptyResponsePassthrough(t *testing.T) {
-	expected := &providers.LLMResponse{
-		Content:      "hello",
-		FinishReason: "stop",
-	}
-	mock := &mockProvider{responses: []*providers.LLMResponse{expected}}
+	mock := new(mockProvider)
+	expected := &providers.LLMResponse{Content: "hello", FinishReason: "stop"}
+	mock.On("Chat", testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything).Return(expected, nil)
 	p := &retryEmptyProvider{inner: mock}
 
 	resp, err := p.Chat(context.Background(), []providers.Message{{Role: "user", Content: "hi"}}, nil, "mock", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.Content != "hello" {
-		t.Fatalf("expected content 'hello', got %q", resp.Content)
-	}
-	if mock.callCount != 1 {
-		t.Fatalf("expected 1 call, got %d", mock.callCount)
-	}
+
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", resp.Content)
+	mock.AssertNumberOfCalls(t, "Chat", 1)
 }
 
 func TestRetryEmpty_EmptyResponseTriggersRetry(t *testing.T) {
 	empty := &providers.LLMResponse{Content: "", FinishReason: "stop"}
 	filled := &providers.LLMResponse{Content: "world", FinishReason: "stop"}
-	mock := &mockProvider{responses: []*providers.LLMResponse{empty, filled}}
+	mock := new(mockProvider)
+	mock.On("Chat", testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything).Return(empty, nil).Once()
+	mock.On("Chat", testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything).Return(filled, nil).Once()
 	p := &retryEmptyProvider{inner: mock}
 
 	resp, err := p.Chat(context.Background(), []providers.Message{{Role: "user", Content: "hi"}}, nil, "mock", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.Content != "world" {
-		t.Fatalf("expected content 'world', got %q", resp.Content)
-	}
-	if mock.callCount != 2 {
-		t.Fatalf("expected 2 calls, got %d", mock.callCount)
-	}
-	msgs := mock.lastMsgs
-	if len(msgs) != 3 {
-		t.Fatalf("expected 3 messages on retry, got %d", len(msgs))
-	}
-	if msgs[1].Role != "assistant" || msgs[1].Content != "" {
-		t.Fatalf("expected empty assistant message at index 1, got role=%s content=%q", msgs[1].Role, msgs[1].Content)
-	}
-	if msgs[2].Role != "user" || msgs[2].Content != retryEmptyPrompt {
-		t.Fatalf("expected retry prompt at index 2, got role=%s content=%q", msgs[2].Role, msgs[2].Content)
-	}
+
+	assert.NoError(t, err)
+	assert.Equal(t, "world", resp.Content)
+	mock.AssertNumberOfCalls(t, "Chat", 2)
+
+	retryMsgs := mock.Calls[1].Arguments.Get(1).([]providers.Message)
+	assert.Len(t, retryMsgs, 3)
+	assert.Equal(t, "assistant", retryMsgs[1].Role)
+	assert.Equal(t, "", retryMsgs[1].Content)
+	assert.Equal(t, "user", retryMsgs[2].Role)
+	assert.Equal(t, retryEmptyPrompt, retryMsgs[2].Content)
 }
 
 func TestRetryEmpty_DoubleEmptyReturnsFirst(t *testing.T) {
-	empty1 := &providers.LLMResponse{Content: "", FinishReason: "stop"}
-	empty2 := &providers.LLMResponse{Content: "", FinishReason: "stop"}
-	mock := &mockProvider{responses: []*providers.LLMResponse{empty1, empty2}}
+	empty := &providers.LLMResponse{Content: "", FinishReason: "stop"}
+	mock := new(mockProvider)
+	mock.On("Chat", testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything).Return(empty, nil)
 	p := &retryEmptyProvider{inner: mock}
 
 	resp, err := p.Chat(context.Background(), []providers.Message{{Role: "user", Content: "hi"}}, nil, "mock", nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if resp.Content != "" {
-		t.Fatalf("expected empty content, got %q", resp.Content)
-	}
-	if resp.FinishReason != "stop" {
-		t.Fatalf("expected finish_reason 'stop', got %q", resp.FinishReason)
-	}
-	if mock.callCount != 2 {
-		t.Fatalf("expected 2 calls (original + retry), got %d", mock.callCount)
-	}
+
+	assert.NoError(t, err)
+	assert.Equal(t, "", resp.Content)
+	assert.Equal(t, "stop", resp.FinishReason)
+	mock.AssertNumberOfCalls(t, "Chat", 2)
 }
 
 func TestRetryEmpty_ErrorPassesThrough(t *testing.T) {
-	mock := &mockProvider{
-		responses: []*providers.LLMResponse{nil},
-		errors:    []error{context.Canceled},
-	}
+	mock := new(mockProvider)
+	mock.On("Chat", testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything, testifymock.Anything).Return(nil, context.Canceled)
 	p := &retryEmptyProvider{inner: mock}
 
 	resp, err := p.Chat(context.Background(), nil, nil, "mock", nil)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if resp != nil {
-		t.Fatalf("expected nil response on error, got %+v", resp)
-	}
-	if mock.callCount != 1 {
-		t.Fatalf("expected 1 call (no retry on error), got %d", mock.callCount)
-	}
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, resp)
+	mock.AssertNumberOfCalls(t, "Chat", 1)
 }
 
 func TestRetryEmpty_GetDefaultModel(t *testing.T) {
-	p := &retryEmptyProvider{inner: &mockProvider{}}
-	if m := p.GetDefaultModel(); m != "mock" {
-		t.Fatalf("expected 'mock', got %q", m)
-	}
-}
+	mock := new(mockProvider)
+	mock.On("GetDefaultModel").Return("mock")
+	p := &retryEmptyProvider{inner: mock}
 
-type mockStatefulProvider struct {
-	mockProvider
-	closed bool
+	assert.Equal(t, "mock", p.GetDefaultModel())
 }
-
-func (m *mockStatefulProvider) Close() { m.closed = true }
 
 func TestRetryEmpty_CloseDelegates(t *testing.T) {
-	inner := &mockStatefulProvider{}
+	inner := new(mockStatefulProvider)
+	inner.On("Close").Once()
 	p := &retryEmptyProvider{inner: inner}
 	p.Close()
-	if !inner.closed {
-		t.Fatal("expected Close to be delegated to inner StatefulProvider")
-	}
+	inner.AssertCalled(t, "Close")
 }
 
 func TestRetryEmpty_CloseNoStatefulProvider(t *testing.T) {
-	inner := &mockProvider{}
+	inner := new(mockProvider)
 	p := &retryEmptyProvider{inner: inner}
 	p.Close()
+	inner.AssertNotCalled(t, "Close")
 }
 
 func TestWrapWithRetryEmpty_SkipsStartupBlocked(t *testing.T) {
 	sb := &startupBlockedProvider{reason: "test"}
 	result := wrapWithRetryEmpty(sb)
-	if _, ok := result.(*startupBlockedProvider); !ok {
-		t.Fatal("expected startupBlockedProvider to pass through unwrapped")
-	}
+	assert.IsType(t, &startupBlockedProvider{}, result)
 }
 
 func TestWrapWithRetryEmpty_WrapsNormalProvider(t *testing.T) {
-	mock := &mockProvider{}
+	mock := new(mockProvider)
 	result := wrapWithRetryEmpty(mock)
-	if _, ok := result.(*retryEmptyProvider); !ok {
-		t.Fatal("expected retryEmptyProvider wrapper")
-	}
+	assert.IsType(t, &retryEmptyProvider{}, result)
 }
 
 func TestIsEmptyResponse(t *testing.T) {
@@ -176,9 +144,7 @@ func TestIsEmptyResponse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isEmptyResponse(tt.resp); got != tt.expected {
-				t.Errorf("isEmptyResponse(%+v) = %v, want %v", tt.resp, got, tt.expected)
-			}
+			assert.Equal(t, tt.expected, isEmptyResponse(tt.resp))
 		})
 	}
 }

--- a/internal/gateway/retry_provider_test.go
+++ b/internal/gateway/retry_provider_test.go
@@ -1,0 +1,184 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sipeed/picoclaw/pkg/providers"
+)
+
+type mockProvider struct {
+	responses []*providers.LLMResponse
+	errors    []error
+	callCount int
+	lastMsgs  []providers.Message
+}
+
+func (m *mockProvider) Chat(_ context.Context, messages []providers.Message, _ []providers.ToolDefinition, _ string, _ map[string]any) (*providers.LLMResponse, error) {
+	idx := m.callCount
+	m.callCount++
+	m.lastMsgs = messages
+	if idx < len(m.responses) {
+		if idx < len(m.errors) && m.errors[idx] != nil {
+			return m.responses[idx], m.errors[idx]
+		}
+		return m.responses[idx], nil
+	}
+	return &providers.LLMResponse{}, nil
+}
+
+func (m *mockProvider) GetDefaultModel() string { return "mock" }
+
+func TestRetryEmpty_NonEmptyResponsePassthrough(t *testing.T) {
+	expected := &providers.LLMResponse{
+		Content:      "hello",
+		FinishReason: "stop",
+	}
+	mock := &mockProvider{responses: []*providers.LLMResponse{expected}}
+	p := &retryEmptyProvider{inner: mock}
+
+	resp, err := p.Chat(context.Background(), []providers.Message{{Role: "user", Content: "hi"}}, nil, "mock", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "hello" {
+		t.Fatalf("expected content 'hello', got %q", resp.Content)
+	}
+	if mock.callCount != 1 {
+		t.Fatalf("expected 1 call, got %d", mock.callCount)
+	}
+}
+
+func TestRetryEmpty_EmptyResponseTriggersRetry(t *testing.T) {
+	empty := &providers.LLMResponse{Content: "", FinishReason: "stop"}
+	filled := &providers.LLMResponse{Content: "world", FinishReason: "stop"}
+	mock := &mockProvider{responses: []*providers.LLMResponse{empty, filled}}
+	p := &retryEmptyProvider{inner: mock}
+
+	resp, err := p.Chat(context.Background(), []providers.Message{{Role: "user", Content: "hi"}}, nil, "mock", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "world" {
+		t.Fatalf("expected content 'world', got %q", resp.Content)
+	}
+	if mock.callCount != 2 {
+		t.Fatalf("expected 2 calls, got %d", mock.callCount)
+	}
+	msgs := mock.lastMsgs
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages on retry, got %d", len(msgs))
+	}
+	if msgs[1].Role != "assistant" || msgs[1].Content != "" {
+		t.Fatalf("expected empty assistant message at index 1, got role=%s content=%q", msgs[1].Role, msgs[1].Content)
+	}
+	if msgs[2].Role != "user" || msgs[2].Content != retryEmptyPrompt {
+		t.Fatalf("expected retry prompt at index 2, got role=%s content=%q", msgs[2].Role, msgs[2].Content)
+	}
+}
+
+func TestRetryEmpty_DoubleEmptyReturnsFirst(t *testing.T) {
+	empty1 := &providers.LLMResponse{Content: "", FinishReason: "stop"}
+	empty2 := &providers.LLMResponse{Content: "", FinishReason: "stop"}
+	mock := &mockProvider{responses: []*providers.LLMResponse{empty1, empty2}}
+	p := &retryEmptyProvider{inner: mock}
+
+	resp, err := p.Chat(context.Background(), []providers.Message{{Role: "user", Content: "hi"}}, nil, "mock", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "" {
+		t.Fatalf("expected empty content, got %q", resp.Content)
+	}
+	if resp.FinishReason != "stop" {
+		t.Fatalf("expected finish_reason 'stop', got %q", resp.FinishReason)
+	}
+	if mock.callCount != 2 {
+		t.Fatalf("expected 2 calls (original + retry), got %d", mock.callCount)
+	}
+}
+
+func TestRetryEmpty_ErrorPassesThrough(t *testing.T) {
+	mock := &mockProvider{
+		responses: []*providers.LLMResponse{nil},
+		errors:    []error{context.Canceled},
+	}
+	p := &retryEmptyProvider{inner: mock}
+
+	resp, err := p.Chat(context.Background(), nil, nil, "mock", nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response on error, got %+v", resp)
+	}
+	if mock.callCount != 1 {
+		t.Fatalf("expected 1 call (no retry on error), got %d", mock.callCount)
+	}
+}
+
+func TestRetryEmpty_GetDefaultModel(t *testing.T) {
+	p := &retryEmptyProvider{inner: &mockProvider{}}
+	if m := p.GetDefaultModel(); m != "mock" {
+		t.Fatalf("expected 'mock', got %q", m)
+	}
+}
+
+type mockStatefulProvider struct {
+	mockProvider
+	closed bool
+}
+
+func (m *mockStatefulProvider) Close() { m.closed = true }
+
+func TestRetryEmpty_CloseDelegates(t *testing.T) {
+	inner := &mockStatefulProvider{}
+	p := &retryEmptyProvider{inner: inner}
+	p.Close()
+	if !inner.closed {
+		t.Fatal("expected Close to be delegated to inner StatefulProvider")
+	}
+}
+
+func TestRetryEmpty_CloseNoStatefulProvider(t *testing.T) {
+	inner := &mockProvider{}
+	p := &retryEmptyProvider{inner: inner}
+	p.Close()
+}
+
+func TestWrapWithRetryEmpty_SkipsStartupBlocked(t *testing.T) {
+	sb := &startupBlockedProvider{reason: "test"}
+	result := wrapWithRetryEmpty(sb)
+	if _, ok := result.(*startupBlockedProvider); !ok {
+		t.Fatal("expected startupBlockedProvider to pass through unwrapped")
+	}
+}
+
+func TestWrapWithRetryEmpty_WrapsNormalProvider(t *testing.T) {
+	mock := &mockProvider{}
+	result := wrapWithRetryEmpty(mock)
+	if _, ok := result.(*retryEmptyProvider); !ok {
+		t.Fatal("expected retryEmptyProvider wrapper")
+	}
+}
+
+func TestIsEmptyResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		resp     *providers.LLMResponse
+		expected bool
+	}{
+		{"empty content no tools", &providers.LLMResponse{Content: ""}, true},
+		{"non-empty content", &providers.LLMResponse{Content: "hi"}, false},
+		{"tool calls only", &providers.LLMResponse{ToolCalls: []providers.ToolCall{{ID: "1"}}}, false},
+		{"reasoning content only", &providers.LLMResponse{Content: "", ReasoningContent: "thinking..."}, false},
+		{"content and tools", &providers.LLMResponse{Content: "hi", ToolCalls: []providers.ToolCall{{ID: "1"}}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isEmptyResponse(tt.resp); got != tt.expected {
+				t.Errorf("isEmptyResponse(%+v) = %v, want %v", tt.resp, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When OpenRouter (or the model behind it) returns an empty response — `Content: ""`, no tool calls, no error — the agent loop treats it as a direct answer and falls back to a generic `"The model returned an empty response..."` message. A single retry almost always succeeds since these are transient.

This PR adds a `retryEmptyProvider` wrapper in `internal/gateway/` that intercepts empty `Chat` responses, injects an assistant+user retry pair into the message history, and calls `Chat` once more. The wrapper is wired in `gateway.go` between `createProvider` and `NewAgentLoop`. No changes to the picoclaw submodule.

## Changes

- **`internal/gateway/retry_provider.go`** — `retryEmptyProvider` wrapping `LLMProvider`: on empty content + no tool calls + no reasoning, appends an empty assistant message and a user retry prompt, then calls `Chat` again. Delegates `GetDefaultModel()` and `Close()` (for `StatefulProvider`). `wrapWithRetryEmpty()` skips `startupBlockedProvider`.
- **`internal/gateway/retry_provider_test.go`** — 10 tests: non-empty passthrough, retry on empty, double-empty returns first, error passthrough, `GetDefaultModel`, `Close` delegation, wrapper skip logic, and `isEmptyResponse` cases.
- **`internal/gateway/gateway.go`** — `provider = wrapWithRetryEmpty(provider)` after `createProvider`, before `NewAgentLoop`.

## Test plan

- `make test` — all packages pass
- `make lint` — 0 issues
- `go vet` — clean
- Unit tests cover: happy path passthrough, empty-response retry (verifies injected messages), double-empty returns first response (no infinite loop), error passthrough (no retry on error), `Close` delegation to `StatefulProvider`, `Close` no-op when inner isn't stateful, `wrapWithRetryEmpty` skips startup-blocked provider, `isEmptyResponse` table-driven cases