### PR TITLE
feat(whatsapp): interactive button/list widgets for agent options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,26 @@ API keys and secrets in `config.json` can reference environment variables instea
 
 The `env://VAR_NAME` scheme is resolved at startup by `internal/envresolve`. This fills a gap in upstream picoclaw which handles `enc://` and `file://` but not `env://`.
 
+### WhatsApp interactive widgets (buttons and lists)
+
+When the agent sets MIME-style metadata on an outbound message, the WhatsApp channel renders native interactive widgets instead of plain text.
+
+**Outbound metadata schema:**
+
+| Key | Value |
+|-----|-------|
+| `Content-Type` | `application/x-wa-buttons` or `application/x-wa-list` |
+| `X-WA-Body` | Body text shown above the options (falls back to `Content` if absent) |
+| `X-WA-Option-0`, `X-WA-Option-1`, … | Individual option labels (0-indexed, contiguous) |
+
+- `application/x-wa-buttons` renders a WhatsApp `ButtonsMessage` (max 3 tappable buttons). If more than 3 options are provided, the first 2 are kept and the rest are collapsed into a synthetic "Other (chat about this)" button.
+- `application/x-wa-list` renders a `ListMessage` with a single-select row list (no limit on rows).
+- If `Content-Type` is absent, unknown, or options are empty, the message falls back to plain text.
+
+**Inbound widget replies:**
+
+When the user taps a button or selects a list row, the reply is forwarded to the agent as plain `Content` (the selected label text) with `metadata["wa_reply_type"] = "button"` attached.
+
 ### Unauthorized sender reply
 
 When a message arrives from a sender not listed in `allow_from`, sushiclaw replies with a rejection message ("You are not authorized to use this bot.") instead of silently dropping the message. Applies to the WhatsApp native channel.

--- a/pkg/channels/whatsapp_native/whatsapp_native.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native.go
@@ -388,6 +388,26 @@ func (c *WhatsAppNativeChannel) handleIncoming(evt *events.Message) {
 
 	content = utils.SanitizeMessageContent(content)
 
+	// Decode interactive widget replies (button tap / list selection).
+	var waReplyType string
+	if content == "" {
+		if br := evt.Message.GetButtonsResponseMessage(); br != nil {
+			content = br.GetSelectedDisplayText()
+			if content == "" {
+				content = br.GetSelectedButtonID()
+			}
+			waReplyType = "button"
+		} else if lr := evt.Message.GetListResponseMessage(); lr != nil {
+			if sr := lr.GetSingleSelectReply(); sr != nil {
+				content = sr.GetSelectedRowID()
+			}
+			waReplyType = "button"
+		}
+		if waReplyType != "" {
+			content = utils.SanitizeMessageContent(content)
+		}
+	}
+
 	var mediaPaths []string
 
 	// Download media attachment, if present and a MediaStore is configured.
@@ -422,6 +442,9 @@ func (c *WhatsAppNativeChannel) handleIncoming(evt *events.Message) {
 	}
 
 	metadata := make(map[string]string)
+	if waReplyType != "" {
+		metadata["wa_reply_type"] = waReplyType
+	}
 	metadata["message_id"] = evt.Info.ID
 	if evt.Info.PushName != "" {
 		metadata["user_name"] = evt.Info.PushName
@@ -575,14 +598,100 @@ func (c *WhatsAppNativeChannel) Send(ctx context.Context, msg bus.OutboundMessag
 		return nil, fmt.Errorf("invalid chat id %q: %w", msg.ChatID, err)
 	}
 
-	waMsg := &waE2E.Message{
-		Conversation: proto.String(msg.Content),
-	}
+	waMsg := buildOutboundProtoMessage(msg)
 
 	if _, err = client.SendMessage(ctx, to, waMsg); err != nil {
 		return nil, fmt.Errorf("whatsapp send: %w", channels.ErrTemporary)
 	}
 	return nil, nil
+}
+
+// buildOutboundProtoMessage converts an OutboundMessage into a whatsmeow proto
+// message. When MIME-style metadata is present it constructs an interactive
+// widget; otherwise it falls back to a plain Conversation message.
+//
+// Metadata schema:
+//
+//	Content-Type: "application/x-wa-buttons" — button widget (max 3)
+//	Content-Type: "application/x-wa-list"    — list widget (any number of rows)
+//	X-WA-Body:    body text shown above the options
+//	X-WA-Option-N: individual option labels (0-indexed)
+//
+// When Content-Type is "application/x-wa-buttons" and more than 3 options are
+// provided, the first 2 are kept and the rest are collapsed into a synthetic
+// "Other (chat about this)" button, respecting WhatsApp's hard 3-button limit.
+func buildOutboundProtoMessage(msg bus.OutboundMessage) *waE2E.Message {
+	ct := msg.Metadata["Content-Type"]
+	body := msg.Metadata["X-WA-Body"]
+	if body == "" {
+		body = msg.Content
+	}
+
+	var opts []string
+	for i := 0; ; i++ {
+		v, ok := msg.Metadata[fmt.Sprintf("X-WA-Option-%d", i)]
+		if !ok {
+			break
+		}
+		opts = append(opts, v)
+	}
+
+	switch ct {
+	case "application/x-wa-buttons":
+		if len(opts) == 0 {
+			break
+		}
+		display := opts
+		if len(display) > 3 {
+			display = append(opts[:2:2], "Other (chat about this)")
+		}
+		buttons := make([]*waE2E.ButtonsMessage_Button, len(display))
+		for i, label := range display {
+			buttons[i] = &waE2E.ButtonsMessage_Button{
+				ButtonID: proto.String(fmt.Sprintf("%d", i)),
+				ButtonText: &waE2E.ButtonsMessage_Button_ButtonText{
+					DisplayText: proto.String(label),
+				},
+				Type: waE2E.ButtonsMessage_Button_RESPONSE.Enum(),
+			}
+		}
+		return &waE2E.Message{
+			ButtonsMessage: &waE2E.ButtonsMessage{
+				ContentText: proto.String(body),
+				HeaderType:  waE2E.ButtonsMessage_EMPTY.Enum(),
+				Buttons:     buttons,
+			},
+		}
+
+	case "application/x-wa-list":
+		if len(opts) == 0 {
+			break
+		}
+		rows := make([]*waE2E.ListMessage_Row, len(opts))
+		for i, label := range opts {
+			// RowID is set to the label text so that an incoming
+			// ListResponseMessage.SingleSelectReply.SelectedRowID directly
+			// carries the user's choice as the message content.
+			rows[i] = &waE2E.ListMessage_Row{
+				RowID: proto.String(label),
+				Title: proto.String(label),
+			}
+		}
+		return &waE2E.Message{
+			ListMessage: &waE2E.ListMessage{
+				Title:      proto.String(body),
+				ButtonText: proto.String("Select"),
+				ListType:   waE2E.ListMessage_SINGLE_SELECT.Enum(),
+				Sections: []*waE2E.ListMessage_Section{
+					{Rows: rows},
+				},
+			},
+		}
+	}
+
+	return &waE2E.Message{
+		Conversation: proto.String(msg.Content),
+	}
 }
 
 // parseJID converts a chat ID (phone number or JID string) to types.JID.

--- a/pkg/channels/whatsapp_native/whatsapp_native_sushi30_test.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native_sushi30_test.go
@@ -2,6 +2,7 @@ package whatsapp
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -215,6 +216,217 @@ func TestHandleIncoming_RecentMessage_Processed(t *testing.T) {
 	msg := receiveInbound(t, mb)
 	if msg.Content != content {
 		t.Fatalf("expected content=%q, got %q", content, msg.Content)
+	}
+}
+
+// --- buildOutboundProtoMessage tests ---
+
+func TestBuildOutboundProtoMessage_Buttons(t *testing.T) {
+	msg := bus.OutboundMessage{
+		Content: "fallback",
+		Metadata: map[string]string{
+			"Content-Type":  "application/x-wa-buttons",
+			"X-WA-Body":     "Pick one:",
+			"X-WA-Option-0": "Alpha",
+			"X-WA-Option-1": "Beta",
+			"X-WA-Option-2": "Gamma",
+		},
+	}
+	waMsg := buildOutboundProtoMessage(msg)
+
+	bm := waMsg.GetButtonsMessage()
+	if bm == nil {
+		t.Fatal("expected ButtonsMessage, got nil")
+	}
+	if bm.GetContentText() != "Pick one:" {
+		t.Errorf("body: got %q, want %q", bm.GetContentText(), "Pick one:")
+	}
+	if len(bm.Buttons) != 3 {
+		t.Fatalf("expected 3 buttons, got %d", len(bm.Buttons))
+	}
+	labels := []string{"Alpha", "Beta", "Gamma"}
+	for i, btn := range bm.Buttons {
+		if btn.GetButtonText().GetDisplayText() != labels[i] {
+			t.Errorf("button[%d]: got %q, want %q", i, btn.GetButtonText().GetDisplayText(), labels[i])
+		}
+		if btn.GetButtonID() != fmt.Sprintf("%d", i) {
+			t.Errorf("button[%d] ID: got %q, want %q", i, btn.GetButtonID(), fmt.Sprintf("%d", i))
+		}
+	}
+}
+
+func TestBuildOutboundProtoMessage_ButtonsOverflow(t *testing.T) {
+	msg := bus.OutboundMessage{
+		Content: "fallback",
+		Metadata: map[string]string{
+			"Content-Type":  "application/x-wa-buttons",
+			"X-WA-Body":     "Choose:",
+			"X-WA-Option-0": "One",
+			"X-WA-Option-1": "Two",
+			"X-WA-Option-2": "Three",
+			"X-WA-Option-3": "Four",
+			"X-WA-Option-4": "Five",
+		},
+	}
+	waMsg := buildOutboundProtoMessage(msg)
+
+	bm := waMsg.GetButtonsMessage()
+	if bm == nil {
+		t.Fatal("expected ButtonsMessage, got nil")
+	}
+	if len(bm.Buttons) != 3 {
+		t.Fatalf("expected 3 buttons (overflow collapsed), got %d", len(bm.Buttons))
+	}
+	if bm.Buttons[0].GetButtonText().GetDisplayText() != "One" {
+		t.Errorf("button[0]: got %q, want \"One\"", bm.Buttons[0].GetButtonText().GetDisplayText())
+	}
+	if bm.Buttons[1].GetButtonText().GetDisplayText() != "Two" {
+		t.Errorf("button[1]: got %q, want \"Two\"", bm.Buttons[1].GetButtonText().GetDisplayText())
+	}
+	if bm.Buttons[2].GetButtonText().GetDisplayText() != "Other (chat about this)" {
+		t.Errorf("button[2]: got %q, want \"Other (chat about this)\"", bm.Buttons[2].GetButtonText().GetDisplayText())
+	}
+}
+
+func TestBuildOutboundProtoMessage_List(t *testing.T) {
+	msg := bus.OutboundMessage{
+		Content: "fallback",
+		Metadata: map[string]string{
+			"Content-Type":  "application/x-wa-list",
+			"X-WA-Body":     "Select a city:",
+			"X-WA-Option-0": "New York",
+			"X-WA-Option-1": "London",
+			"X-WA-Option-2": "Tokyo",
+			"X-WA-Option-3": "Sydney",
+		},
+	}
+	waMsg := buildOutboundProtoMessage(msg)
+
+	lm := waMsg.GetListMessage()
+	if lm == nil {
+		t.Fatal("expected ListMessage, got nil")
+	}
+	if lm.GetTitle() != "Select a city:" {
+		t.Errorf("title: got %q, want %q", lm.GetTitle(), "Select a city:")
+	}
+	if len(lm.Sections) != 1 {
+		t.Fatalf("expected 1 section, got %d", len(lm.Sections))
+	}
+	rows := lm.Sections[0].Rows
+	if len(rows) != 4 {
+		t.Fatalf("expected 4 rows, got %d", len(rows))
+	}
+	labels := []string{"New York", "London", "Tokyo", "Sydney"}
+	for i, row := range rows {
+		if row.GetTitle() != labels[i] {
+			t.Errorf("row[%d] title: got %q, want %q", i, row.GetTitle(), labels[i])
+		}
+		// RowID == label so incoming reply carries the choice directly.
+		if row.GetRowID() != labels[i] {
+			t.Errorf("row[%d] ID: got %q, want %q", i, row.GetRowID(), labels[i])
+		}
+	}
+}
+
+func TestBuildOutboundProtoMessage_FallbackPlainText(t *testing.T) {
+	msg := bus.OutboundMessage{Content: "hello world"}
+	waMsg := buildOutboundProtoMessage(msg)
+
+	if waMsg.GetConversation() != "hello world" {
+		t.Errorf("got %q, want %q", waMsg.GetConversation(), "hello world")
+	}
+	if waMsg.GetButtonsMessage() != nil {
+		t.Error("expected no ButtonsMessage on plain fallback")
+	}
+	if waMsg.GetListMessage() != nil {
+		t.Error("expected no ListMessage on plain fallback")
+	}
+}
+
+func TestBuildOutboundProtoMessage_EmptyOptions(t *testing.T) {
+	// Content-Type set but no X-WA-Option-N → fall back to plain text.
+	msg := bus.OutboundMessage{
+		Content: "plain",
+		Metadata: map[string]string{
+			"Content-Type": "application/x-wa-buttons",
+			"X-WA-Body":    "Choose:",
+		},
+	}
+	waMsg := buildOutboundProtoMessage(msg)
+
+	if waMsg.GetConversation() != "plain" {
+		t.Errorf("got %q, want %q", waMsg.GetConversation(), "plain")
+	}
+}
+
+// --- handleIncoming widget reply tests ---
+
+func TestHandleIncoming_ButtonsResponse_Forwarded(t *testing.T) {
+	ch, mb := makeTestChannel(nil)
+
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Sender: types.NewJID("1001", types.DefaultUserServer),
+				Chat:   types.NewJID("1001", types.DefaultUserServer),
+			},
+			ID:        "mid-btn",
+			PushName:  "Alice",
+			Timestamp: time.Now().Add(1 * time.Second),
+		},
+		Message: &waE2E.Message{
+			ButtonsResponseMessage: &waE2E.ButtonsResponseMessage{
+				Response: &waE2E.ButtonsResponseMessage_SelectedDisplayText{
+					SelectedDisplayText: "Book a flight",
+				},
+				SelectedButtonID: proto.String("0"),
+				Type:             waE2E.ButtonsResponseMessage_DISPLAY_TEXT.Enum(),
+			},
+		},
+	}
+
+	ch.handleIncoming(evt)
+
+	msg := receiveInbound(t, mb)
+	if msg.Content != "Book a flight" {
+		t.Errorf("content: got %q, want %q", msg.Content, "Book a flight")
+	}
+	if msg.Metadata["wa_reply_type"] != "button" {
+		t.Errorf("wa_reply_type: got %q, want %q", msg.Metadata["wa_reply_type"], "button")
+	}
+}
+
+func TestHandleIncoming_ListResponse_Forwarded(t *testing.T) {
+	ch, mb := makeTestChannel(nil)
+
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Sender: types.NewJID("1001", types.DefaultUserServer),
+				Chat:   types.NewJID("1001", types.DefaultUserServer),
+			},
+			ID:        "mid-list",
+			PushName:  "Bob",
+			Timestamp: time.Now().Add(1 * time.Second),
+		},
+		Message: &waE2E.Message{
+			ListResponseMessage: &waE2E.ListResponseMessage{
+				SingleSelectReply: &waE2E.ListResponseMessage_SingleSelectReply{
+					SelectedRowID: proto.String("London"),
+				},
+				ListType: waE2E.ListResponseMessage_SINGLE_SELECT.Enum(),
+			},
+		},
+	}
+
+	ch.handleIncoming(evt)
+
+	msg := receiveInbound(t, mb)
+	if msg.Content != "London" {
+		t.Errorf("content: got %q, want %q", msg.Content, "London")
+	}
+	if msg.Metadata["wa_reply_type"] != "button" {
+		t.Errorf("wa_reply_type: got %q, want %q", msg.Metadata["wa_reply_type"], "button")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `Send()` now reads MIME-style metadata (`Content-Type`, `X-WA-Body`, `X-WA-Option-N`) and renders a native `ButtonsMessage` (≤3 tappable buttons) or `ListMessage` (single-select rows) instead of plain text
- Button overflow: >3 options collapses to first 2 + "Other (chat about this)" — respects WhatsApp's hard 3-button limit
- `handleIncoming()` decodes `ButtonsResponseMessage` / `ListResponseMessage` replies and forwards the selected label as content with `metadata["wa_reply_type"] = "button"`
- README documents the metadata schema

## Metadata schema

| Key | Value |
|-----|-------|
| `Content-Type` | `application/x-wa-buttons` or `application/x-wa-list` |
| `X-WA-Body` | Body text above the options |
| `X-WA-Option-0`, `X-WA-Option-1`, … | Option labels (0-indexed) |

## Test plan

- `TestBuildOutboundProtoMessage_Buttons` — 3 options → correct `ButtonsMessage` fields
- `TestBuildOutboundProtoMessage_ButtonsOverflow` — 5 options → 3-button message (2 real + "Other")
- `TestBuildOutboundProtoMessage_List` — 4 options → `ListMessage` SINGLE_SELECT, row IDs = labels
- `TestBuildOutboundProtoMessage_FallbackPlainText` — no metadata → plain `Conversation`
- `TestBuildOutboundProtoMessage_EmptyOptions` — `Content-Type` set, no options → plain fallback
- `TestHandleIncoming_ButtonsResponse_Forwarded` — button tap → content + `wa_reply_type=button`
- `TestHandleIncoming_ListResponse_Forwarded` — list select → content + `wa_reply_type=button`

All pass. Full suite green (`make test`). Lint clean (`make lint`).

Closes #31