### PR TITLE
fix(channels): register whatsapp_native factory under correct type name

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -22,9 +22,8 @@
     }
   ],
   "channels": {
-    "whatsapp": {
+    "whatsapp_native": {
       "enabled": false,
-      "bridge_url": "ws://localhost:3001",
       "use_native": true,
       "session_store_path": "",
       "allow_from": [],

--- a/config_example_sushi30_test.go
+++ b/config_example_sushi30_test.go
@@ -39,10 +39,10 @@ func TestExampleConfigLoadsAsV2(t *testing.T) {
 		t.Error("model_list is empty")
 	}
 
-	// WhatsApp: use_native should be set
-	waDecoded, err := cfg.Channels["whatsapp"].GetDecoded()
+	// WhatsApp: use_native should be set (channel registered under "whatsapp_native" key)
+	waDecoded, err := cfg.Channels["whatsapp_native"].GetDecoded()
 	if err != nil {
-		t.Fatalf("decode whatsapp settings: %v", err)
+		t.Fatalf("decode whatsapp_native settings: %v", err)
 	}
 	waCfg, ok := waDecoded.(*config.WhatsAppSettings)
 	if !ok {

--- a/pkg/channels/whatsapp_native/init.go
+++ b/pkg/channels/whatsapp_native/init.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	channels.RegisterFactory("whatsapp", func(channelName, _ string, cfg *config.Config, b *bus.MessageBus) (channels.Channel, error) {
+	channels.RegisterFactory("whatsapp_native", func(channelName, _ string, cfg *config.Config, b *bus.MessageBus) (channels.Channel, error) {
 		bc := cfg.Channels[channelName]
 		decoded, err := bc.GetDecoded()
 		if err != nil {

--- a/pkg/channels/whatsapp_native/init_test.go
+++ b/pkg/channels/whatsapp_native/init_test.go
@@ -1,0 +1,21 @@
+package whatsapp
+
+import (
+	"testing"
+
+	"github.com/sipeed/picoclaw/pkg/channels"
+	"github.com/sipeed/picoclaw/pkg/config"
+)
+
+// TestFactoryRegisteredAsWhatsAppNative guards against re-registering the factory
+// under the legacy "whatsapp" name, which fails picoclaw's readiness check that
+// requires type == "whatsapp_native" for bridge-less native operation.
+func TestFactoryRegisteredAsWhatsAppNative(t *testing.T) {
+	names := channels.GetRegisteredFactoryNames()
+	for _, n := range names {
+		if n == config.ChannelWhatsAppNative {
+			return
+		}
+	}
+	t.Errorf("whatsapp_native factory not registered; got %v", names)
+}


### PR DESCRIPTION
## Summary

- After upgrading picoclaw (`667fc85d`), `getChannelConfigAndEnabled` validates `WhatsAppSettings` by type: `"whatsapp"` requires `bridge_url != ""`, while `"whatsapp_native"` requires `use_native == true`. The factory was registered under `"whatsapp"`, so the channel was silently skipped at startup → "Warning: no channels enabled".
- Rename factory registration from `"whatsapp"` → `"whatsapp_native"` in `init.go`
- Rename example config key to `"whatsapp_native"` (migration sets `type = key name`)
- Add regression test asserting the factory is registered under `config.ChannelWhatsAppNative`

## Test plan

- [ ] `make test` passes (all packages green)
- [ ] After Docker rebuild, logs show `Channels enabled: [whatsapp_native]` instead of the warning
- [ ] WhatsApp messages reach the agent

## Note

The personal-server config also needs updating: rename `"whatsapp"` key → `"whatsapp_native"` and upgrade to v3 format to prevent `SaveConfig` from silently erasing the `email_channel` section on migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)