### PR TITLE
feat(versioning): add CalVer publishing with GoReleaser and dev Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,19 +32,34 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Compute short SHA
-        id: sha
+      - name: Compute build metadata
+        id: meta
         shell: bash
-        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "commit=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+          echo "builttime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Compute Go version
+        id: gover
+        run: echo "version=$(go version | awk '{print $3}')" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
+          build-args: |
+            VERSION=dev
+            COMMIT=${{ steps.meta.outputs.commit }}
+            BUILDTIME=${{ steps.meta.outputs.builttime }}
+            GOVER=${{ steps.gover.outputs.version }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ steps.sha.outputs.short }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${{ steps.meta.outputs.commit }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "2[0-9][0-9][0-9].[0-9][0-9].*"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,71 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+git:
+  ignore_tags:
+    - nightly
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: sushiclaw
+    env:
+      - CGO_ENABLED=0
+    tags:
+      - whatsapp_native
+    ldflags:
+      - -s -w
+      - -X github.com/sushi30/sushiclaw/internal/version.Version={{ .Version }}
+      - -X github.com/sushi30/sushiclaw/internal/version.GitCommit={{ .ShortCommit }}
+      - -X github.com/sushi30/sushiclaw/internal/version.BuildTime={{ .Date }}
+      - -X github.com/sushi30/sushiclaw/internal/version.GoVersion={{ with index .Env "GOVERSION" }}{{ . }}{{ else }}unknown{{ end }}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+dockers_v2:
+  - id: sushiclaw
+    dockerfile: docker/Dockerfile.goreleaser
+    ids:
+      - sushiclaw
+    images:
+      - ghcr.io/sushi30/sushiclaw
+    tags:
+      - "{{ .Version }}"
+      - latest
+    platforms:
+      - linux/amd64
+      - linux/arm64
+
+archives:
+  - formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+release:
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@
 # ============================================================
 FROM golang:1.25-alpine AS builder
 
+ARG VERSION=dev
+ARG COMMIT=dev
+ARG BUILDTIME
+ARG GOVER
+
 WORKDIR /src
 
 # Cache go module dependencies
@@ -13,7 +18,13 @@ RUN go mod download
 
 # Copy source and build
 COPY . .
-RUN CGO_ENABLED=0 go build -o sushiclaw .
+RUN CGO_ENABLED=0 go build \
+    -tags whatsapp_native \
+    -ldflags "-X github.com/sushi30/sushiclaw/internal/version.Version=${VERSION} \
+              -X github.com/sushi30/sushiclaw/internal/version.GitCommit=${COMMIT} \
+              -X github.com/sushi30/sushiclaw/internal/version.BuildTime=${BUILDTIME} \
+              -X github.com/sushi30/sushiclaw/internal/version.GoVersion=${GOVER}" \
+    -o sushiclaw .
 
 # ============================================================
 # Stage 2: Minimal runtime image
@@ -24,7 +35,7 @@ RUN apk add --no-cache ca-certificates tzdata
 
 # Health check (picoclaw health server runs on 18790)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD wget -q --spider http://localhost:18790/health || exit 1
+    CMD wget -q --spider http://localhost:18790/health || exit 1
 
 COPY --from=builder /src/sushiclaw /usr/local/bin/sushiclaw
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
-BINARY := sushiclaw
+BINARY      := sushiclaw
 INSTALL_DIR := $(HOME)/.local/bin
-
-GIT_COMMIT := $(shell git rev-parse --short=8 HEAD 2>/dev/null || echo "dev")
+VERSION     ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo dev)
+COMMIT      := $(shell git rev-parse --short=8 HEAD 2>/dev/null || echo dev)
+BUILDTIME   := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+GOVER       := $(shell go version | awk '{print $$3}')
 VERSION_PKG := github.com/sushi30/sushiclaw/internal/version
-LDFLAGS := -X $(VERSION_PKG).GitCommit=$(GIT_COMMIT)
+LDFLAGS     := -X $(VERSION_PKG).Version=$(VERSION) \
+               -X $(VERSION_PKG).GitCommit=$(COMMIT) \
+               -X $(VERSION_PKG).BuildTime=$(BUILDTIME) \
+               -X $(VERSION_PKG).GoVersion=$(GOVER)
 
-.PHONY: build test install lint fmt vet deps sync-picoclaw test-integration
+.PHONY: build test install lint fmt vet deps sync-picoclaw test-integration release-check
 
 build:
 	CGO_ENABLED=0 go build -tags whatsapp_native -ldflags "$(LDFLAGS)" -o $(BINARY) .
@@ -34,3 +39,7 @@ sync-picoclaw:
 
 test-integration:
 	go test -v -run 'TestEmailInboundPipeline|TestEmailOutboundPipeline' ./pkg/channels/email/...
+
+release-check:
+	@test "$(VERSION)" != "dev" || (echo "ERROR: no git tag found, set VERSION= explicitly" && exit 1)
+	@echo "Releasing $(VERSION) from commit $(COMMIT)"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Personal AI agent built on top of [picoclaw](https://github.com/sipeed/picoclaw).
 
 For general setup, configuration, and picoclaw concepts see the [picoclaw docs](https://github.com/sipeed/picoclaw).
-This README documents only what sushiclaw adds on top.
+This README documents only what sushiclaw adds on top. See [RELEASE.md](RELEASE.md) for versioning and release instructions.
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,44 @@
+# Releases
+
+sushiclaw uses calendar versioning: **YYYY.MM.iteration** (e.g. `2026.04.0`, `2026.04.1`).
+
+- `YYYY` — year of release
+- `MM` — month of release
+- `iteration` — zero-indexed counter within that month (resets each month)
+
+There is no semver or breaking-change tracking — bump the iteration for any release.
+
+## Creating a release
+
+1. Ensure main is up to date and all checks pass.
+2. Tag and push:
+
+   ```bash
+   git tag 2026.04.0 -m "Release 2026.04.0"
+   git push origin 2026.04.0
+   ```
+
+3. The `release` workflow builds binaries and Docker images via GoReleaser, then creates a GitHub Release.
+
+## Docker tags
+
+| Event                | Tags                          | Source                     |
+|----------------------|-------------------------------|----------------------------|
+| Push to `main`       | `dev-<8-char-commit>`        | `docker.yml` workflow      |
+| Push tag `YYYY.MM.N` | `YYYY.MM.N`, `latest`        | `release.yml` (GoReleaser) |
+
+## Checking the version
+
+```bash
+./sushiclaw version
+# 2026.04.0 (git: abc12345, built: 2026-04-22T15:30:00Z, go: go1.25.0)
+```
+
+Unbuilt binaries show `dev (git: ..., built: ..., go: ...)`.
+
+## Building locally
+
+```bash
+make build                      # VERSION=dev (auto-detected from git tags)
+VERSION=2026.04.0 make build    # Override for specific version
+```

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -1,0 +1,16 @@
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD wget -q --spider http://localhost:18790/health || exit 1
+
+COPY sushiclaw /usr/local/bin/sushiclaw
+
+RUN addgroup -g 1000 sushiclaw && \
+    adduser -D -u 1000 -G sushiclaw sushiclaw
+
+USER sushiclaw
+
+ENTRYPOINT ["sushiclaw"]
+CMD ["gateway"]

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,29 @@
 package version
 
-var GitCommit = "dev"
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	Version   = "dev"
+	GitCommit string
+	BuildTime string
+	GoVersion string
+)
+
+func FormatVersion() string {
+	v := Version
+	if GitCommit != "" {
+		v += fmt.Sprintf(" (git: %s", GitCommit)
+		if BuildTime != "" {
+			v += fmt.Sprintf(", built: %s", BuildTime)
+		}
+		goVer := GoVersion
+		if goVer == "" {
+			goVer = runtime.Version()
+		}
+		v += fmt.Sprintf(", go: %s)", goVer)
+	}
+	return v
+}

--- a/main.go
+++ b/main.go
@@ -38,10 +38,10 @@ func newVersionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:     "version",
 		Aliases: []string{"v"},
-		Short:   "Print build commit hash",
+		Short:   "Print build version info",
 		Args:    cobra.NoArgs,
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Println(version.GitCommit)
+			fmt.Println(version.FormatVersion())
 		},
 	}
 }

--- a/pkg/channels/email/threading_test.go
+++ b/pkg/channels/email/threading_test.go
@@ -121,7 +121,7 @@ func TestCleanSubject(t *testing.T) {
 		{"fwd: Hello", "Hello"},
 		{"Re: Fwd: Hello", "Hello"},
 		{"Re: Re: Hello", "Hello"},
-		{"Re:Hello", "Hello"},   // no space after colon
+		{"Re:Hello", "Hello"}, // no space after colon
 		{"Fwd:Hello", "Hello"},
 		{"  Re:  Hello  ", "Hello"},
 		{"Hello World", "Hello World"},

--- a/pkg/channels/whatsapp_native/formatting_test.go
+++ b/pkg/channels/whatsapp_native/formatting_test.go
@@ -166,8 +166,8 @@ func TestDetectOptions(t *testing.T) {
 			wantOpts: nil,
 		},
 		{
-			name: "11 items exceeds maximum not detected",
-			input: "Which one?\n1. A\n2. B\n3. C\n4. D\n5. E\n6. F\n7. G\n8. H\n9. I\n10. J\n11. K",
+			name:     "11 items exceeds maximum not detected",
+			input:    "Which one?\n1. A\n2. B\n3. C\n4. D\n5. E\n6. F\n7. G\n8. H\n9. I\n10. J\n11. K",
 			wantOpts: nil,
 		},
 		{

--- a/pkg/tools/trusted_exec.go
+++ b/pkg/tools/trusted_exec.go
@@ -54,9 +54,9 @@ func NewTrustedExecTool(
 	}, nil
 }
 
-func (t *TrustedExecTool) Name() string                { return "exec" }
-func (t *TrustedExecTool) Description() string         { return t.restricted.Description() }
-func (t *TrustedExecTool) Parameters() map[string]any  { return t.restricted.Parameters() }
+func (t *TrustedExecTool) Name() string               { return "exec" }
+func (t *TrustedExecTool) Description() string        { return t.restricted.Description() }
+func (t *TrustedExecTool) Parameters() map[string]any { return t.restricted.Parameters() }
 
 // Execute dispatches to the trusted inner tool when the caller's chatID is in
 // the allowlist, otherwise to the restricted inner tool.


### PR DESCRIPTION
## Summary

Introduces calendar versioning (`YYYY.MM.iteration`) for sushiclaw with automated release publishing via GoReleaser and Docker.

### Changes

- **`internal/version/version.go`** — New package with `Version`, `GitCommit`, `BuildTime`, `GoVersion` vars (injected via ldflags) and `FormatVersion()` method
- **`main.go`** — Added `sushiclaw version` (alias `v`) command printing full build info
- **`Makefile`** — Ldflags injection for all 4 version vars; `VERSION` defaults to latest git tag; added `release-check` target
- **`Dockerfile`** — ARG vars + ldflags for dev build version injection
- **`docker/Dockerfile.goreleaser`** — Runtime-only image for tagged releases (copies pre-built binary)
- **`.goreleaser.yaml`** — Binary archives (linux/darwin/windows, amd64/arm64) + Docker image (`ghcr.io/sushi30/sushiclaw`)
- **`.github/workflows/release.yml`** — Triggered on `YYYY.MM.*` tag push, GoReleaser publishes GitHub Release + Docker images
- **`.github/workflows/docker.yml`** — Push to `main` now builds `dev-{8-char-commit}` Docker tags with version build-args (removed `latest`, reserved for releases)
- **`RELEASE.md`** — Documents version scheme, release process, Docker tag strategy
- **`README.md`** — Links to RELEASE.md

### Docker tag strategy

| Event | Tags | Workflow |
|-------|------|----------|
| Push to `main` | `dev-abc12345` | `docker.yml` |
| Push tag `2026.04.0` | `2026.04.0`, `latest` | `release.yml` (GoReleaser) |

## Test plan

- [x] `make build` — compiles with ldflags, `./sushiclaw version` outputs `dev (git: 91caf2f9, built: ..., go: go1.25.9)`
- [x] `make test` — all packages pass
- [x] `go vet ./...` — no issues
- [x] `golangci-lint run ./...` — no issues
- [x] `make fmt` — clean
- [ ] Tag `2026.04.0` after merge, verify GoReleaser creates GitHub Release + Docker images
- [ ] Push to main after merge, verify `dev-{commit}` Docker image is published