### PR TITLE
feat(gateway): wire heartbeat service into sushiclaw gateway

### DIFF
--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -339,12 +339,16 @@ func GetConfigPath() string {
 	return filepath.Join(GetHome(), "config.json")
 }
 
-func createHeartbeatHandler(agentLoop *agent.AgentLoop) heartbeat.HeartbeatHandler {
+type heartbeatProcessor interface {
+	ProcessHeartbeat(ctx context.Context, content, channel, chatID string) (string, error)
+}
+
+func createHeartbeatHandler(proc heartbeatProcessor) heartbeat.HeartbeatHandler {
 	return func(prompt, channel, chatID string) *tools.ToolResult {
 		if channel == "" || chatID == "" {
 			channel, chatID = "cli", "direct"
 		}
-		response, err := agentLoop.ProcessHeartbeat(context.Background(), prompt, channel, chatID)
+		response, err := proc.ProcessHeartbeat(context.Background(), prompt, channel, chatID)
 		if err != nil {
 			return tools.ErrorResult(fmt.Sprintf("Heartbeat error: %v", err))
 		}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -21,10 +21,12 @@ import (
 	"github.com/sipeed/picoclaw/pkg/channels"
 	"github.com/sipeed/picoclaw/pkg/config"
 	"github.com/sipeed/picoclaw/pkg/health"
+	"github.com/sipeed/picoclaw/pkg/heartbeat"
 	"github.com/sipeed/picoclaw/pkg/logger"
 	"github.com/sipeed/picoclaw/pkg/media"
 	"github.com/sipeed/picoclaw/pkg/pid"
 	"github.com/sipeed/picoclaw/pkg/providers"
+	"github.com/sipeed/picoclaw/pkg/tools"
 )
 
 const (
@@ -171,6 +173,13 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 
 	go agentLoop.Run(ctx) //nolint:errcheck
 
+	hbService := heartbeat.NewHeartbeatService(cfg.WorkspacePath(), cfg.Heartbeat.Interval, cfg.Heartbeat.Enabled)
+	hbService.SetBus(agentBus)
+	hbService.SetHandler(createHeartbeatHandler(agentLoop))
+	if err = hbService.Start(); err != nil {
+		return fmt.Errorf("error starting heartbeat service: %w", err)
+	}
+
 	debugMgr := &DebugManager{agentLoop: agentLoop, externalBus: externalBus}
 
 	// Inbound bridge: intercept /debug and block unrecognized slash commands
@@ -226,6 +235,8 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 	defer shutdownCancel()
 	_ = cm.StopAll(shutdownCtx)
+
+	hbService.Stop()
 
 	if cp, ok := provider.(providers.StatefulProvider); ok {
 		cp.Close()
@@ -326,4 +337,20 @@ func GetConfigPath() string {
 		return p
 	}
 	return filepath.Join(GetHome(), "config.json")
+}
+
+func createHeartbeatHandler(agentLoop *agent.AgentLoop) heartbeat.HeartbeatHandler {
+	return func(prompt, channel, chatID string) *tools.ToolResult {
+		if channel == "" || chatID == "" {
+			channel, chatID = "cli", "direct"
+		}
+		response, err := agentLoop.ProcessHeartbeat(context.Background(), prompt, channel, chatID)
+		if err != nil {
+			return tools.ErrorResult(fmt.Sprintf("Heartbeat error: %v", err))
+		}
+		if response == "HEARTBEAT_OK" {
+			return tools.SilentResult("Heartbeat OK")
+		}
+		return tools.SilentResult(response)
+	}
 }

--- a/internal/gateway/heartbeat_handler_test.go
+++ b/internal/gateway/heartbeat_handler_test.go
@@ -1,0 +1,94 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type stubProcessor struct {
+	response string
+	err      error
+	// captures what was passed in
+	gotChannel string
+	gotChatID  string
+}
+
+func (s *stubProcessor) ProcessHeartbeat(_ context.Context, _, channel, chatID string) (string, error) {
+	s.gotChannel = channel
+	s.gotChatID = chatID
+	return s.response, s.err
+}
+
+func TestCreateHeartbeatHandler_DefaultsEmptyChannelToCLI(t *testing.T) {
+	proc := &stubProcessor{response: "HEARTBEAT_OK"}
+	handler := createHeartbeatHandler(proc)
+
+	handler("check time", "", "")
+
+	if proc.gotChannel != "cli" {
+		t.Errorf("channel = %q, want %q", proc.gotChannel, "cli")
+	}
+	if proc.gotChatID != "direct" {
+		t.Errorf("chatID = %q, want %q", proc.gotChatID, "direct")
+	}
+}
+
+func TestCreateHeartbeatHandler_PreservesNonEmptyChannel(t *testing.T) {
+	proc := &stubProcessor{response: "HEARTBEAT_OK"}
+	handler := createHeartbeatHandler(proc)
+
+	handler("check time", "telegram", "123456")
+
+	if proc.gotChannel != "telegram" {
+		t.Errorf("channel = %q, want %q", proc.gotChannel, "telegram")
+	}
+	if proc.gotChatID != "123456" {
+		t.Errorf("chatID = %q, want %q", proc.gotChatID, "123456")
+	}
+}
+
+func TestCreateHeartbeatHandler_HeartbeatOK_ReturnsSilent(t *testing.T) {
+	proc := &stubProcessor{response: "HEARTBEAT_OK"}
+	handler := createHeartbeatHandler(proc)
+
+	result := handler("check", "telegram", "123")
+
+	if result.IsError {
+		t.Errorf("expected no error, got: %s", result.ForLLM)
+	}
+	if !result.Silent {
+		t.Error("expected Silent=true for HEARTBEAT_OK")
+	}
+}
+
+func TestCreateHeartbeatHandler_OtherResponse_ReturnsSilentWithContent(t *testing.T) {
+	proc := &stubProcessor{response: "Rain expected tomorrow"}
+	handler := createHeartbeatHandler(proc)
+
+	result := handler("weather", "telegram", "123")
+
+	if result.IsError {
+		t.Errorf("unexpected error: %s", result.ForLLM)
+	}
+	if !result.Silent {
+		t.Error("expected Silent=true")
+	}
+	if result.ForLLM != "Rain expected tomorrow" {
+		t.Errorf("ForLLM = %q, want %q", result.ForLLM, "Rain expected tomorrow")
+	}
+}
+
+func TestCreateHeartbeatHandler_ProcessError_ReturnsError(t *testing.T) {
+	proc := &stubProcessor{err: errors.New("provider offline")}
+	handler := createHeartbeatHandler(proc)
+
+	result := handler("check", "telegram", "123")
+
+	if !result.IsError {
+		t.Error("expected IsError=true on processor error")
+	}
+	if result.ForLLM == "" {
+		t.Error("expected non-empty error message")
+	}
+}


### PR DESCRIPTION
## Summary
- `HeartbeatService` was never initialized in sushiclaw's gateway, so HEARTBEAT.md tasks never fired
- Mirrors the initialization pattern from picoclaw's gateway: create → SetBus → SetHandler → Start → Stop on shutdown
- Adds `createHeartbeatHandler` that delegates to `agentLoop.ProcessHeartbeat`

## Test plan
- [x] `make build` — compiles clean
- [x] `make test` — all 8 packages pass
- [x] `make lint` — 0 issues

## References
Closes #61