### PR TITLE
feat(gateway): inject /debug into /help menu

### DIFF
--- a/internal/gateway/bridge_test.go
+++ b/internal/gateway/bridge_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -205,5 +206,31 @@ func TestHandleInbound_UnknownCommandBeforeDebug(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for error reply on externalBus")
+	}
+}
+
+// TestInjectDebugIntoHelp_HelpResponse verifies that a /help response gets
+// the /debug line appended.
+func TestInjectDebugIntoHelp_HelpResponse(t *testing.T) {
+	helpContent := "/start - Start the agent\n/help - Show this help message\n/clear - Clear history"
+	msg := bus.OutboundMessage{Channel: "telegram", ChatID: "c1", Content: helpContent}
+	got := injectDebugIntoHelp(msg)
+	if got.Content == helpContent {
+		t.Fatal("expected /debug line to be appended, content unchanged")
+	}
+	const want = "\n/debug - Toggle debug event forwarding to this chat"
+	if !strings.HasSuffix(got.Content, want) {
+		t.Fatalf("expected content to end with %q, got %q", want, got.Content)
+	}
+}
+
+// TestInjectDebugIntoHelp_NonHelpResponse verifies that non-help content is
+// returned unchanged.
+func TestInjectDebugIntoHelp_NonHelpResponse(t *testing.T) {
+	content := "Hello, world!"
+	msg := bus.OutboundMessage{Channel: "telegram", ChatID: "c2", Content: content}
+	got := injectDebugIntoHelp(msg)
+	if got.Content != content {
+		t.Fatalf("expected content unchanged, got %q", got.Content)
 	}
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -199,7 +199,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 				if !ok {
 					return
 				}
-				_ = externalBus.PublishOutbound(ctx, msg)
+				_ = externalBus.PublishOutbound(ctx, injectDebugIntoHelp(msg))
 			}
 		}
 	}()
@@ -237,6 +237,16 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 
 	logger.Info("Gateway stopped")
 	return nil
+}
+
+// injectDebugIntoHelp appends the /debug entry to outbound help responses.
+// Detection uses the stable marker "/help - Show this help message" that
+// picoclaw's formatHelpMessage always produces for the built-in /help command.
+func injectDebugIntoHelp(msg bus.OutboundMessage) bus.OutboundMessage {
+	if strings.Contains(msg.Content, "/help - Show this help message") {
+		msg.Content += "\n/debug - Toggle debug event forwarding to this chat"
+	}
+	return msg
 }
 
 // handleInbound processes a single inbound message from externalBus.


### PR DESCRIPTION
## Summary
- `/debug` was handled by the inbound bus bridge, so picoclaw's help registry had no knowledge of it
- Intercept outbound help responses (detected by the stable marker `/help - Show this help message`) and append the `/debug` entry

## Test plan
- `TestInjectDebugIntoHelp_HelpResponse`: verifies `/debug` line appended to help output
- `TestInjectDebugIntoHelp_NonHelpResponse`: verifies non-help messages pass through unchanged
- All existing bridge tests continue to pass (`make test` clean)

Closes #40