### PR TITLE
feat(gateway): add /debug command to toggle agent event visibility

### DIFF
--- a/internal/gateway/bridge_test.go
+++ b/internal/gateway/bridge_test.go
@@ -1,0 +1,88 @@
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sipeed/picoclaw/pkg/agent"
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/config"
+)
+
+func newBridgeTestLoop() *agent.AgentLoop {
+	return agent.NewAgentLoop(config.DefaultConfig(), bus.NewMessageBus(), &debugStubProvider{})
+}
+
+// TestHandleInbound_DebugCommand verifies that a /debug message is intercepted:
+// a reply is sent to externalBus and nothing is forwarded to agentBus.
+func TestHandleInbound_DebugCommand(t *testing.T) {
+	agentBus := bus.NewMessageBus()
+	extBus := bus.NewMessageBus()
+	mgr := &DebugManager{agentLoop: newBridgeTestLoop(), externalBus: extBus}
+
+	ctx := t.Context()
+
+	handleInbound(ctx, bus.InboundMessage{
+		Channel: "telegram",
+		ChatID:  "chat99",
+		Content: "/debug",
+	}, mgr, agentBus, extBus)
+
+	// externalBus should have the toggle reply.
+	select {
+	case out := <-extBus.OutboundChan():
+		if out.Channel != "telegram" {
+			t.Fatalf("reply Channel = %q, want telegram", out.Channel)
+		}
+		if out.ChatID != "chat99" {
+			t.Fatalf("reply ChatID = %q, want chat99", out.ChatID)
+		}
+		if out.Content == "" {
+			t.Fatal("reply Content is empty")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for /debug reply on externalBus")
+	}
+
+	// agentBus must NOT have received the /debug message.
+	select {
+	case fwd := <-agentBus.InboundChan():
+		t.Fatalf("unexpected message forwarded to agentBus: %+v", fwd)
+	default:
+		// Nothing there — correct.
+	}
+}
+
+// TestHandleInbound_NormalMessage verifies that a non-debug message is
+// forwarded to agentBus and no reply appears on externalBus.
+func TestHandleInbound_NormalMessage(t *testing.T) {
+	agentBus := bus.NewMessageBus()
+	extBus := bus.NewMessageBus()
+	mgr := &DebugManager{agentLoop: newBridgeTestLoop(), externalBus: extBus}
+
+	ctx := t.Context()
+
+	handleInbound(ctx, bus.InboundMessage{
+		Channel: "telegram",
+		ChatID:  "chat88",
+		Content: "hello world",
+	}, mgr, agentBus, extBus)
+
+	// agentBus should receive the forwarded message.
+	select {
+	case fwd := <-agentBus.InboundChan():
+		if fwd.Content != "hello world" {
+			t.Fatalf("forwarded Content = %q, want hello world", fwd.Content)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for forwarded message on agentBus")
+	}
+
+	// externalBus must NOT have received a reply.
+	select {
+	case out := <-extBus.OutboundChan():
+		t.Fatalf("unexpected reply on externalBus: %+v", out)
+	default:
+		// Nothing there — correct.
+	}
+}

--- a/internal/gateway/debug.go
+++ b/internal/gateway/debug.go
@@ -1,0 +1,188 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/sipeed/picoclaw/pkg/agent"
+	"github.com/sipeed/picoclaw/pkg/bus"
+)
+
+// DebugManager toggles per-chat debug event forwarding.
+// When active, it subscribes to the agent event bus and publishes
+// formatted event messages back to the chat that issued /debug.
+type DebugManager struct {
+	mu          sync.Mutex
+	active      bool
+	cancel      context.CancelFunc
+	agentLoop   *agent.AgentLoop
+	externalBus *bus.MessageBus
+	channel     string
+	chatID      string
+}
+
+// Toggle flips debug mode and returns a status string to send back to the user.
+func (d *DebugManager) Toggle(ctx context.Context, channel, chatID string) string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.active {
+		d.cancel()
+		d.cancel = nil
+		d.active = false
+		d.channel = ""
+		d.chatID = ""
+		return "Debug mode disabled."
+	}
+
+	d.channel = channel
+	d.chatID = chatID
+	d.active = true
+
+	fwdCtx, cancel := context.WithCancel(ctx)
+	d.cancel = cancel
+	go d.runEventForwarder(fwdCtx)
+
+	return "Debug mode enabled. Agent events will be sent to this chat."
+}
+
+// runEventForwarder subscribes to agent events and forwards formatted
+// messages to the chat that enabled debug mode.
+func (d *DebugManager) runEventForwarder(ctx context.Context) {
+	sub := d.agentLoop.SubscribeEvents(64)
+	defer d.agentLoop.UnsubscribeEvents(sub.ID)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case evt, ok := <-sub.C:
+			if !ok {
+				return
+			}
+			msg := d.formatEvent(evt)
+			if msg == "" {
+				continue
+			}
+			d.mu.Lock()
+			ch := d.channel
+			cid := d.chatID
+			d.mu.Unlock()
+			if ch == "" {
+				continue
+			}
+			_ = d.externalBus.PublishOutbound(ctx, bus.OutboundMessage{
+				Channel: ch,
+				ChatID:  cid,
+				Content: msg,
+			})
+		}
+	}
+}
+
+// formatEvent converts an agent Event into a compact human-readable string.
+// Returns "" for events that should be suppressed (e.g. llm_delta, session_summarize).
+func (d *DebugManager) formatEvent(evt agent.Event) string {
+	switch evt.Kind {
+	case agent.EventKindTurnStart:
+		p, ok := evt.Payload.(agent.TurnStartPayload)
+		if !ok {
+			break
+		}
+		return fmt.Sprintf("[debug] turn start: channel=%s chat=%s", p.Channel, p.ChatID)
+
+	case agent.EventKindTurnEnd:
+		p, ok := evt.Payload.(agent.TurnEndPayload)
+		if !ok {
+			break
+		}
+		return fmt.Sprintf("[debug] turn end: status=%s iter=%d dur=%dms",
+			p.Status, p.Iterations, p.Duration.Milliseconds())
+
+	case agent.EventKindLLMRequest:
+		p, ok := evt.Payload.(agent.LLMRequestPayload)
+		if !ok {
+			break
+		}
+		return fmt.Sprintf("[debug] llm→ model=%s msgs=%d tools=%d",
+			p.Model, p.MessagesCount, p.ToolsCount)
+
+	case agent.EventKindLLMResponse:
+		p, ok := evt.Payload.(agent.LLMResponsePayload)
+		if !ok {
+			break
+		}
+		return fmt.Sprintf("[debug] llm← calls=%d content=%d reasoning=%v",
+			p.ToolCalls, p.ContentLen, p.HasReasoning)
+
+	case agent.EventKindLLMRetry:
+		p, ok := evt.Payload.(agent.LLMRetryPayload)
+		if !ok {
+			break
+		}
+		return fmt.Sprintf("[debug] llm retry: attempt=%d/%d reason=%s backoff=%dms",
+			p.Attempt, p.MaxRetries, p.Reason, p.Backoff.Milliseconds())
+
+	case agent.EventKindToolExecStart:
+		p, ok := evt.Payload.(agent.ToolExecStartPayload)
+		if !ok {
+			break
+		}
+		args := compactJSON(p.Arguments)
+		return fmt.Sprintf("[debug] tool↓ %s args=%s", p.Tool, args)
+
+	case agent.EventKindToolExecEnd:
+		p, ok := evt.Payload.(agent.ToolExecEndPayload)
+		if !ok {
+			break
+		}
+		return fmt.Sprintf("[debug] tool↑ %s dur=%dms err=%v",
+			p.Tool, p.Duration.Milliseconds(), p.IsError)
+
+	case agent.EventKindToolExecSkipped:
+		p, ok := evt.Payload.(agent.ToolExecSkippedPayload)
+		if !ok {
+			break
+		}
+		return fmt.Sprintf("[debug] tool skipped: %s reason=%s", p.Tool, p.Reason)
+
+	case agent.EventKindContextCompress:
+		p, ok := evt.Payload.(agent.ContextCompressPayload)
+		if !ok {
+			break
+		}
+		return fmt.Sprintf("[debug] context compressed: dropped=%d remaining=%d reason=%s",
+			p.DroppedMessages, p.RemainingMessages, p.Reason)
+
+	case agent.EventKindError:
+		p, ok := evt.Payload.(agent.ErrorPayload)
+		if !ok {
+			break
+		}
+		return fmt.Sprintf("[debug] error: stage=%s msg=%s", p.Stage, p.Message)
+
+	// Suppressed: too noisy or not user-facing.
+	case agent.EventKindLLMDelta,
+		agent.EventKindSessionSummarize,
+		agent.EventKindSteeringInjected,
+		agent.EventKindFollowUpQueued,
+		agent.EventKindInterruptReceived,
+		agent.EventKindSubTurnSpawn,
+		agent.EventKindSubTurnEnd,
+		agent.EventKindSubTurnResultDelivered,
+		agent.EventKindSubTurnOrphan:
+		return ""
+	}
+	return ""
+}
+
+// compactJSON marshals v to a compact JSON string, falling back to fmt.Sprint on error.
+func compactJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprint(v)
+	}
+	return string(b)
+}

--- a/internal/gateway/debug_test.go
+++ b/internal/gateway/debug_test.go
@@ -1,0 +1,207 @@
+package gateway
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sipeed/picoclaw/pkg/agent"
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sipeed/picoclaw/pkg/providers"
+)
+
+// debugStubProvider satisfies providers.LLMProvider without real API calls.
+type debugStubProvider struct{}
+
+func (s *debugStubProvider) Chat(_ context.Context, _ []providers.Message, _ []providers.ToolDefinition, _ string, _ map[string]any) (*providers.LLMResponse, error) {
+	return &providers.LLMResponse{}, nil
+}
+func (s *debugStubProvider) GetDefaultModel() string { return "stub" }
+
+func newDebugTestLoop() (*agent.AgentLoop, *bus.MessageBus) {
+	agentBus := bus.NewMessageBus()
+	loop := agent.NewAgentLoop(config.DefaultConfig(), agentBus, &debugStubProvider{})
+	return loop, agentBus
+}
+
+// TestDebugManager_ToggleOnOff verifies that the first Toggle enables debug
+// mode and the second disables it, with distinct reply strings each time.
+func TestDebugManager_ToggleOnOff(t *testing.T) {
+	loop, _ := newDebugTestLoop()
+	extBus := bus.NewMessageBus()
+	mgr := &DebugManager{agentLoop: loop, externalBus: extBus}
+
+	ctx := t.Context()
+
+	reply1 := mgr.Toggle(ctx, "telegram", "chat1")
+	if !mgr.active {
+		t.Fatal("expected active=true after first Toggle")
+	}
+	if !strings.Contains(reply1, "enabled") {
+		t.Fatalf("first Toggle reply should contain 'enabled', got %q", reply1)
+	}
+
+	reply2 := mgr.Toggle(ctx, "telegram", "chat1")
+	if mgr.active {
+		t.Fatal("expected active=false after second Toggle")
+	}
+	if !strings.Contains(reply2, "disabled") {
+		t.Fatalf("second Toggle reply should contain 'disabled', got %q", reply2)
+	}
+}
+
+// TestDebugManager_FormatEvent checks that each interesting EventKind produces
+// a [debug]-prefixed string, and that suppressed kinds return "".
+func TestDebugManager_FormatEvent(t *testing.T) {
+	mgr := &DebugManager{}
+
+	interesting := []struct {
+		name    string
+		evt     agent.Event
+		wantPfx string
+	}{
+		{
+			name:    "turn_start",
+			evt:     agent.Event{Kind: agent.EventKindTurnStart, Payload: agent.TurnStartPayload{Channel: "tg", ChatID: "c1"}},
+			wantPfx: "[debug] turn start",
+		},
+		{
+			name:    "turn_end",
+			evt:     agent.Event{Kind: agent.EventKindTurnEnd, Payload: agent.TurnEndPayload{Status: agent.TurnEndStatusCompleted, Iterations: 2, Duration: 500 * time.Millisecond}},
+			wantPfx: "[debug] turn end",
+		},
+		{
+			name:    "llm_request",
+			evt:     agent.Event{Kind: agent.EventKindLLMRequest, Payload: agent.LLMRequestPayload{Model: "claude", MessagesCount: 4, ToolsCount: 2}},
+			wantPfx: "[debug] llm→",
+		},
+		{
+			name:    "llm_response",
+			evt:     agent.Event{Kind: agent.EventKindLLMResponse, Payload: agent.LLMResponsePayload{ToolCalls: 1, ContentLen: 200}},
+			wantPfx: "[debug] llm←",
+		},
+		{
+			name:    "llm_retry",
+			evt:     agent.Event{Kind: agent.EventKindLLMRetry, Payload: agent.LLMRetryPayload{Attempt: 1, MaxRetries: 3, Reason: "timeout", Backoff: time.Second}},
+			wantPfx: "[debug] llm retry",
+		},
+		{
+			name:    "tool_exec_start",
+			evt:     agent.Event{Kind: agent.EventKindToolExecStart, Payload: agent.ToolExecStartPayload{Tool: "bash", Arguments: map[string]any{"cmd": "ls"}}},
+			wantPfx: "[debug] tool↓ bash",
+		},
+		{
+			name:    "tool_exec_end",
+			evt:     agent.Event{Kind: agent.EventKindToolExecEnd, Payload: agent.ToolExecEndPayload{Tool: "bash", Duration: 100 * time.Millisecond}},
+			wantPfx: "[debug] tool↑ bash",
+		},
+		{
+			name:    "tool_exec_skipped",
+			evt:     agent.Event{Kind: agent.EventKindToolExecSkipped, Payload: agent.ToolExecSkippedPayload{Tool: "bash", Reason: "hard_abort"}},
+			wantPfx: "[debug] tool skipped",
+		},
+		{
+			name:    "context_compress",
+			evt:     agent.Event{Kind: agent.EventKindContextCompress, Payload: agent.ContextCompressPayload{Reason: "proactive_budget", DroppedMessages: 5, RemainingMessages: 10}},
+			wantPfx: "[debug] context compressed",
+		},
+		{
+			name:    "error",
+			evt:     agent.Event{Kind: agent.EventKindError, Payload: agent.ErrorPayload{Stage: "tool", Message: "exec failed"}},
+			wantPfx: "[debug] error",
+		},
+	}
+
+	for _, tc := range interesting {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mgr.formatEvent(tc.evt)
+			if got == "" {
+				t.Fatalf("formatEvent(%s) returned empty string, want %q prefix", tc.name, tc.wantPfx)
+			}
+			if !strings.HasPrefix(got, tc.wantPfx) {
+				t.Fatalf("formatEvent(%s) = %q, want prefix %q", tc.name, got, tc.wantPfx)
+			}
+		})
+	}
+
+	suppressed := []struct {
+		name string
+		kind agent.EventKind
+	}{
+		{"llm_delta", agent.EventKindLLMDelta},
+		{"session_summarize", agent.EventKindSessionSummarize},
+		{"steering_injected", agent.EventKindSteeringInjected},
+		{"follow_up_queued", agent.EventKindFollowUpQueued},
+		{"interrupt_received", agent.EventKindInterruptReceived},
+		{"subturn_spawn", agent.EventKindSubTurnSpawn},
+		{"subturn_end", agent.EventKindSubTurnEnd},
+		{"subturn_result_delivered", agent.EventKindSubTurnResultDelivered},
+		{"subturn_orphan", agent.EventKindSubTurnOrphan},
+	}
+
+	for _, tc := range suppressed {
+		t.Run(tc.name+"_suppressed", func(t *testing.T) {
+			got := mgr.formatEvent(agent.Event{Kind: tc.kind})
+			if got != "" {
+				t.Fatalf("formatEvent(%s) = %q, want empty (suppressed)", tc.name, got)
+			}
+		})
+	}
+}
+
+// TestDebugManager_EventsForwardedWhenActive verifies that after Toggle(on),
+// events from the agent loop appear as outbound messages on externalBus.
+func TestDebugManager_EventsForwardedWhenActive(t *testing.T) {
+	loop, _ := newDebugTestLoop()
+	extBus := bus.NewMessageBus()
+	mgr := &DebugManager{agentLoop: loop, externalBus: extBus}
+
+	ctx := t.Context()
+
+	mgr.Toggle(ctx, "telegram", "chat42")
+	// Give the subscriber goroutine a moment to start.
+	time.Sleep(20 * time.Millisecond)
+
+	// Trigger a turn via ProcessDirect — emits TurnStart + LLMRequest + TurnEnd events.
+	go func() {
+		_, _ = loop.ProcessDirect(ctx, "hello", "debug-test-session")
+	}()
+
+	select {
+	case msg := <-extBus.OutboundChan():
+		if msg.ChatID != "chat42" {
+			t.Fatalf("expected ChatID chat42, got %q", msg.ChatID)
+		}
+		if msg.Channel != "telegram" {
+			t.Fatalf("expected Channel telegram, got %q", msg.Channel)
+		}
+		if !strings.HasPrefix(msg.Content, "[debug]") {
+			t.Fatalf("expected [debug] prefix, got %q", msg.Content)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for debug event on externalBus")
+	}
+}
+
+// TestDebugManager_NoEventsWhenInactive verifies that when debug mode has not
+// been toggled on, no messages appear on externalBus from agent events.
+func TestDebugManager_NoEventsWhenInactive(t *testing.T) {
+	loop, _ := newDebugTestLoop()
+	extBus := bus.NewMessageBus()
+	// No DebugManager created / Toggle not called — no subscriber registered.
+
+	ctx := t.Context()
+
+	go func() {
+		_, _ = loop.ProcessDirect(ctx, "hello", "debug-inactive-session")
+	}()
+
+	select {
+	case msg := <-extBus.OutboundChan():
+		t.Fatalf("unexpected message on externalBus when debug inactive: %+v", msg)
+	case <-time.After(300 * time.Millisecond):
+		// Nothing arrived — correct.
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -80,8 +81,13 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 
 	provider = wrapWithRetryEmpty(provider)
 
-	msgBus := bus.NewMessageBus()
-	agentLoop := agent.NewAgentLoop(cfg, msgBus, provider)
+	// externalBus: channels publish inbound here; channel manager reads outbound from here.
+	// agentBus: agent loop reads inbound from here; publishes outbound here.
+	// A bridge goroutine intercepts /debug on the inbound path and forwards everything
+	// else to agentBus. A second bridge forwards agent responses back to externalBus.
+	externalBus := bus.NewMessageBus()
+	agentBus := bus.NewMessageBus()
+	agentLoop := agent.NewAgentLoop(cfg, agentBus, provider)
 
 	if allowedSenders := sushitools.ParseAllowedSenders(); len(allowedSenders) > 0 {
 		if cfg.Tools.IsToolEnabled("exec") {
@@ -113,18 +119,22 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	mediaStore.Start()
 	defer mediaStore.Stop()
 
-	cm, err := channels.NewManager(cfg, msgBus, mediaStore)
+	cm, err := channels.NewManager(cfg, externalBus, mediaStore)
 	if err != nil {
 		return fmt.Errorf("error creating channel manager: %w", err)
 	}
 
-	emailCh, err := email.InitChannel(msgBus)
+	emailCh, err := email.InitChannel(externalBus)
 	if err != nil {
 		return fmt.Errorf("email channel: %w", err)
 	}
 	if emailCh != nil {
 		cm.RegisterChannel("email", emailCh)
 	}
+
+	// Also register the channel manager as stream delegate on agentBus so that
+	// the agent loop's streaming queries (al.bus.GetStreamer) reach the manager.
+	agentBus.SetStreamDelegate(cm)
 
 	agentLoop.SetChannelManager(cm)
 	agentLoop.SetMediaStore(mediaStore)
@@ -157,6 +167,51 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 
 	go agentLoop.Run(ctx) //nolint:errcheck
 
+	debugMgr := &DebugManager{agentLoop: agentLoop, externalBus: externalBus}
+
+	// Inbound bridge: intercept /debug before forwarding to agent loop.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-externalBus.InboundChan():
+				if !ok {
+					return
+				}
+				handleInbound(ctx, msg, debugMgr, agentBus, externalBus)
+			}
+		}
+	}()
+
+	// Outbound bridge: forward agent responses and media back to channels.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-agentBus.OutboundChan():
+				if !ok {
+					return
+				}
+				_ = externalBus.PublishOutbound(ctx, msg)
+			}
+		}
+	}()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-agentBus.OutboundMediaChan():
+				if !ok {
+					return
+				}
+				_ = externalBus.PublishOutboundMedia(ctx, msg)
+			}
+		}
+	}()
+
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 	<-sigChan
@@ -172,9 +227,27 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	}
 	agentLoop.Stop()
 	agentLoop.Close()
+	agentBus.Close()
+	externalBus.Close()
 
 	logger.Info("Gateway stopped")
 	return nil
+}
+
+// handleInbound processes a single inbound message from externalBus.
+// /debug is intercepted and handled by debugMgr; all other messages are
+// forwarded to agentBus for normal agent-loop processing.
+func handleInbound(ctx context.Context, msg bus.InboundMessage, debugMgr *DebugManager, agentBus, externalBus *bus.MessageBus) {
+	if strings.TrimSpace(msg.Content) == "/debug" {
+		reply := debugMgr.Toggle(ctx, msg.Channel, msg.ChatID)
+		_ = externalBus.PublishOutbound(ctx, bus.OutboundMessage{
+			Channel: msg.Channel,
+			ChatID:  msg.ChatID,
+			Content: reply,
+		})
+		return
+	}
+	_ = agentBus.PublishInbound(ctx, msg)
 }
 
 type startupBlockedProvider struct{ reason string }


### PR DESCRIPTION
## Summary

- Adds a `/debug` slash command that toggles verbose event output to the originating chat
- Implements a two-bus bridge in the gateway (`externalBus` for channels, `agentBus` for the agent loop) to intercept `/debug` without modifying picoclaw
- `DebugManager` subscribes to `agent.EventBus` when active and forwards formatted `[debug]` messages for tool calls, LLM requests/responses, context compression, retries, and errors
- Streaming support preserved via explicit `agentBus.SetStreamDelegate(cm)`

## Approach

picoclaw's command registry is sealed at construction time — no `RegisterCommand` API exists. Instead of modifying picoclaw, the gateway now owns two buses bridged by goroutines:

```
Channel → externalBus.inbound → [bridge: /debug intercepted] → agentBus.inbound → AgentLoop
Channel ←  externalBus.outbound ← [bridge: forward] ← agentBus.outbound ← AgentLoop
                                   [DebugManager] ──────────────────────→ externalBus.outbound
```

## Test plan

- `make build` — clean compile
- `make lint` — 0 issues
- `make test` — all packages green
- Unit tests cover: toggle on/off state and reply strings, `formatEvent` for all 10 interesting kinds + 9 suppressed kinds, events forwarded to chat when active, no events when inactive
- Bridge tests cover: `/debug` consumed + reply sent, normal message forwarded to agent bus

Closes #19