### PR TITLE
feat(cli): add version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 BINARY := sushiclaw
 INSTALL_DIR := $(HOME)/.local/bin
 
+GIT_COMMIT := $(shell git rev-parse --short=8 HEAD 2>/dev/null || echo "dev")
+VERSION_PKG := github.com/sushi30/sushiclaw/internal/version
+LDFLAGS := -X $(VERSION_PKG).GitCommit=$(GIT_COMMIT)
+
 .PHONY: build test install lint fmt vet deps sync-picoclaw test-integration
 
 build:
-	CGO_ENABLED=0 go build -o $(BINARY) .
+	CGO_ENABLED=0 go build -tags whatsapp_native -ldflags "$(LDFLAGS)" -o $(BINARY) .
 
 test:
 	go test ./...

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var GitCommit = "dev"

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/sushi30/sushiclaw/internal/gateway"
+	"github.com/sushi30/sushiclaw/internal/version"
 
 	// Register owned channel implementations.
 	_ "github.com/sushi30/sushiclaw/pkg/channels/telegram"
@@ -29,7 +30,20 @@ func newRootCommand() *cobra.Command {
 		Short: "Sushiclaw personal AI agent",
 	}
 	cmd.AddCommand(newGatewayCommand())
+	cmd.AddCommand(newVersionCommand())
 	return cmd
+}
+
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:     "version",
+		Aliases: []string{"v"},
+		Short:   "Print build commit hash",
+		Args:    cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
+			fmt.Println(version.GitCommit)
+		},
+	}
 }
 
 func newGatewayCommand() *cobra.Command {


### PR DESCRIPTION
## Summary
- Adds `sushiclaw version` (alias `v`) command that prints the 8-char git commit hash
- Injects `GIT_COMMIT` via ldflags at build time; falls back to `"dev"` for `go run`
- Fixes missing `-tags whatsapp_native` in the `make build` target

## Test plan
- `make build && ./sushiclaw version` → prints 8-char hash
- `./sushiclaw v` → same output via alias
- `go run . version` → prints `dev`
- All tests pass (`make test`)
- Lint clean (`make lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)