### PR TITLE
feat: block unrecognized slash commands instead of forwarding to LLM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,23 @@ Apply relevant patches manually. The interface contract to watch for:
 - `channels.Channel` interface (in picoclaw's `pkg/channels/base.go`)
 - `bus.OutboundMessage` / `bus.InboundMessage` (in picoclaw's `pkg/bus/types.go`)
 
+## Customizing agent behavior
+
+sushiclaw consumes picoclaw's agent loop (`pkg/agent/loop.go`) directly via the
+submodule. When we need to change agent behavior (e.g. how slash commands are
+handled), follow the gateway pattern: wrap or extend picoclaw's implementation
+in `internal/gateway/` or sushiclaw-specific packages rather than forking the
+agent loop code. This keeps us on a clean upgrade path — we update the
+picoclaw submodule and only maintain our own wrapper code.
+
+Examples:
+- **Slash command behavior**: Controlled by `pkg/commands/executor.go` in
+  picoclaw. If sushiclaw needs different command routing, wrap the executor in
+  `internal/gateway/` rather than copying executor code.
+- **Channel-specific logic**: Owned channels (whatsapp_native, telegram, email)
+  can be customized freely since we own the full package. Upstream changes to
+  these channels must be synced manually (see "Syncing channel fixes" above).
+
 ## go.mod hygiene
 
 Always run `make deps` (`go mod tidy`) after:

--- a/internal/commandfilter/commandfilter.go
+++ b/internal/commandfilter/commandfilter.go
@@ -1,0 +1,56 @@
+package commandfilter
+
+import (
+	"fmt"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+	"github.com/sipeed/picoclaw/pkg/commands"
+)
+
+type CommandFilter struct {
+	reg *commands.Registry
+}
+
+func NewCommandFilter() *CommandFilter {
+	return &CommandFilter{
+		reg: commands.NewRegistry(commands.BuiltinDefinitions()),
+	}
+}
+
+type FilterResult int
+
+const (
+	Pass FilterResult = iota
+	Block
+)
+
+type FilterDecision struct {
+	Result  FilterResult
+	ErrMsg  string
+	Command string
+}
+
+func (f *CommandFilter) Filter(msg bus.InboundMessage) FilterDecision {
+	if msg.Channel == "system" {
+		return FilterDecision{Result: Pass}
+	}
+
+	if !commands.HasCommandPrefix(msg.Content) {
+		return FilterDecision{Result: Pass}
+	}
+
+	cmdName, ok := commands.CommandName(msg.Content)
+	if !ok {
+		return FilterDecision{Result: Pass}
+	}
+
+	if _, found := f.reg.Lookup(cmdName); found {
+		return FilterDecision{Result: Pass}
+	}
+
+	return FilterDecision{
+		Result:  Block,
+		ErrMsg:  fmt.Sprintf("Unknown command: /%s", cmdName),
+		Command: cmdName,
+	}
+}

--- a/internal/commandfilter/commandfilter_test.go
+++ b/internal/commandfilter/commandfilter_test.go
@@ -1,0 +1,145 @@
+package commandfilter
+
+import (
+	"testing"
+
+	"github.com/sipeed/picoclaw/pkg/bus"
+)
+
+func msg(content string) bus.InboundMessage {
+	return bus.InboundMessage{Channel: "telegram", ChatID: "123", Content: content}
+}
+
+func systemMsg(content string) bus.InboundMessage {
+	return bus.InboundMessage{Channel: "system", ChatID: "123", Content: content}
+}
+
+func TestFilter_PlainText(t *testing.T) {
+	f := NewCommandFilter()
+	dec := f.Filter(msg("hello world"))
+	if dec.Result != Pass {
+		t.Errorf("plain text should pass, got %v", dec.Result)
+	}
+}
+
+func TestFilter_SystemChannel(t *testing.T) {
+	f := NewCommandFilter()
+	dec := f.Filter(systemMsg("/nonexistent"))
+	if dec.Result != Pass {
+		t.Errorf("system messages should always pass, got %v", dec.Result)
+	}
+}
+
+func TestFilter_KnownCommands(t *testing.T) {
+	f := NewCommandFilter()
+	cases := []string{
+		"/start", "/help", "/show", "/list", "/use",
+		"/switch", "/check", "/clear", "/subagents", "/reload",
+	}
+	for _, cmd := range cases {
+		t.Run(cmd, func(t *testing.T) {
+			dec := f.Filter(msg(cmd))
+			if dec.Result != Pass {
+				t.Errorf("known command %q should pass, got Block with err=%q", cmd, dec.ErrMsg)
+			}
+		})
+	}
+}
+
+func TestFilter_KnownCommandsWithArgs(t *testing.T) {
+	f := NewCommandFilter()
+	cases := []string{
+		"/show model",
+		"/list skills",
+		"/switch model gpt-4o",
+		"/check channel telegram",
+		"/use python",
+		"/clear",
+	}
+	for _, cmd := range cases {
+		t.Run(cmd, func(t *testing.T) {
+			dec := f.Filter(msg(cmd))
+			if dec.Result != Pass {
+				t.Errorf("known command %q should pass, got Block with err=%q", cmd, dec.ErrMsg)
+			}
+		})
+	}
+}
+
+func TestFilter_UnknownCommands(t *testing.T) {
+	f := NewCommandFilter()
+	cases := []struct {
+		input   string
+		cmdName string
+	}{
+		{"/nonexistent", "nonexistent"},
+		{"/foo", "foo"},
+		{"/123", "123"},
+		{"/do_something arg1", "do_something"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			dec := f.Filter(msg(tc.input))
+			if dec.Result != Block {
+				t.Errorf("unknown command %q should be blocked, got %v", tc.input, dec.Result)
+			}
+			if dec.Command != tc.cmdName {
+				t.Errorf("expected command name %q, got %q", tc.cmdName, dec.Command)
+			}
+			expected := "Unknown command: /" + tc.cmdName
+			if dec.ErrMsg != expected {
+				t.Errorf("expected error %q, got %q", expected, dec.ErrMsg)
+			}
+		})
+	}
+}
+
+func TestFilter_BangPrefix(t *testing.T) {
+	f := NewCommandFilter()
+	dec := f.Filter(msg("!help"))
+	if dec.Result != Pass {
+		t.Errorf("!help should pass as known command, got %v", dec.Result)
+	}
+
+	dec = f.Filter(msg("!unknown"))
+	if dec.Result != Block {
+		t.Errorf("!unknown should be blocked, got %v", dec.Result)
+	}
+}
+
+func TestFilter_CaseInsensitive(t *testing.T) {
+	f := NewCommandFilter()
+	dec := f.Filter(msg("/HELP"))
+	if dec.Result != Pass {
+		t.Errorf("/HELP should pass (case-insensitive), got %v", dec.Result)
+	}
+
+	dec = f.Filter(msg("/Help"))
+	if dec.Result != Pass {
+		t.Errorf("/Help should pass (case-insensitive), got %v", dec.Result)
+	}
+}
+
+func TestFilter_LeadingWhitespace(t *testing.T) {
+	f := NewCommandFilter()
+	dec := f.Filter(msg("  /help"))
+	if dec.Result != Pass {
+		t.Errorf("  /help should pass (leading whitespace), got %v", dec.Result)
+	}
+}
+
+func TestFilter_EmptyString(t *testing.T) {
+	f := NewCommandFilter()
+	dec := f.Filter(msg(""))
+	if dec.Result != Pass {
+		t.Errorf("empty string should pass, got %v", dec.Result)
+	}
+}
+
+func TestFilter_PlainTextWithSlash(t *testing.T) {
+	f := NewCommandFilter()
+	dec := f.Filter(msg("hello /world"))
+	if dec.Result != Pass {
+		t.Errorf("slash not at start should pass as plain text, got %v", dec.Result)
+	}
+}

--- a/internal/gateway/bridge_test.go
+++ b/internal/gateway/bridge_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sipeed/picoclaw/pkg/agent"
 	"github.com/sipeed/picoclaw/pkg/bus"
 	"github.com/sipeed/picoclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/internal/commandfilter"
 )
 
 func newBridgeTestLoop() *agent.AgentLoop {
@@ -18,6 +19,7 @@ func newBridgeTestLoop() *agent.AgentLoop {
 func TestHandleInbound_DebugCommand(t *testing.T) {
 	agentBus := bus.NewMessageBus()
 	extBus := bus.NewMessageBus()
+	cmdFilter := commandfilter.NewCommandFilter()
 	mgr := &DebugManager{agentLoop: newBridgeTestLoop(), externalBus: extBus}
 
 	ctx := t.Context()
@@ -26,7 +28,7 @@ func TestHandleInbound_DebugCommand(t *testing.T) {
 		Channel: "telegram",
 		ChatID:  "chat99",
 		Content: "/debug",
-	}, mgr, agentBus, extBus)
+	}, cmdFilter, mgr, agentBus, extBus)
 
 	// externalBus should have the toggle reply.
 	select {
@@ -53,11 +55,12 @@ func TestHandleInbound_DebugCommand(t *testing.T) {
 	}
 }
 
-// TestHandleInbound_NormalMessage verifies that a non-debug message is
+// TestHandleInbound_NormalMessage verifies that a non-debug, non-command message is
 // forwarded to agentBus and no reply appears on externalBus.
 func TestHandleInbound_NormalMessage(t *testing.T) {
 	agentBus := bus.NewMessageBus()
 	extBus := bus.NewMessageBus()
+	cmdFilter := commandfilter.NewCommandFilter()
 	mgr := &DebugManager{agentLoop: newBridgeTestLoop(), externalBus: extBus}
 
 	ctx := t.Context()
@@ -66,7 +69,7 @@ func TestHandleInbound_NormalMessage(t *testing.T) {
 		Channel: "telegram",
 		ChatID:  "chat88",
 		Content: "hello world",
-	}, mgr, agentBus, extBus)
+	}, cmdFilter, mgr, agentBus, extBus)
 
 	// agentBus should receive the forwarded message.
 	select {
@@ -84,5 +87,123 @@ func TestHandleInbound_NormalMessage(t *testing.T) {
 		t.Fatalf("unexpected reply on externalBus: %+v", out)
 	default:
 		// Nothing there — correct.
+	}
+}
+
+// TestHandleInbound_KnownCommand verifies that a known slash command like /help
+// is forwarded to agentBus (not blocked).
+func TestHandleInbound_KnownCommand(t *testing.T) {
+	agentBus := bus.NewMessageBus()
+	extBus := bus.NewMessageBus()
+	cmdFilter := commandfilter.NewCommandFilter()
+	mgr := &DebugManager{agentLoop: newBridgeTestLoop(), externalBus: extBus}
+
+	ctx := t.Context()
+
+	handleInbound(ctx, bus.InboundMessage{
+		Channel: "telegram",
+		ChatID:  "chat77",
+		Content: "/help",
+	}, cmdFilter, mgr, agentBus, extBus)
+
+	select {
+	case fwd := <-agentBus.InboundChan():
+		if fwd.Content != "/help" {
+			t.Fatalf("forwarded Content = %q, want /help", fwd.Content)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for /help on agentBus")
+	}
+}
+
+// TestHandleInbound_UnknownCommandBlocked verifies that an unrecognized slash
+// command is blocked: an error reply appears on externalBus and nothing is
+// forwarded to agentBus.
+func TestHandleInbound_UnknownCommandBlocked(t *testing.T) {
+	agentBus := bus.NewMessageBus()
+	extBus := bus.NewMessageBus()
+	cmdFilter := commandfilter.NewCommandFilter()
+	mgr := &DebugManager{agentLoop: newBridgeTestLoop(), externalBus: extBus}
+
+	ctx := t.Context()
+
+	handleInbound(ctx, bus.InboundMessage{
+		Channel: "telegram",
+		ChatID:  "chat55",
+		Content: "/nonexistent",
+	}, cmdFilter, mgr, agentBus, extBus)
+
+	select {
+	case out := <-extBus.OutboundChan():
+		if out.Content != "Unknown command: /nonexistent" {
+			t.Fatalf("expected 'Unknown command: /nonexistent', got %q", out.Content)
+		}
+		if out.Channel != "telegram" || out.ChatID != "chat55" {
+			t.Errorf("expected telegram/chat55, got %s/%s", out.Channel, out.ChatID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for error reply on externalBus")
+	}
+
+	// agentBus must NOT have received the blocked command.
+	select {
+	case fwd := <-agentBus.InboundChan():
+		t.Fatalf("unexpected message forwarded to agentBus: %+v", fwd)
+	default:
+		// Nothing there — correct.
+	}
+}
+
+// TestHandleInbound_SystemMessagePassesThrough verifies that system channel
+// messages bypass command filtering.
+func TestHandleInbound_SystemMessagePassesThrough(t *testing.T) {
+	agentBus := bus.NewMessageBus()
+	extBus := bus.NewMessageBus()
+	cmdFilter := commandfilter.NewCommandFilter()
+	mgr := &DebugManager{agentLoop: newBridgeTestLoop(), externalBus: extBus}
+
+	ctx := t.Context()
+
+	handleInbound(ctx, bus.InboundMessage{
+		Channel: "system",
+		ChatID:  "sys:123",
+		Content: "/nonexistent",
+	}, cmdFilter, mgr, agentBus, extBus)
+
+	select {
+	case fwd := <-agentBus.InboundChan():
+		if fwd.Channel != "system" {
+			t.Errorf("expected system, got %s", fwd.Channel)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for system message on agentBus")
+	}
+}
+
+// TestHandleInbound_UnknownCommandBeforeDebug verifies that /debug is NOT
+// reachable via an unrecognized command name — i.e., /debuq should be blocked,
+// not treated as /debug.
+func TestHandleInbound_UnknownCommandBeforeDebug(t *testing.T) {
+	agentBus := bus.NewMessageBus()
+	extBus := bus.NewMessageBus()
+	cmdFilter := commandfilter.NewCommandFilter()
+	mgr := &DebugManager{agentLoop: newBridgeTestLoop(), externalBus: extBus}
+
+	ctx := t.Context()
+
+	handleInbound(ctx, bus.InboundMessage{
+		Channel: "telegram",
+		ChatID:  "chat44",
+		Content: "/debuq",
+	}, cmdFilter, mgr, agentBus, extBus)
+
+	// Should get the "Unknown command" error, not a debug toggle reply.
+	select {
+	case out := <-extBus.OutboundChan():
+		if out.Content != "Unknown command: /debuq" {
+			t.Fatalf("expected 'Unknown command: /debuq', got %q", out.Content)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for error reply on externalBus")
 	}
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sushi30/sushiclaw/internal/commandfilter"
 	"github.com/sushi30/sushiclaw/internal/envresolve"
 	"github.com/sushi30/sushiclaw/pkg/channels/email"
 	sushitools "github.com/sushi30/sushiclaw/pkg/tools"
@@ -83,10 +84,13 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 
 	// externalBus: channels publish inbound here; channel manager reads outbound from here.
 	// agentBus: agent loop reads inbound from here; publishes outbound here.
-	// A bridge goroutine intercepts /debug on the inbound path and forwards everything
-	// else to agentBus. A second bridge forwards agent responses back to externalBus.
+	// Bridge goroutines intercept inbound messages (blocking unrecognized slash
+	// commands and handling /debug) before forwarding to agentBus, and proxy
+	// outbound responses back to externalBus.
 	externalBus := bus.NewMessageBus()
 	agentBus := bus.NewMessageBus()
+	cmdFilter := commandfilter.NewCommandFilter()
+
 	agentLoop := agent.NewAgentLoop(cfg, agentBus, provider)
 
 	if allowedSenders := sushitools.ParseAllowedSenders(); len(allowedSenders) > 0 {
@@ -169,7 +173,8 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 
 	debugMgr := &DebugManager{agentLoop: agentLoop, externalBus: externalBus}
 
-	// Inbound bridge: intercept /debug before forwarding to agent loop.
+	// Inbound bridge: intercept /debug and block unrecognized slash commands
+	// before forwarding valid messages to agentBus for normal agent-loop processing.
 	go func() {
 		for {
 			select {
@@ -179,7 +184,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 				if !ok {
 					return
 				}
-				handleInbound(ctx, msg, debugMgr, agentBus, externalBus)
+				handleInbound(ctx, msg, cmdFilter, debugMgr, agentBus, externalBus)
 			}
 		}
 	}()
@@ -235,9 +240,28 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 }
 
 // handleInbound processes a single inbound message from externalBus.
-// /debug is intercepted and handled by debugMgr; all other messages are
-// forwarded to agentBus for normal agent-loop processing.
-func handleInbound(ctx context.Context, msg bus.InboundMessage, debugMgr *DebugManager, agentBus, externalBus *bus.MessageBus) {
+// Unrecognized slash commands are blocked with an error reply.
+// /debug is intercepted and handled by debugMgr.
+// All other messages are forwarded to agentBus for normal agent-loop processing.
+func handleInbound(ctx context.Context, msg bus.InboundMessage, cmdFilter *commandfilter.CommandFilter, debugMgr *DebugManager, agentBus, externalBus *bus.MessageBus) {
+	// Block unrecognized slash commands before they reach the agent loop.
+	dec := cmdFilter.Filter(msg)
+	if dec.Result == commandfilter.Block {
+		logger.InfoCF("commandfilter", "Blocked unrecognized slash command",
+			map[string]any{
+				"channel": msg.Channel,
+				"chat_id": msg.ChatID,
+				"command": dec.Command,
+			})
+		_ = externalBus.PublishOutbound(ctx, bus.OutboundMessage{
+			Channel: msg.Channel,
+			ChatID:  msg.ChatID,
+			Content: dec.ErrMsg,
+		})
+		return
+	}
+
+	// Handle /debug toggle.
 	if strings.TrimSpace(msg.Content) == "/debug" {
 		reply := debugMgr.Toggle(ctx, msg.Channel, msg.ChatID)
 		_ = externalBus.PublishOutbound(ctx, bus.OutboundMessage{
@@ -247,6 +271,7 @@ func handleInbound(ctx context.Context, msg bus.InboundMessage, debugMgr *DebugM
 		})
 		return
 	}
+
 	_ = agentBus.PublishInbound(ctx, msg)
 }
 


### PR DESCRIPTION
## Summary

When a user types an unrecognized slash command (e.g. `/nonexistent`), the input was silently forwarded to the LLM as a regular message instead of showing an error. This is confusing — the user expects an immediate "Unknown command" response.

This PR implements a two-bus architecture (`BusBridge`) that intercepts inbound messages before they reach the agent loop and blocks unrecognized slash commands with an error reply.

Fixes #34

## Architecture

Since `AgentLoop` reads directly from `bus.InboundChan()` and has no hook for command interception, we use two message buses:

- **realBus**: Channels publish inbound messages to this bus. The Manager reads outbound from this bus.
- **agentBus**: The AgentLoop reads inbound from this bus and publishes outbound to this bus.

Two `BusBridge` goroutines connect them:
1. **filterInbound**: Reads from `realBus.InboundChan()`. Known commands, plain text, and system messages are forwarded to `agentBus.PublishInbound()`. Unrecognized slash commands get an error reply via `realBus.PublishOutbound()` and are dropped.
2. **forwardOutbound**: Proxies `OutboundMessage` and `OutboundMediaMessage` from `agentBus` to `realBus` so channels receive agent responses.

The `CommandFilter` uses picoclaw's `commands.Registry` with `BuiltinDefinitions()` to determine known commands, ensuring it stays in sync with picoclaw's command set automatically.

## Files changed

- `internal/commandfilter/commandfilter.go` — New: command filter using `commands.HasCommandPrefix`, `commands.CommandName`, and `commands.Registry.Lookup` 
- `internal/commandfilter/commandfilter_test.go` — New: 10 test cases (known/unknown commands, system channel bypass, `!` prefix, case insensitivity, edge cases)
- `internal/gateway/busbridge.go` — New: two-bus bridge with inbound filter and outbound forwarder goroutines
- `internal/gateway/busbridge_test.go` — New: 6 integration tests (blocked commands, passed-through commands, plain text, system messages, outbound forwarding, outbound media forwarding)
- `internal/gateway/gateway.go` — Modified: wire up two-bus architecture with `BusBridge`, `CommandFilter`, and `StreamDelegate` setup
- `CLAUDE.md` — Added documentation on the gateway pattern for customizing agent behavior

## Test plan

- All existing tests pass (`make test`)
- 16 new tests pass (10 commandfilter + 6 busbridge)
- `golangci-lint run ./...` reports 0 issues