### PR TITLE
feat(email): reply in-thread with RFC 2822 threading headers

### DIFF
--- a/pkg/channels/email/email.go
+++ b/pkg/channels/email/email.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/smtp"
 	"strings"
+	"sync"
 	"time"
 
 	imap "github.com/emersion/go-imap/v2"
@@ -40,12 +41,19 @@ type EmailConfig struct {
 	ReasoningChannelID string                     `json:"reasoning_channel_id"`
 }
 
+// threadInfo holds the metadata needed to construct threading headers for a reply.
+type threadInfo struct {
+	subject   string
+	inReplyTo []string // Message-IDs from the In-Reply-To header of the original email
+}
+
 // EmailChannel implements the Channel interface using SMTP (outbound) and IMAP polling (inbound).
 type EmailChannel struct {
 	*channels.BaseChannel
-	config EmailConfig
-	ctx    context.Context
-	cancel context.CancelFunc
+	config  EmailConfig
+	ctx     context.Context
+	cancel  context.CancelFunc
+	threads sync.Map // messageID (string) → threadInfo
 }
 
 // NewEmailChannel creates a new email channel.
@@ -125,6 +133,26 @@ func (c *EmailChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]str
 		subject = "Message"
 	}
 
+	var extraHeaders strings.Builder
+	if msg.ReplyToMessageID != "" {
+		var inReplyTo []string
+		if v, ok := c.threads.Load(msg.ReplyToMessageID); ok {
+			info := v.(threadInfo)
+			if info.subject != "" {
+				s := info.subject
+				if !strings.HasPrefix(strings.ToLower(s), "re: ") {
+					s = "Re: " + s
+				}
+				subject = s
+			}
+			inReplyTo = info.inReplyTo
+		}
+		// Wrap raw message ID in angle brackets per RFC 2822.
+		replyTo := "<" + msg.ReplyToMessageID + ">"
+		extraHeaders.WriteString("In-Reply-To: " + replyTo + "\r\n")
+		extraHeaders.WriteString("References: " + buildReferences(replyTo, inReplyTo) + "\r\n")
+	}
+
 	smtpPort := c.config.SMTPPort
 	if smtpPort == 0 {
 		smtpPort = 587
@@ -136,8 +164,8 @@ func (c *EmailChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]str
 		smtpUser = c.config.SMTPFrom.String()
 	}
 
-	body := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\n\r\n%s",
-		c.config.SMTPFrom.String(), to, subject, msg.Content)
+	body := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\n%s\r\n%s",
+		c.config.SMTPFrom.String(), to, subject, extraHeaders.String(), msg.Content)
 
 	var auth smtp.Auth
 	if c.config.SMTPPassword.String() != "" {
@@ -336,6 +364,13 @@ func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope
 		"subject": envelope.Subject,
 	})
 
+	if envelope.MessageID != "" {
+		c.threads.Store(envelope.MessageID, threadInfo{
+			subject:   envelope.Subject,
+			inReplyTo: envelope.InReplyTo,
+		})
+	}
+
 	sender := bus.SenderInfo{
 		Platform:    "email",
 		PlatformID:  fromAddr,
@@ -351,6 +386,15 @@ func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope
 	)
 
 	return true, plainText
+}
+
+// buildReferences constructs the RFC 2822 References header value for a reply.
+// It concatenates any prior inReplyTo IDs with the current messageID.
+func buildReferences(messageID string, inReplyTo []string) string {
+	parts := make([]string, 0, len(inReplyTo)+1)
+	parts = append(parts, inReplyTo...)
+	parts = append(parts, messageID)
+	return strings.Join(parts, " ")
 }
 
 func extractFrom(env *imap.Envelope) string {

--- a/pkg/channels/email/email_integration_test.go
+++ b/pkg/channels/email/email_integration_test.go
@@ -62,7 +62,7 @@ func startMockIMAPServer(t *testing.T, rawMIME string) (host, port string) {
 
 	go func() { _ = srv.Serve(ln) }()
 
-	t.Cleanup(func() { srv.Close() })
+	t.Cleanup(func() { _ = srv.Close() })
 
 	addr := ln.Addr().String()
 	h, p, _ := net.SplitHostPort(addr)
@@ -86,12 +86,12 @@ func startSMTPCapture(t *testing.T) (host, port string, received <-chan string) 
 		if err != nil {
 			return
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 
 		rw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
 
 		send := func(line string) {
-			fmt.Fprintf(conn, "%s\r\n", line)
+			_, _ = fmt.Fprintf(conn, "%s\r\n", line)
 		}
 
 		send("220 localhost ESMTP test")
@@ -114,9 +114,7 @@ func startSMTPCapture(t *testing.T) (host, port string, received <-chan string) 
 					inData = false
 				} else {
 					// RFC 5321: lines starting with "." are dot-stuffed
-					if strings.HasPrefix(line, ".") {
-						line = line[1:]
-					}
+					line = strings.TrimPrefix(line, ".")
 					body.WriteString(line)
 					body.WriteString("\r\n")
 				}
@@ -140,7 +138,7 @@ func startSMTPCapture(t *testing.T) (host, port string, received <-chan string) 
 		}
 	}()
 
-	t.Cleanup(func() { ln.Close() })
+	t.Cleanup(func() { _ = ln.Close() })
 
 	addr := ln.Addr().String()
 	h, p, _ := net.SplitHostPort(addr)
@@ -241,6 +239,93 @@ func TestEmailOutboundPipeline(t *testing.T) {
 		}
 		if !strings.Contains(body, "user@example.com") {
 			t.Errorf("SMTP body does not contain recipient:\n%s", body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: SMTP capture received nothing")
+	}
+}
+
+// TestEmailReplyThreading verifies that when Send is called with a ReplyToMessageID
+// matching an email that was previously received via IMAP, the outbound SMTP message
+// contains RFC 2822 threading headers (In-Reply-To, References) and a Re: subject.
+func TestEmailReplyThreading(t *testing.T) {
+	// IMAP parses Message-ID and strips angle brackets.
+	// The raw header is "<orig-123@test.com>" but envelope.MessageID == "orig-123@test.com".
+	const originalMsgID = "orig-123@test.com"
+	const originalSubject = "Hello Agent"
+
+	rawMIME := "From: sender@example.com\r\nTo: bot@test.com\r\n" +
+		"Subject: " + originalSubject + "\r\n" +
+		"Message-ID: <" + originalMsgID + ">\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n\r\n" +
+		"Please reply to this"
+
+	imapHost, imapPort := startMockIMAPServer(t, rawMIME)
+	imapPortInt, _ := strconv.Atoi(imapPort)
+
+	smtpHost, smtpPort, received := startSMTPCapture(t)
+	smtpPortInt, _ := strconv.Atoi(smtpPort)
+
+	msgBus := bus.NewMessageBus()
+	cfg := EmailConfig{
+		SMTPHost:         smtpHost,
+		SMTPPort:         smtpPortInt,
+		SMTPFrom:         *config.NewSecureString("bot@test.com"),
+		DefaultSubject:   "Message",
+		IMAPHost:         imapHost,
+		IMAPPort:         imapPortInt,
+		IMAPUser:         *config.NewSecureString("testuser"),
+		IMAPPassword:     *config.NewSecureString("testpass"),
+		PollIntervalSecs: 1,
+	}
+
+	ch, err := NewEmailChannel(cfg, msgBus)
+	if err != nil {
+		t.Fatalf("NewEmailChannel: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := ch.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer ch.Stop(ctx) //nolint:errcheck
+
+	// Wait for the inbound message — this proves processEmail ran and populated the cache.
+	select {
+	case msg := <-msgBus.InboundChan():
+		if msg.MessageID != originalMsgID {
+			t.Errorf("inbound MessageID = %q, want %q", msg.MessageID, originalMsgID)
+		}
+	case <-ctx.Done():
+		t.Fatal("timeout: no inbound message — IMAP poll did not deliver the message")
+	}
+
+	// Now send the reply using the original Message-ID as ReplyToMessageID.
+	_, err = ch.Send(ctx, bus.OutboundMessage{
+		ChatID:           "sender@example.com",
+		Content:          "This is my reply",
+		ReplyToMessageID: originalMsgID,
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	// Send wraps the raw messageID in angle brackets per RFC 2822.
+	msgIDHeader := "<" + originalMsgID + ">"
+
+	select {
+	case body := <-received:
+		if !strings.Contains(body, "Subject: Re: "+originalSubject) {
+			t.Errorf("SMTP body missing Re: subject:\n%s", body)
+		}
+		if !strings.Contains(body, "In-Reply-To: "+msgIDHeader) {
+			t.Errorf("SMTP body missing In-Reply-To header:\n%s", body)
+		}
+		if !strings.Contains(body, "References: "+msgIDHeader) {
+			t.Errorf("SMTP body missing References header:\n%s", body)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout: SMTP capture received nothing")

--- a/pkg/channels/email/email_test.go
+++ b/pkg/channels/email/email_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -380,6 +381,117 @@ func TestProcessEmail_TextInteraction(t *testing.T) {
 		if inbound.Content != "Hello from email" {
 			t.Fatalf("content=%q", inbound.Content)
 		}
+	}
+}
+
+func TestSend_ReplyThreadingHeaders(t *testing.T) {
+	// Raw message IDs have no angle brackets (as returned by imap.Envelope.MessageID).
+	// Send wraps them in <> when writing RFC 2822 headers.
+	tests := []struct {
+		name             string
+		cachedSubject    string
+		cachedInReplyTo  []string
+		replyToMessageID string // raw, no angle brackets
+		wantSubjectLine  string
+		wantInReplyTo    string
+		wantReferences   string
+		wantNoThreading  bool
+	}{
+		{
+			name:             "reply with known subject",
+			cachedSubject:    "Hello Agent",
+			cachedInReplyTo:  nil,
+			replyToMessageID: "orig@test.com",
+			wantSubjectLine:  "Subject: Re: Hello Agent",
+			wantInReplyTo:    "In-Reply-To: <orig@test.com>",
+			wantReferences:   "References: <orig@test.com>",
+		},
+		{
+			name:             "subject already has Re: prefix",
+			cachedSubject:    "Re: Hello Agent",
+			cachedInReplyTo:  nil,
+			replyToMessageID: "orig@test.com",
+			wantSubjectLine:  "Subject: Re: Hello Agent",
+			wantInReplyTo:    "In-Reply-To: <orig@test.com>",
+			wantReferences:   "References: <orig@test.com>",
+		},
+		{
+			name:             "reply with prior References chain",
+			cachedSubject:    "Hello Agent",
+			cachedInReplyTo:  []string{"<first@test.com>"},
+			replyToMessageID: "orig@test.com",
+			wantSubjectLine:  "Subject: Re: Hello Agent",
+			wantInReplyTo:    "In-Reply-To: <orig@test.com>",
+			wantReferences:   "References: <first@test.com> <orig@test.com>",
+		},
+		{
+			name:             "no ReplyToMessageID — no threading headers",
+			cachedSubject:    "Hello Agent",
+			replyToMessageID: "",
+			wantNoThreading:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			smtpHost, smtpPort, received := startSMTPCapture(t)
+			smtpPortInt, _ := strconv.Atoi(smtpPort)
+
+			msgBus := bus.NewMessageBus()
+			cfg := EmailConfig{
+				SMTPHost:       smtpHost,
+				SMTPPort:       smtpPortInt,
+				SMTPFrom:       *config.NewSecureString("bot@test.com"),
+				DefaultSubject: "Message",
+				IMAPHost:       "127.0.0.1",
+				IMAPPort:       10143,
+				IMAPUser:       *config.NewSecureString("u"),
+				IMAPPassword:   *config.NewSecureString("p"),
+			}
+
+			ch, err := NewEmailChannel(cfg, msgBus)
+			if err != nil {
+				t.Fatalf("NewEmailChannel: %v", err)
+			}
+			ch.SetRunning(true)
+
+			if tt.replyToMessageID != "" {
+				ch.threads.Store(tt.replyToMessageID, threadInfo{
+					subject:   tt.cachedSubject,
+					inReplyTo: tt.cachedInReplyTo,
+				})
+			}
+
+			ctx := context.Background()
+			_, err = ch.Send(ctx, bus.OutboundMessage{
+				ChatID:           "user@example.com",
+				Content:          "Agent reply",
+				ReplyToMessageID: tt.replyToMessageID,
+			})
+			if err != nil {
+				t.Fatalf("Send: %v", err)
+			}
+
+			select {
+			case body := <-received:
+				if tt.wantNoThreading {
+					if strings.Contains(body, "In-Reply-To:") {
+						t.Errorf("expected no In-Reply-To header, got:\n%s", body)
+					}
+					if strings.Contains(body, "References:") {
+						t.Errorf("expected no References header, got:\n%s", body)
+					}
+					return
+				}
+				for _, want := range []string{tt.wantSubjectLine, tt.wantInReplyTo, tt.wantReferences} {
+					if !strings.Contains(body, want) {
+						t.Errorf("SMTP body missing %q:\n%s", want, body)
+					}
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("timeout: SMTP capture received nothing")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #22

## Summary

- `EmailChannel` gains an in-memory `sync.Map` cache mapping each received `Message-ID` → `{subject, inReplyTo}`, populated in `processEmail`
- `Send` checks `OutboundMessage.ReplyToMessageID` (set by the agent loop to the original inbound `MessageID`); when set, it adds `In-Reply-To`, `References` headers and `Re:` subject prefix to the outgoing SMTP message
- Raw message IDs are wrapped in angle brackets when written to headers per RFC 2822
- Lint fixes to pre-existing test helper warnings (`errcheck`, `staticcheck`)

## Test plan

- **Unit**: `TestSend_ReplyThreadingHeaders` — table-driven, covers reply with known subject, idempotent `Re:` prefix, prior References chain, and plain send with no threading headers
- **Integration**: `TestEmailReplyThreading` — end-to-end through in-process IMAP + SMTP servers; asserts `Subject: Re: Hello Agent`, `In-Reply-To`, and `References` headers in captured SMTP output
- All tests pass: `make test` ✓
- Lint clean: `make lint` ✓