### PR TITLE
docs: email channel config migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,26 +65,25 @@ When a message arrives from a sender not listed in `allow_from`, sushiclaw repli
 
 SMTP (outbound) + IMAP polling (inbound) channel. The agent can receive and reply to emails.
 
-Config block (`channels.email` in `config.json`):
+Email is wired as a sidecar outside picoclaw's channel registry. Its config lives under a
+top-level `email_channel` key — **not** inside `channels`:
 
 ```json
 {
-  "channels": {
-    "email": {
-      "enabled": true,
-      "smtp_host": "smtp.example.com",
-      "smtp_port": 587,
-      "smtp_from": "bot@example.com",
-      "smtp_user": "bot@example.com",
-      "smtp_password": "env://SMTP_PASSWORD",
-      "imap_host": "imap.example.com",
-      "imap_port": 993,
-      "imap_user": "bot@example.com",
-      "imap_password": "env://IMAP_PASSWORD",
-      "poll_interval_secs": 30,
-      "allow_from": ["trusted@example.com"],
-      "default_subject": "Re: your message"
-    }
+  "email_channel": {
+    "enabled": true,
+    "smtp_host": "smtp.example.com",
+    "smtp_port": 587,
+    "smtp_from": "bot@example.com",
+    "smtp_user": "bot@example.com",
+    "smtp_password": "env://SMTP_PASSWORD",
+    "imap_host": "imap.example.com",
+    "imap_port": 993,
+    "imap_user": "bot@example.com",
+    "imap_password": "env://IMAP_PASSWORD",
+    "poll_interval_secs": 30,
+    "allow_from": ["trusted@example.com"],
+    "default_subject": "Re: your message"
   }
 }
 ```
@@ -93,3 +92,6 @@ Config block (`channels.email` in `config.json`):
 - Port 993 (default) → implicit TLS for IMAP.
 - Polled messages are marked `\Seen` after processing.
 - `allow_from` restricts which sender addresses the agent will respond to.
+
+> **Migrating from an older config?** See [RELEASE_NOTES.md](RELEASE_NOTES.md) for
+> step-by-step instructions if your config uses the old `channels.email` format.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,87 @@
+# Release Notes
+
+## Email channel config migration (fix/email4)
+
+### What changed
+
+The email channel is wired manually outside picoclaw's channel registry.
+This means email config must live under the top-level `email_channel` key,
+**not** inside the `channels` map.
+
+If your config has `channels.email`, startup will fail with:
+
+```
+error loading config: channel "email" has unknown type "email"
+```
+
+### Required config migration
+
+Open `~/.picoclaw/config.json` (or `$SUSHICLAW_CONFIG`) and move the email
+block from `channels` to a top-level `email_channel` key.
+
+**Before:**
+
+```json
+{
+  "channels": {
+    "whatsapp": { ... },
+    "email": {
+      "enabled": true,
+      "smtp_host": "smtp.gmail.com",
+      "smtp_port": 587,
+      "smtp_from": "env://SMTP_USER",
+      "smtp_user": "env://SMTP_USER",
+      "smtp_password": "env://SMTP_PASSWORD",
+      "imap_host": "imap.gmail.com",
+      "imap_port": 993,
+      "imap_user": "env://SMTP_USER",
+      "imap_password": "env://SMTP_PASSWORD",
+      "poll_interval_secs": 10,
+      "allow_from": ["you@example.com"]
+    }
+  }
+}
+```
+
+**After:**
+
+```json
+{
+  "channels": {
+    "whatsapp": { ... }
+  },
+  "email_channel": {
+    "enabled": true,
+    "smtp_host": "smtp.gmail.com",
+    "smtp_port": 587,
+    "smtp_from": "env://SMTP_USER",
+    "smtp_user": "env://SMTP_USER",
+    "smtp_password": "env://SMTP_PASSWORD",
+    "imap_host": "imap.gmail.com",
+    "imap_port": 993,
+    "imap_user": "env://SMTP_USER",
+    "imap_password": "env://SMTP_PASSWORD",
+    "poll_interval_secs": 10,
+    "allow_from": ["you@example.com"]
+  }
+}
+```
+
+### Reference: full email_channel options
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | bool | Enable/disable the email channel |
+| `smtp_host` | string | SMTP server hostname |
+| `smtp_port` | int | SMTP port (typically 587 for TLS, 465 for SSL) |
+| `smtp_from` | string | Sender address (supports `env://VAR`) |
+| `smtp_user` | string | SMTP auth username (supports `env://VAR`) |
+| `smtp_password` | string | SMTP auth password (supports `env://VAR`) |
+| `default_subject` | string | Subject for new outbound emails |
+| `imap_host` | string | IMAP server hostname |
+| `imap_port` | int | IMAP port (typically 993) |
+| `imap_user` | string | IMAP username (supports `env://VAR`) |
+| `imap_password` | string | IMAP password (supports `env://VAR`) |
+| `poll_interval_secs` | int | How often to poll for new mail (seconds) |
+| `allow_from` | []string | Allowlist of sender addresses that can message the agent |
+| `reasoning_channel_id` | string | Channel ID for extended reasoning responses |


### PR DESCRIPTION
## Summary

Adds `RELEASE_NOTES.md` with:
- Explanation of why `channels.email` no longer works
- Step-by-step migration from `channels.email` → `email_channel`
- Before/after config snippets
- Full reference table of all `email_channel` options

Companion to #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)