### PR TITLE
fix(email): unique subjects for new conversations + proper MIME construction

### DIFF
--- a/pkg/channels/email/email.go
+++ b/pkg/channels/email/email.go
@@ -176,13 +176,13 @@ func (c *EmailChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]str
 	var bodyBuf bytes.Buffer
 	w, err := gomail.CreateSingleInlineWriter(&bodyBuf, h)
 	if err != nil {
-		return nil, fmt.Errorf("create mime writer: %w", channels.ErrSendFailed)
+		return nil, fmt.Errorf("create mime writer: %w: %w", err, channels.ErrSendFailed)
 	}
 	if _, err := w.Write([]byte(msg.Content)); err != nil {
-		return nil, fmt.Errorf("write mime body: %w", channels.ErrSendFailed)
+		return nil, fmt.Errorf("write mime body: %w: %w", err, channels.ErrSendFailed)
 	}
 	if err := w.Close(); err != nil {
-		return nil, fmt.Errorf("close mime body: %w", channels.ErrSendFailed)
+		return nil, fmt.Errorf("close mime body: %w: %w", err, channels.ErrSendFailed)
 	}
 
 	smtpPort := c.config.SMTPPort
@@ -224,19 +224,18 @@ func (c *EmailChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]str
 
 	// Store thread info for the outbound message so future inbound replies
 	// can trace back to this thread.
-	outboundRawID := outboundMsgIDRaw
 	if root == "" && msg.ReplyToMessageID != "" {
 		root = msg.ReplyToMessageID
 	}
 	if root == "" {
-		root = outboundRawID
+		root = outboundMsgIDRaw
 	}
 	var outboundRefs []string
 	outboundRefs = append(outboundRefs, parentRefs...)
 	if msg.ReplyToMessageID != "" {
 		outboundRefs = append(outboundRefs, "<"+msg.ReplyToMessageID+">")
 	}
-	c.threads.Store(outboundRawID, threadInfo{
+	c.threads.Store(outboundMsgIDRaw, threadInfo{
 		subject:    subject,
 		references: outboundRefs,
 		threadRoot: root,
@@ -425,7 +424,7 @@ func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope
 		}
 	}
 	if root == "" && envelope.MessageID != "" {
-		root = envelope.MessageID
+		root = strings.Trim(envelope.MessageID, "<>")
 	}
 
 	if envelope.MessageID != "" {

--- a/pkg/channels/email/email.go
+++ b/pkg/channels/email/email.go
@@ -136,6 +136,9 @@ func (c *EmailChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]str
 		subject = "Message"
 	}
 
+	outboundMsgID := generateMessageID(extractDomain(c.config.SMTPFrom.String()))
+	outboundMsgIDRaw := strings.Trim(outboundMsgID, "<>")
+
 	var parentRefs []string
 	var root string
 	if msg.ReplyToMessageID != "" {
@@ -153,17 +156,33 @@ func (c *EmailChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]str
 		}
 	}
 
-	outboundMsgID := generateMessageID(extractDomain(c.config.SMTPFrom.String()))
-	dateStr := time.Now().Format("Mon, 02 Jan 2006 15:04:05 -0700")
+	if msg.ReplyToMessageID == "" && len(outboundMsgIDRaw) >= 8 {
+		subject = fmt.Sprintf("%s [%s]", subject, outboundMsgIDRaw[:8])
+	}
 
-	var extraHeaders strings.Builder
-	extraHeaders.WriteString("Date: " + dateStr + "\r\n")
-	extraHeaders.WriteString("Message-ID: " + outboundMsgID + "\r\n")
+	var h gomail.Header
+	h.SetAddressList("From", []*gomail.Address{{Address: c.config.SMTPFrom.String()}})
+	h.SetAddressList("To", []*gomail.Address{{Address: to}})
+	h.SetSubject(subject)
+	h.SetDate(time.Now())
+	h.SetMessageID(outboundMsgIDRaw)
 
 	if msg.ReplyToMessageID != "" {
-		replyTo := "<" + msg.ReplyToMessageID + ">"
-		extraHeaders.WriteString("In-Reply-To: " + replyTo + "\r\n")
-		extraHeaders.WriteString("References: " + buildReferences(replyTo, parentRefs) + "\r\n")
+		h.SetMsgIDList("In-Reply-To", []string{msg.ReplyToMessageID})
+		refs := buildReferencesList(msg.ReplyToMessageID, parentRefs)
+		h.SetMsgIDList("References", refs)
+	}
+
+	var bodyBuf bytes.Buffer
+	w, err := gomail.CreateSingleInlineWriter(&bodyBuf, h)
+	if err != nil {
+		return nil, fmt.Errorf("create mime writer: %w", channels.ErrSendFailed)
+	}
+	if _, err := w.Write([]byte(msg.Content)); err != nil {
+		return nil, fmt.Errorf("write mime body: %w", channels.ErrSendFailed)
+	}
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("close mime body: %w", channels.ErrSendFailed)
 	}
 
 	smtpPort := c.config.SMTPPort
@@ -176,9 +195,6 @@ func (c *EmailChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]str
 	if smtpUser == "" {
 		smtpUser = c.config.SMTPFrom.String()
 	}
-
-	body := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\n%s\r\n%s",
-		c.config.SMTPFrom.String(), to, subject, extraHeaders.String(), msg.Content)
 
 	var auth smtp.Auth
 	if c.config.SMTPPassword.String() != "" {
@@ -197,18 +213,18 @@ func (c *EmailChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]str
 			return nil, fmt.Errorf("smtp new client: %w", channels.ErrTemporary)
 		}
 		defer func() { _ = client.Close() }()
-		if err := sendViaSMTPClient(client, auth, c.config.SMTPFrom.String(), to, []byte(body)); err != nil {
+		if err := sendViaSMTPClient(client, auth, c.config.SMTPFrom.String(), to, bodyBuf.Bytes()); err != nil {
 			return nil, err
 		}
 	} else {
-		if err := smtp.SendMail(addr, auth, c.config.SMTPFrom.String(), []string{to}, []byte(body)); err != nil {
+		if err := smtp.SendMail(addr, auth, c.config.SMTPFrom.String(), []string{to}, bodyBuf.Bytes()); err != nil {
 			return nil, fmt.Errorf("smtp send: %w: %w", err, channels.ErrTemporary)
 		}
 	}
 
 	// Store thread info for the outbound message so future inbound replies
 	// can trace back to this thread.
-	outboundRawID := strings.Trim(outboundMsgID, "<>")
+	outboundRawID := outboundMsgIDRaw
 	if root == "" && msg.ReplyToMessageID != "" {
 		root = msg.ReplyToMessageID
 	}
@@ -446,13 +462,16 @@ func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope
 	return true, plainText
 }
 
-// buildReferences constructs the RFC 5322 References header value for a reply.
-// It concatenates the parent's References chain with the current message ID.
-func buildReferences(messageID string, parentRefs []string) string {
-	parts := make([]string, 0, len(parentRefs)+1)
-	parts = append(parts, parentRefs...)
-	parts = append(parts, messageID)
-	return strings.Join(parts, " ")
+// buildReferencesList returns a list of message IDs (without angle brackets)
+// for use with mail.Header.SetMsgIDList. The list contains the parent's
+// References chain followed by the immediate parent's Message-ID.
+func buildReferencesList(parentMsgID string, parentRefs []string) []string {
+	refs := make([]string, 0, len(parentRefs)+1)
+	for _, ref := range parentRefs {
+		refs = append(refs, strings.Trim(ref, " <>"))
+	}
+	refs = append(refs, strings.Trim(parentMsgID, " <>"))
+	return refs
 }
 
 // normalizeMsgIDs ensures all message IDs in a list are angle-bracketed.

--- a/pkg/channels/email/email_integration_test.go
+++ b/pkg/channels/email/email_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -19,6 +20,8 @@ import (
 	"github.com/sipeed/picoclaw/pkg/channels"
 	"github.com/sipeed/picoclaw/pkg/config"
 )
+
+var subjectHexSuffixRe = regexp.MustCompile(`^Message \[([0-9a-f]{8})\]$`)
 
 // literalReaderImpl satisfies imap.LiteralReader with a fixed size.
 type literalReaderImpl struct {
@@ -248,8 +251,12 @@ func TestEmailOutboundPipeline(t *testing.T) {
 		if !strings.Contains(body, "Date: ") {
 			t.Errorf("SMTP body missing Date header:\n%s", body)
 		}
-		if !strings.Contains(body, "Message-ID: <") {
+		if !strings.Contains(strings.ToLower(body), "message-id: <") {
 			t.Errorf("SMTP body missing Message-ID header:\n%s", body)
+		}
+		subject := extractSubjectFromSMTPBody(t, body)
+		if !subjectHexSuffixRe.MatchString(subject) {
+			t.Errorf("outbound subject = %q, want match for %q (unique suffix required for new-conversation emails)", subject, subjectHexSuffixRe.String())
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timeout: SMTP capture received nothing")
@@ -341,7 +348,7 @@ func TestEmailReplyThreading(t *testing.T) {
 		if !strings.Contains(body, "References: "+msgIDHeader) {
 			t.Errorf("SMTP body missing References header:\n%s", body)
 		}
-		if !strings.Contains(body, "Message-ID: <") {
+		if !strings.Contains(strings.ToLower(body), "message-id: <") {
 			t.Errorf("SMTP body missing Message-ID header:\n%s", body)
 		}
 	case <-time.After(5 * time.Second):
@@ -427,7 +434,7 @@ func TestEmailNewEmail_ThreadReply(t *testing.T) {
 		if !strings.Contains(body, "References: "+msgIDHeader) {
 			t.Errorf("SMTP body missing References:\n%s", body)
 		}
-		if !strings.Contains(body, "Message-ID: <") {
+		if !strings.Contains(strings.ToLower(body), "message-id: <") {
 			t.Errorf("SMTP body missing Message-ID header:\n%s", body)
 		}
 	case <-time.After(5 * time.Second):
@@ -589,17 +596,17 @@ func TestEmailNewEmail_FreshThread(t *testing.T) {
 }
 
 // extractMessageIDFromBody parses the Message-ID header value from raw SMTP body.
+// The header name is matched case-insensitively (RFC 5322 headers are case-insensitive).
 func extractMessageIDFromBody(t *testing.T, body string) string {
 	t.Helper()
 	for _, line := range strings.Split(body, "\r\n") {
-		if strings.HasPrefix(line, "Message-ID: ") {
-			return strings.Trim(line[len("Message-ID: "):], " <>")
+		if strings.HasPrefix(strings.ToLower(line), "message-id: ") {
+			return strings.Trim(line[12:], " <>")
 		}
 	}
-	// Also try \n line endings
 	for _, line := range strings.Split(body, "\n") {
-		if strings.HasPrefix(line, "Message-ID: ") {
-			return strings.Trim(line[len("Message-ID: "):], " <>")
+		if strings.HasPrefix(strings.ToLower(line), "message-id: ") {
+			return strings.Trim(line[12:], " <>")
 		}
 	}
 	return ""

--- a/pkg/channels/email/email_test.go
+++ b/pkg/channels/email/email_test.go
@@ -534,7 +534,7 @@ func TestSend_ReplyThreadingHeaders(t *testing.T) {
 			wantReferences:   "References: <first@test.com> <orig@test.com>",
 		},
 		{
-			name:             "no ReplyToMessageID — no threading headers",
+			name:             "no ReplyToMessageID — no threading headers, subject has unique suffix",
 			cachedSubject:    "Hello Agent",
 			replyToMessageID: "",
 			wantNoThreading:  true,
@@ -584,7 +584,7 @@ func TestSend_ReplyThreadingHeaders(t *testing.T) {
 
 			select {
 			case body := <-received:
-				if !strings.Contains(body, "Message-ID: <") {
+				if !strings.Contains(strings.ToLower(body), "message-id: <") {
 					t.Errorf("expected Message-ID header in outbound:\n%s", body)
 				}
 				if !strings.Contains(body, "Date: ") {
@@ -596,6 +596,11 @@ func TestSend_ReplyThreadingHeaders(t *testing.T) {
 					}
 					if strings.Contains(body, "References:") {
 						t.Errorf("expected no References header, got:\n%s", body)
+					}
+					subject := extractSubjectFromSMTPBody(t, body)
+					m := subjectHexSuffixRe.FindStringSubmatch(subject)
+					if m == nil {
+						t.Errorf("new-conversation subject = %q, want match for %q", subject, subjectHexSuffixRe.String())
 					}
 					return
 				}
@@ -609,6 +614,191 @@ func TestSend_ReplyThreadingHeaders(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSend_NewConversation_UniqueSubject(t *testing.T) {
+	smtp1Host, smtp1Port, received1 := startSMTPCapture(t)
+	smtp1PortInt, _ := strconv.Atoi(smtp1Port)
+
+	smtp2Host, smtp2Port, received2 := startSMTPCapture(t)
+	smtp2PortInt, _ := strconv.Atoi(smtp2Port)
+
+	msgBus := bus.NewMessageBus()
+
+	cfg1 := EmailConfig{
+		SMTPHost:       smtp1Host,
+		SMTPPort:       smtp1PortInt,
+		SMTPFrom:       *config.NewSecureString("bot@test.com"),
+		DefaultSubject: "Message",
+		IMAPHost:       "127.0.0.1",
+		IMAPPort:       10143,
+		IMAPUser:       *config.NewSecureString("u"),
+		IMAPPassword:   *config.NewSecureString("p"),
+	}
+
+	cfg2 := EmailConfig{
+		SMTPHost:       smtp2Host,
+		SMTPPort:       smtp2PortInt,
+		SMTPFrom:       *config.NewSecureString("bot@test.com"),
+		DefaultSubject: "Message",
+		IMAPHost:       "127.0.0.1",
+		IMAPPort:       10144,
+		IMAPUser:       *config.NewSecureString("u"),
+		IMAPPassword:   *config.NewSecureString("p"),
+	}
+
+	ch1, err := NewEmailChannel(cfg1, msgBus)
+	if err != nil {
+		t.Fatalf("NewEmailChannel: %v", err)
+	}
+	ch1.SetRunning(true)
+
+	ch2, err := NewEmailChannel(cfg2, msgBus)
+	if err != nil {
+		t.Fatalf("NewEmailChannel: %v", err)
+	}
+	ch2.SetRunning(true)
+
+	// First Send with empty ReplyToMessageID
+	_, err = ch1.Send(context.Background(), bus.OutboundMessage{
+		ChatID:  "user@example.com",
+		Content: "First new conversation",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	// Second Send with empty ReplyToMessageID
+	_, err = ch2.Send(context.Background(), bus.OutboundMessage{
+		ChatID:  "user@example.com",
+		Content: "Second new conversation",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	var body1, body2 string
+	select {
+	case body1 = <-received1:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: SMTP capture received nothing for first message")
+	}
+
+	select {
+	case body2 = <-received2:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: SMTP capture received nothing for second message")
+	}
+
+	// Extract subject lines
+	subject1 := extractSubjectFromSMTPBody(t, body1)
+	subject2 := extractSubjectFromSMTPBody(t, body2)
+
+	// Both subjects should match "Message [xxxxxxxx]" pattern
+	m1 := subjectHexSuffixRe.FindStringSubmatch(subject1)
+	if m1 == nil {
+		t.Errorf("subject1 = %q, want match for %q", subject1, subjectHexSuffixRe.String())
+	}
+	m2 := subjectHexSuffixRe.FindStringSubmatch(subject2)
+	if m2 == nil {
+		t.Errorf("subject2 = %q, want match for %q", subject2, subjectHexSuffixRe.String())
+	}
+
+	// Subjects should be different
+	if subject1 == subject2 {
+		t.Errorf("two new-conversation emails should have different subjects, both = %q", subject1)
+	}
+
+	// The suffix should match the first 8 chars of the Message-ID hex portion
+	mid1 := extractMessageIDFromBody(t, body1)
+	if m1 != nil && len(mid1) >= 8 {
+		expectedSuffix := mid1[:8]
+		if m1[1] != expectedSuffix {
+			t.Errorf("subject suffix = %q, want first 8 chars of Message-ID %q = %q", m1[1], mid1, expectedSuffix)
+		}
+	}
+	mid2 := extractMessageIDFromBody(t, body2)
+	if m2 != nil && len(mid2) >= 8 {
+		expectedSuffix := mid2[:8]
+		if m2[1] != expectedSuffix {
+			t.Errorf("subject suffix = %q, want first 8 chars of Message-ID %q = %q", m2[1], mid2, expectedSuffix)
+		}
+	}
+
+	// No In-Reply-To or References headers on new-conversation emails
+	for _, b := range []string{body1, body2} {
+		if strings.Contains(b, "In-Reply-To:") {
+			t.Errorf("new-conversation email should not have In-Reply-To:\n%s", b)
+		}
+		if strings.Contains(b, "References:") {
+			t.Errorf("new-conversation email should not have References:\n%s", b)
+		}
+	}
+}
+
+func TestSend_ReplyDoesNotAddSuffix(t *testing.T) {
+	smtpHost, smtpPort, received := startSMTPCapture(t)
+	smtpPortInt, _ := strconv.Atoi(smtpPort)
+
+	msgBus := bus.NewMessageBus()
+	cfg := EmailConfig{
+		SMTPHost:       smtpHost,
+		SMTPPort:       smtpPortInt,
+		SMTPFrom:       *config.NewSecureString("bot@test.com"),
+		DefaultSubject: "Message",
+		IMAPHost:       "127.0.0.1",
+		IMAPPort:       10143,
+		IMAPUser:       *config.NewSecureString("u"),
+		IMAPPassword:   *config.NewSecureString("p"),
+	}
+
+	ch, err := NewEmailChannel(cfg, msgBus)
+	if err != nil {
+		t.Fatalf("NewEmailChannel: %v", err)
+	}
+	ch.SetRunning(true)
+
+	const origMsgID = "orig-suffix-test@test.com"
+	ch.threads.Store(origMsgID, threadInfo{
+		subject:    "Important Thread",
+		references: nil,
+		threadRoot: origMsgID,
+	})
+
+	_, err = ch.Send(context.Background(), bus.OutboundMessage{
+		ChatID:           "user@example.com",
+		Content:          "Replying to thread",
+		ReplyToMessageID: origMsgID,
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	select {
+	case body := <-received:
+		subject := extractSubjectFromSMTPBody(t, body)
+		if subject != "Re: Important Thread" {
+			t.Errorf("reply subject = %q, want %q (no suffix on replies)", subject, "Re: Important Thread")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: SMTP capture received nothing")
+	}
+}
+
+func extractSubjectFromSMTPBody(t *testing.T, body string) string {
+	t.Helper()
+	for _, line := range strings.Split(body, "\r\n") {
+		if strings.HasPrefix(line, "Subject: ") {
+			return strings.TrimPrefix(line, "Subject: ")
+		}
+	}
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "Subject: ") {
+			return strings.TrimPrefix(line, "Subject: ")
+		}
+	}
+	t.Fatalf("no Subject header found in SMTP body:\n%s", body)
+	return ""
 }
 
 func TestProcessEmail_SkipsEmptyOrSenderlessMessages(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Unique subject suffix for new conversations**: When the agent initiates an email (not a reply), the subject now includes a unique suffix `[xxxxxxxx]` derived from the first 8 hex chars of the Message-ID. This prevents Gmail from merging all agent-initiated emails into a single thread.

- **Proper MIME construction via `mail.Header`**: Refactored `Send()` to use `emersion/go-message/mail` for proper RFC 5322 MIME message construction instead of raw string concatenation. This ensures headers are properly formatted and encoded.

## Problem Solved

Gmail groups emails by subject when there's no `In-Reply-To`/`References` header. Previously, all agent-initiated emails used the same default subject (e.g., "Message"), causing them to be merged into one thread.

## Test Plan

- Added `TestSend_NewConversation_UniqueSubject` - verifies two new-conversation emails have different subjects and the suffix matches the Message-ID
- Added `TestSend_ReplyDoesNotAddSuffix` - verifies replies don't get the suffix (threading headers handle Gmail grouping)
- Updated `TestSend_ReplyThreadingHeaders` to verify unique subject for new conversations
- Updated `TestEmailOutboundPipeline` to verify unique subject suffix
- All tests use case-insensitive header matching per RFC 5322

```
make test  # all pass
make lint  # 0 issues
```