### PR TITLE
fix: skip reconnect when websocket already connected

### DIFF
--- a/pkg/channels/whatsapp_native/whatsapp_native.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native.go
@@ -323,6 +323,9 @@ func (c *WhatsAppNativeChannel) reconnectWithBackoff() {
 		if client == nil {
 			return
 		}
+		if client.IsConnected() {
+			return
+		}
 
 		logger.InfoCF("whatsapp", "WhatsApp reconnecting", map[string]any{"backoff": backoff.String()})
 		err := client.Connect()


### PR DESCRIPTION
## Summary
- `reconnectWithBackoff()` was calling `client.Connect()` without first checking if the socket was already up
- Whatsmeow auto-reconnects internally, so by the time our loop fires, the connection is often healthy — causing spurious `WRN WhatsApp reconnect failed error="websocket is already connected"` every 5 minutes
- Added `client.IsConnected()` guard to return early if already connected

## Test plan
- [x] `make build` — clean compile
- [x] `make test` — all 7 packages pass locally
- [ ] Deploy and confirm no more spurious WRN reconnect logs when connection is healthy

Closes #23