### PR TITLE
feat(whatsapp): handle contact card messages

### DIFF
--- a/pkg/channels/whatsapp_native/whatsapp_native.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native.go
@@ -375,6 +375,7 @@ func (c *WhatsAppNativeChannel) handleIncoming(evt *events.Message) {
 	}
 
 	// Extract caption from media sub-messages when there is no plain-text body.
+	var waMessageType string
 	if content == "" {
 		switch {
 		case evt.Message.GetImageMessage() != nil:
@@ -383,6 +384,12 @@ func (c *WhatsAppNativeChannel) handleIncoming(evt *events.Message) {
 			content = evt.Message.GetVideoMessage().GetCaption()
 		case evt.Message.GetDocumentMessage() != nil:
 			content = evt.Message.GetDocumentMessage().GetCaption()
+		case evt.Message.GetContactMessage() != nil:
+			content = formatContactContent(evt.Message.GetContactMessage())
+			waMessageType = "contact"
+		case evt.Message.GetContactsArrayMessage() != nil:
+			content = formatContactsArrayContent(evt.Message.GetContactsArrayMessage())
+			waMessageType = "contact"
 		}
 	}
 
@@ -444,6 +451,9 @@ func (c *WhatsAppNativeChannel) handleIncoming(evt *events.Message) {
 	metadata := make(map[string]string)
 	if waReplyType != "" {
 		metadata["wa_reply_type"] = waReplyType
+	}
+	if waMessageType != "" {
+		metadata["wa_message_type"] = waMessageType
 	}
 	metadata["message_id"] = evt.Info.ID
 	if evt.Info.PushName != "" {
@@ -567,6 +577,81 @@ func mediaFilenameAndMIME(msg *waE2E.Message) (filename, mimetype string) {
 		return "sticker.webp", mime
 	}
 	return "media", "application/octet-stream"
+}
+
+// parseVCard extracts the first FN, TEL, EMAIL, and ORG values from a vCard string.
+func parseVCard(vcard string) map[string]string {
+	result := make(map[string]string)
+	for _, line := range strings.Split(vcard, "\n") {
+		line = strings.TrimRight(line, "\r")
+		idx := strings.Index(line, ":")
+		if idx < 0 {
+			continue
+		}
+		fieldSpec := strings.ToUpper(line[:idx])
+		value := strings.TrimSpace(line[idx+1:])
+		if value == "" {
+			continue
+		}
+		fieldName := strings.SplitN(fieldSpec, ";", 2)[0]
+		switch fieldName {
+		case "FN":
+			if result["fn"] == "" {
+				result["fn"] = value
+			}
+		case "TEL":
+			if result["tel"] == "" {
+				result["tel"] = value
+			}
+		case "EMAIL":
+			if result["email"] == "" {
+				result["email"] = value
+			}
+		case "ORG":
+			if result["org"] == "" {
+				result["org"] = value
+			}
+		}
+	}
+	return result
+}
+
+func formatContactContent(c *waE2E.ContactMessage) string {
+	name := c.GetDisplayName()
+	var parts []string
+	if vc := c.GetVcard(); vc != "" {
+		fields := parseVCard(vc)
+		if fn := fields["fn"]; fn != "" {
+			name = fn
+		}
+		if tel := fields["tel"]; tel != "" {
+			parts = append(parts, "Phone: "+tel)
+		}
+		if email := fields["email"]; email != "" {
+			parts = append(parts, "Email: "+email)
+		}
+		if org := fields["org"]; org != "" {
+			parts = append(parts, "Organization: "+org)
+		}
+	}
+	header := "[Contact Card: " + name + "]"
+	if len(parts) == 0 {
+		return header
+	}
+	return header + "\n" + strings.Join(parts, "\n")
+}
+
+func formatContactsArrayContent(ca *waE2E.ContactsArrayMessage) string {
+	contacts := ca.GetContacts()
+	if len(contacts) == 0 {
+		return "[Contact Cards]"
+	}
+	lines := make([]string, 0, len(contacts)+1)
+	lines = append(lines, fmt.Sprintf("[Contact Cards: %d]", len(contacts)))
+	for i, c := range contacts {
+		lines = append(lines, fmt.Sprintf("%d. %s", i+1, formatContactContent(c)))
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (c *WhatsAppNativeChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]string, error) {

--- a/pkg/channels/whatsapp_native/whatsapp_native_sushi30_test.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native_sushi30_test.go
@@ -3,6 +3,7 @@ package whatsapp
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -427,6 +428,117 @@ func TestHandleIncoming_ListResponse_Forwarded(t *testing.T) {
 	}
 	if msg.Metadata["wa_reply_type"] != "button" {
 		t.Errorf("wa_reply_type: got %q, want %q", msg.Metadata["wa_reply_type"], "button")
+	}
+}
+
+// --- Contact card tests ---
+
+func TestHandleIncoming_ContactMessage_Forwarded(t *testing.T) {
+	ch, mb := makeTestChannel(nil)
+
+	vcard := "BEGIN:VCARD\nVERSION:3.0\nFN:John Doe\nTEL;type=CELL;waid=972501234567:+972 50-123-4567\nEMAIL:john@example.com\nORG:ACME Corp\nEND:VCARD"
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Sender: types.NewJID("1001", types.DefaultUserServer),
+				Chat:   types.NewJID("1001", types.DefaultUserServer),
+			},
+			ID:        "mid-contact",
+			PushName:  "John",
+			Timestamp: time.Now().Add(1 * time.Second),
+		},
+		Message: &waE2E.Message{
+			ContactMessage: &waE2E.ContactMessage{
+				DisplayName: proto.String("John Doe"),
+				Vcard:       proto.String(vcard),
+			},
+		},
+	}
+
+	ch.handleIncoming(evt)
+
+	msg := receiveInbound(t, mb)
+	if !strings.Contains(msg.Content, "[Contact Card: John Doe]") {
+		t.Errorf("expected [Contact Card: John Doe] in content, got: %q", msg.Content)
+	}
+	if !strings.Contains(msg.Content, "Phone:") {
+		t.Errorf("expected Phone: in content, got: %q", msg.Content)
+	}
+	if !strings.Contains(msg.Content, "Email:") {
+		t.Errorf("expected Email: in content, got: %q", msg.Content)
+	}
+	if msg.Metadata["wa_message_type"] != "contact" {
+		t.Errorf("wa_message_type: got %q, want %q", msg.Metadata["wa_message_type"], "contact")
+	}
+}
+
+func TestHandleIncoming_ContactMessage_NoVCard_Forwarded(t *testing.T) {
+	ch, mb := makeTestChannel(nil)
+
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Sender: types.NewJID("1001", types.DefaultUserServer),
+				Chat:   types.NewJID("1001", types.DefaultUserServer),
+			},
+			ID:        "mid-contact-novcard",
+			Timestamp: time.Now().Add(1 * time.Second),
+		},
+		Message: &waE2E.Message{
+			ContactMessage: &waE2E.ContactMessage{
+				DisplayName: proto.String("Jane"),
+			},
+		},
+	}
+
+	ch.handleIncoming(evt)
+
+	msg := receiveInbound(t, mb)
+	if msg.Content != "[Contact Card: Jane]" {
+		t.Errorf("expected content %q, got %q", "[Contact Card: Jane]", msg.Content)
+	}
+	if msg.Metadata["wa_message_type"] != "contact" {
+		t.Errorf("wa_message_type: got %q, want %q", msg.Metadata["wa_message_type"], "contact")
+	}
+}
+
+func TestHandleIncoming_ContactsArrayMessage_Forwarded(t *testing.T) {
+	ch, mb := makeTestChannel(nil)
+
+	evt := &events.Message{
+		Info: types.MessageInfo{
+			MessageSource: types.MessageSource{
+				Sender: types.NewJID("1001", types.DefaultUserServer),
+				Chat:   types.NewJID("1001", types.DefaultUserServer),
+			},
+			ID:        "mid-contacts-array",
+			Timestamp: time.Now().Add(1 * time.Second),
+		},
+		Message: &waE2E.Message{
+			ContactsArrayMessage: &waE2E.ContactsArrayMessage{
+				DisplayName: proto.String("My Contacts"),
+				Contacts: []*waE2E.ContactMessage{
+					{DisplayName: proto.String("Alice")},
+					{DisplayName: proto.String("Bob")},
+				},
+			},
+		},
+	}
+
+	ch.handleIncoming(evt)
+
+	msg := receiveInbound(t, mb)
+	if !strings.Contains(msg.Content, "[Contact Cards: 2]") {
+		t.Errorf("expected [Contact Cards: 2] in content, got: %q", msg.Content)
+	}
+	if !strings.Contains(msg.Content, "Alice") {
+		t.Errorf("expected Alice in content, got: %q", msg.Content)
+	}
+	if !strings.Contains(msg.Content, "Bob") {
+		t.Errorf("expected Bob in content, got: %q", msg.Content)
+	}
+	if msg.Metadata["wa_message_type"] != "contact" {
+		t.Errorf("wa_message_type: got %q, want %q", msg.Metadata["wa_message_type"], "contact")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `ContactMessage` and `ContactsArrayMessage` were silently dropped — `content` stayed empty and the guard on line 440 discarded them
- Adds `parseVCard` (line-scans `FN`/`TEL`/`EMAIL`/`ORG`), `formatContactContent`, and `formatContactsArrayContent` helpers
- Extends the caption-switch in `handleIncoming` with two new cases and sets `wa_message_type=contact` in message metadata

## Test plan
- [x] 3 new TDD tests added (written before implementation): single contact with full vCard, contact with no vCard, multi-contact array
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)