### PR TITLE
fix(whatsapp): auto-detect decision points and send native widget menus

### DIFF
--- a/pkg/channels/whatsapp_native/formatting.go
+++ b/pkg/channels/whatsapp_native/formatting.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+const (
+	waMaxButtonOptions = 3
+	waMaxListOptions   = 10
+)
+
 var (
 	waReHeading    = regexp.MustCompile(`(?m)^#{1,6}\s+([^\n]+)`)
 	waReBlockquote = regexp.MustCompile(`(?m)^>\s*(.*)$`)
@@ -16,7 +21,33 @@ var (
 	waReListItem   = regexp.MustCompile(`(?m)^[-*]\s+`)
 	waReCodeBlock  = regexp.MustCompile("(?s)```[\\w]*\\n?([\\s\\S]*?)```")
 	waReInlineCode = regexp.MustCompile("`([^`]+)`")
+
+	// waReOptionItem matches a numbered (1. / 1)) or bulleted (- / * / •) list item at line start.
+	waReOptionItem = regexp.MustCompile(`(?m)^(?:\d+[.)]\s+|[-*•]\s+)(.+)`)
 )
+
+// detectOptions inspects content for a decision-point pattern: an introductory
+// sentence ending with "?" or ":" followed by 2–10 list items. Returns the body
+// text and option labels when the pattern matches; both are empty otherwise.
+func detectOptions(content string) (body string, opts []string) {
+	matches := waReOptionItem.FindAllStringSubmatchIndex(content, -1)
+	if len(matches) < 2 || len(matches) > waMaxListOptions {
+		return
+	}
+	firstStart := matches[0][0]
+	rawBody := strings.TrimSpace(content[:firstStart])
+	if !strings.HasSuffix(rawBody, "?") && !strings.HasSuffix(rawBody, ":") {
+		return
+	}
+	body = rawBody
+	for _, m := range matches {
+		opt := strings.TrimSpace(content[m[2]:m[3]])
+		if opt != "" {
+			opts = append(opts, opt)
+		}
+	}
+	return
+}
 
 func stripMarkdown(s string) string {
 	s = waReCodeBlock.ReplaceAllStringFunc(s, func(m string) string {

--- a/pkg/channels/whatsapp_native/formatting_test.go
+++ b/pkg/channels/whatsapp_native/formatting_test.go
@@ -106,3 +106,95 @@ func TestStripMarkdown(t *testing.T) {
 		})
 	}
 }
+
+func TestDetectOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantBody string
+		wantOpts []string
+	}{
+		{
+			name:     "numbered list with question",
+			input:    "Which list?\n1. Backlog\n2. In Progress\n3. Done",
+			wantBody: "Which list?",
+			wantOpts: []string{"Backlog", "In Progress", "Done"},
+		},
+		{
+			name:     "bulleted list with colon",
+			input:    "Pick a priority:\n- High\n- Medium\n- Low",
+			wantBody: "Pick a priority:",
+			wantOpts: []string{"High", "Medium", "Low"},
+		},
+		{
+			name:     "4 options exceeds button limit -> list",
+			input:    "Select a list?\n1. Backlog\n2. In Progress\n3. Done\n4. Archive",
+			wantBody: "Select a list?",
+			wantOpts: []string{"Backlog", "In Progress", "Done", "Archive"},
+		},
+		{
+			name:     "numbered with paren",
+			input:    "Choose one?\n1) Alpha\n2) Beta",
+			wantBody: "Choose one?",
+			wantOpts: []string{"Alpha", "Beta"},
+		},
+		{
+			name:     "bullet with star",
+			input:    "Which color?\n* Red\n* Blue",
+			wantBody: "Which color?",
+			wantOpts: []string{"Red", "Blue"},
+		},
+		{
+			name:     "bullet with unicode bullet",
+			input:    "Pick one?\n• First\n• Second",
+			wantBody: "Pick one?",
+			wantOpts: []string{"First", "Second"},
+		},
+		{
+			name:     "plain text no list",
+			input:    "Hello world, how are you?",
+			wantOpts: nil,
+		},
+		{
+			name:     "body without ? or : not detected",
+			input:    "Here is a list\n1. Alpha\n2. Beta",
+			wantOpts: nil,
+		},
+		{
+			name:     "single item not detected",
+			input:    "Pick one?\n1. Only option",
+			wantOpts: nil,
+		},
+		{
+			name: "11 items exceeds maximum not detected",
+			input: "Which one?\n1. A\n2. B\n3. C\n4. D\n5. E\n6. F\n7. G\n8. H\n9. I\n10. J\n11. K",
+			wantOpts: nil,
+		},
+		{
+			name:     "multiline body trimmed",
+			input:    "I found these options.\nWhich would you like?\n- Apple\n- Banana",
+			wantBody: "I found these options.\nWhich would you like?",
+			wantOpts: []string{"Apple", "Banana"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, opts := detectOptions(tc.input)
+			if len(opts) == 0 && len(tc.wantOpts) == 0 {
+				return // both nil/empty: pass
+			}
+			if len(opts) != len(tc.wantOpts) {
+				t.Fatalf("opts count: got %d %v, want %d %v", len(opts), opts, len(tc.wantOpts), tc.wantOpts)
+			}
+			if body != tc.wantBody {
+				t.Errorf("body: got %q, want %q", body, tc.wantBody)
+			}
+			for i, o := range opts {
+				if o != tc.wantOpts[i] {
+					t.Errorf("opts[%d]: got %q, want %q", i, o, tc.wantOpts[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/channels/whatsapp_native/whatsapp_native.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native.go
@@ -683,6 +683,7 @@ func (c *WhatsAppNativeChannel) Send(ctx context.Context, msg bus.OutboundMessag
 		return nil, fmt.Errorf("invalid chat id %q: %w", msg.ChatID, err)
 	}
 
+	msg = injectWidgetMetadata(msg)
 	msg.Content = stripMarkdown(msg.Content)
 	waMsg := buildOutboundProtoMessage(msg)
 
@@ -690,6 +691,32 @@ func (c *WhatsAppNativeChannel) Send(ctx context.Context, msg bus.OutboundMessag
 		return nil, fmt.Errorf("whatsapp send: %w", channels.ErrTemporary)
 	}
 	return nil, nil
+}
+
+// injectWidgetMetadata detects decision-point option lists in the message content
+// and injects WhatsApp widget metadata (Content-Type, X-WA-Body, X-WA-Option-N).
+// It is a no-op when Content-Type is already set or no option pattern is found.
+func injectWidgetMetadata(msg bus.OutboundMessage) bus.OutboundMessage {
+	if msg.Metadata["Content-Type"] != "" {
+		return msg
+	}
+	body, opts := detectOptions(msg.Content)
+	if len(opts) == 0 {
+		return msg
+	}
+	if msg.Metadata == nil {
+		msg.Metadata = make(map[string]string)
+	}
+	if len(opts) <= waMaxButtonOptions {
+		msg.Metadata["Content-Type"] = "application/x-wa-buttons"
+	} else {
+		msg.Metadata["Content-Type"] = "application/x-wa-list"
+	}
+	msg.Metadata["X-WA-Body"] = stripMarkdown(body)
+	for i, opt := range opts {
+		msg.Metadata[fmt.Sprintf("X-WA-Option-%d", i)] = opt
+	}
+	return msg
 }
 
 // buildOutboundProtoMessage converts an OutboundMessage into a whatsmeow proto

--- a/pkg/channels/whatsapp_native/whatsapp_native_sushi30_test.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native_sushi30_test.go
@@ -542,6 +542,85 @@ func TestHandleIncoming_ContactsArrayMessage_Forwarded(t *testing.T) {
 	}
 }
 
+// --- Widget auto-detection integration tests ---
+
+func TestSend_OptionsAutoDetect_ButtonWidget(t *testing.T) {
+	msg := bus.OutboundMessage{
+		Content: "Which list?\n1. Backlog\n2. In Progress",
+	}
+	result := injectWidgetMetadata(msg)
+	waMsg := buildOutboundProtoMessage(result)
+
+	bm := waMsg.GetButtonsMessage()
+	if bm == nil {
+		t.Fatal("expected ButtonsMessage for 2-option list, got nil")
+	}
+	if len(bm.Buttons) != 2 {
+		t.Fatalf("expected 2 buttons, got %d", len(bm.Buttons))
+	}
+	if bm.Buttons[0].GetButtonText().GetDisplayText() != "Backlog" {
+		t.Errorf("button[0]: got %q, want %q", bm.Buttons[0].GetButtonText().GetDisplayText(), "Backlog")
+	}
+	if bm.Buttons[1].GetButtonText().GetDisplayText() != "In Progress" {
+		t.Errorf("button[1]: got %q, want %q", bm.Buttons[1].GetButtonText().GetDisplayText(), "In Progress")
+	}
+	if bm.GetContentText() != "Which list?" {
+		t.Errorf("body: got %q, want %q", bm.GetContentText(), "Which list?")
+	}
+}
+
+func TestSend_OptionsAutoDetect_ListWidget(t *testing.T) {
+	msg := bus.OutboundMessage{
+		Content: "Select a list?\n1. Backlog\n2. In Progress\n3. Done\n4. Archive",
+	}
+	result := injectWidgetMetadata(msg)
+	waMsg := buildOutboundProtoMessage(result)
+
+	lm := waMsg.GetListMessage()
+	if lm == nil {
+		t.Fatal("expected ListMessage for 4-option list, got nil")
+	}
+	if len(lm.Sections) != 1 || len(lm.Sections[0].Rows) != 4 {
+		t.Fatalf("expected 4 rows, got %d", len(lm.Sections[0].Rows))
+	}
+	labels := []string{"Backlog", "In Progress", "Done", "Archive"}
+	for i, row := range lm.Sections[0].Rows {
+		if row.GetTitle() != labels[i] {
+			t.Errorf("row[%d]: got %q, want %q", i, row.GetTitle(), labels[i])
+		}
+	}
+}
+
+func TestSend_ExistingContentType_NotOverridden(t *testing.T) {
+	msg := bus.OutboundMessage{
+		Content: "Which list?\n1. Backlog\n2. In Progress",
+		Metadata: map[string]string{
+			"Content-Type": "application/x-wa-list",
+			"X-WA-Body":    "manual body",
+			"X-WA-Option-0": "Custom A",
+			"X-WA-Option-1": "Custom B",
+		},
+	}
+	result := injectWidgetMetadata(msg)
+	if result.Metadata["X-WA-Body"] != "manual body" {
+		t.Errorf("existing Content-Type should not be overridden; X-WA-Body: got %q", result.Metadata["X-WA-Body"])
+	}
+}
+
+func TestSend_NoBodySuffix_NotDetected(t *testing.T) {
+	msg := bus.OutboundMessage{
+		Content: "Here are some items\n1. Alpha\n2. Beta",
+	}
+	result := injectWidgetMetadata(msg)
+	if result.Metadata["Content-Type"] != "" {
+		t.Errorf("expected no Content-Type for body without ?/: suffix, got %q", result.Metadata["Content-Type"])
+	}
+	waMsg := buildOutboundProtoMessage(result)
+	if waMsg.GetConversation() == "" {
+		t.Error("expected plain Conversation fallback")
+	}
+}
+
 func assertNoMessage(t *testing.T, mb *bus.MessageBus, msg string) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)


### PR DESCRIPTION
## Summary

- Adds `detectOptions` to parse numbered/bulleted option lists from agent responses preceded by a `?` or `:` body
- Adds `injectWidgetMetadata` to populate `Content-Type`, `X-WA-Body`, and `X-WA-Option-N` metadata before `buildOutboundProtoMessage` is called in `Send()`
- ≤3 options → `application/x-wa-buttons`; >3 → `application/x-wa-list`; existing `Content-Type` is never overwritten

## Test plan

- [x] `TestDetectOptions_*` — unit tests for all detection heuristic cases (numbered, bulleted, paren, unicode bullet, min/max bounds, missing suffix)
- [x] `TestSend_OptionsAutoDetect_ButtonWidget` — 2-item list produces `ButtonsMessage`
- [x] `TestSend_OptionsAutoDetect_ListWidget` — 4-item list produces `ListMessage` with correct row labels
- [x] `TestSend_ExistingContentType_NotOverridden` — pre-set metadata is preserved
- [x] `TestSend_NoBodySuffix_NotDetected` — list without `?`/`:` body falls back to plain text
- [x] Full test suite green (`go test ./...`)
- [x] `make build` clean

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)