### PR TITLE
feat(agent): build system prompt from workspace files

### DIFF
--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -1,0 +1,236 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sushi30/sushiclaw/pkg/logger"
+)
+
+// ContextBuilder assembles the agent system prompt from workspace files:
+// AGENT.md, SOUL.md, USER.md, and skills/*/SKILL.md.
+// Prompts are cached and invalidated when source file mtimes change.
+type ContextBuilder struct {
+	workspace string
+
+	mu             sync.RWMutex
+	cachedPrompt   string
+	fileBaseline   map[string]time.Time
+	existedAtCache map[string]bool
+}
+
+// NewContextBuilder creates a ContextBuilder for the given workspace directory.
+func NewContextBuilder(workspace string) *ContextBuilder {
+	return &ContextBuilder{workspace: workspace}
+}
+
+// BuildSystemPromptWithCache returns the assembled system prompt, rebuilding
+// only when source files have changed since the last build.
+func (b *ContextBuilder) BuildSystemPromptWithCache() (string, error) {
+	b.mu.RLock()
+	if b.cachedPrompt != "" && b.cacheValidLocked() {
+		p := b.cachedPrompt
+		b.mu.RUnlock()
+		return p, nil
+	}
+	b.mu.RUnlock()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Double-checked: another goroutine may have rebuilt while we waited.
+	if b.cachedPrompt != "" && b.cacheValidLocked() {
+		return b.cachedPrompt, nil
+	}
+
+	baseline, existed := b.captureBaseline()
+
+	prompt, err := b.buildPrompt()
+	if err != nil {
+		return "", err
+	}
+
+	b.cachedPrompt = prompt
+	b.fileBaseline = baseline
+	b.existedAtCache = existed
+	return prompt, nil
+}
+
+// buildPrompt reads workspace files and assembles the system prompt.
+func (b *ContextBuilder) buildPrompt() (string, error) {
+	var sections []string
+
+	agentBody, agentOK := b.readFileIfExists(filepath.Join(b.workspace, "AGENT.md"))
+	if agentOK {
+		if body := parseMarkdownBody(agentBody); body != "" {
+			sections = append(sections, body)
+		}
+	}
+
+	if soul, ok := b.readFileIfExists(filepath.Join(b.workspace, "SOUL.md")); ok {
+		sections = append(sections, soul)
+	}
+
+	if user, ok := b.readFileIfExists(filepath.Join(b.workspace, "USER.md")); ok {
+		sections = append(sections, "## User Profile\n\n"+user)
+	}
+
+	if summary := b.skillsSummary(filepath.Join(b.workspace, "skills")); summary != "" {
+		sections = append(sections, summary)
+	}
+
+	if len(sections) == 0 {
+		logger.DebugC("agent", "No workspace context files found; using default system prompt")
+		return "", nil
+	}
+
+	return strings.Join(sections, "\n\n---\n\n"), nil
+}
+
+// cacheValidLocked checks whether all tracked files match the cached baseline.
+// Must be called with at least a read lock held.
+func (b *ContextBuilder) cacheValidLocked() bool {
+	if b.fileBaseline == nil {
+		return false
+	}
+	for path, cachedMtime := range b.fileBaseline {
+		info, err := os.Stat(path)
+		if err != nil {
+			if b.existedAtCache[path] {
+				return false // file was deleted
+			}
+			continue
+		}
+		if !b.existedAtCache[path] {
+			return false // file was created
+		}
+		if info.ModTime().After(cachedMtime) {
+			return false // file was modified
+		}
+	}
+	// Also check for new skill files not in baseline.
+	skillsDir := filepath.Join(b.workspace, "skills")
+	entries, err := os.ReadDir(skillsDir)
+	if err == nil {
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			p := filepath.Join(skillsDir, e.Name(), "SKILL.md")
+			if _, tracked := b.fileBaseline[p]; !tracked {
+				return false // new skill appeared
+			}
+		}
+	}
+	return true
+}
+
+// captureBaseline records the current mtime and existence of all source files.
+func (b *ContextBuilder) captureBaseline() (map[string]time.Time, map[string]bool) {
+	paths := []string{
+		filepath.Join(b.workspace, "AGENT.md"),
+		filepath.Join(b.workspace, "SOUL.md"),
+		filepath.Join(b.workspace, "USER.md"),
+	}
+
+	skillsDir := filepath.Join(b.workspace, "skills")
+	if entries, err := os.ReadDir(skillsDir); err == nil {
+		for _, e := range entries {
+			if e.IsDir() {
+				paths = append(paths, filepath.Join(skillsDir, e.Name(), "SKILL.md"))
+			}
+		}
+	}
+
+	baseline := make(map[string]time.Time, len(paths))
+	existed := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if err == nil {
+			baseline[p] = info.ModTime()
+			existed[p] = true
+		} else {
+			baseline[p] = time.Time{}
+			existed[p] = false
+		}
+	}
+	return baseline, existed
+}
+
+// skillsSummary walks skills/ and builds a markdown summary block.
+func (b *ContextBuilder) skillsSummary(skillsDir string) string {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return ""
+	}
+
+	var lines []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		skillFile := filepath.Join(skillsDir, e.Name(), "SKILL.md")
+		content, ok := b.readFileIfExists(skillFile)
+		if !ok {
+			continue
+		}
+		desc := firstDescriptionLine(content)
+		if desc == "" {
+			desc = e.Name()
+		}
+		lines = append(lines, "- **"+e.Name()+"**: "+desc)
+	}
+
+	if len(lines) == 0 {
+		return ""
+	}
+	return "## Skills\n\n" + strings.Join(lines, "\n")
+}
+
+// readFileIfExists returns the file content and whether the file existed.
+func (b *ContextBuilder) readFileIfExists(path string) (string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(data)), true
+}
+
+// parseMarkdownBody strips YAML frontmatter (--- ... ---) from markdown content
+// and returns only the body.
+func parseMarkdownBody(content string) string {
+	content = strings.TrimSpace(content)
+	if !strings.HasPrefix(content, "---") {
+		return content
+	}
+	// Skip the opening ---
+	rest := content[3:]
+	// Find the closing ---
+	idx := strings.Index(rest, "\n---")
+	if idx == -1 {
+		return content
+	}
+	body := strings.TrimSpace(rest[idx+4:])
+	return body
+}
+
+// firstDescriptionLine returns the first non-blank, non-frontmatter line from
+// a SKILL.md file suitable for use as a one-line description.
+func firstDescriptionLine(content string) string {
+	body := parseMarkdownBody(content)
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Strip leading markdown list/emphasis markers for cleanliness.
+		line = strings.TrimLeft(line, "-*> ")
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -30,10 +30,28 @@ func BuildAgent(cfg *config.Config, tools []interfaces.Tool) (*agentsdk.Agent, e
 		return nil, fmt.Errorf("create LLM: %w", err)
 	}
 
+	systemPrompt := "You are Sushiclaw, a helpful personal AI assistant."
+	if ws := cfg.WorkspacePath(); ws != "" {
+		cb := NewContextBuilder(ws)
+		if p, err := cb.BuildSystemPromptWithCache(); err == nil && p != "" {
+			systemPrompt = p
+		}
+	}
+
+	toolNames := make([]string, len(tools))
+	for i, t := range tools {
+		toolNames[i] = t.Name()
+	}
+	logger.DebugCF("agent", "Building agent", map[string]any{
+		"workspace":     cfg.WorkspacePath(),
+		"prompt_length": len(systemPrompt),
+		"tools":         toolNames,
+	})
+
 	a, err := agentsdk.NewAgent(
 		agentsdk.WithName("sushiclaw"),
 		agentsdk.WithLLM(llmClient),
-		agentsdk.WithSystemPrompt("You are Sushiclaw, a helpful personal AI assistant."),
+		agentsdk.WithSystemPrompt(systemPrompt),
 		agentsdk.WithTools(tools...),
 		agentsdk.WithMemory(NewInMemoryMemory()),
 	)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -223,12 +223,22 @@ func LoadConfig(path string) (*Config, error) {
 	return &cfg, nil
 }
 
-// WorkspacePath returns the agent workspace directory.
+// WorkspacePath returns the agent workspace directory with ~ expanded.
 func (c *Config) WorkspacePath() string {
-	if c.Agents.Defaults.Workspace != "" {
-		return c.Agents.Defaults.Workspace
+	p := c.Agents.Defaults.Workspace
+	if p == "" {
+		p = GetHome() + "/workspace"
 	}
-	return GetHome() + "/workspace"
+	return expandHome(p)
+}
+
+// expandHome replaces a leading ~ with the user's home directory.
+func expandHome(p string) string {
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		home, _ := os.UserHomeDir()
+		return home + p[1:]
+	}
+	return p
 }
 
 // Voice returns a zero VoiceConfig (sushiclaw doesn't configure voice globally).

--- a/workspace/AGENT.md
+++ b/workspace/AGENT.md
@@ -1,0 +1,45 @@
+---
+name: pico
+description: >
+  The default general-purpose assistant for everyday conversation, problem
+  solving, and workspace help.
+---
+
+You are Pico, the default assistant for this workspace.
+Your name is PicoClaw 🦞.
+## Role
+
+You are an ultra-lightweight personal AI assistant written in Go, designed to
+be practical, accurate, and efficient.
+
+## Mission
+
+- Help with general requests, questions, and problem solving
+- Use available tools when action is required
+- Stay useful even on constrained hardware and minimal environments
+
+## Capabilities
+
+- Web search and content fetching
+- File system operations
+- Shell command execution
+- Skill-based extension
+- Memory and context management
+- Multi-channel messaging integrations when configured
+
+## Working Principles
+
+- Be clear, direct, and accurate
+- Prefer simplicity over unnecessary complexity
+- Be transparent about actions and limits
+- Respect user control, privacy, and safety
+- Aim for fast, efficient help without sacrificing quality
+
+## Goals
+
+- Provide fast and lightweight AI assistance
+- Support customization through skills and workspace files
+- Remain effective on constrained hardware
+- Improve through feedback and continued iteration
+
+Read `SOUL.md` as part of your identity and communication style.

--- a/workspace/SOUL.md
+++ b/workspace/SOUL.md
@@ -1,0 +1,19 @@
+# Soul
+
+I am PicoClaw: calm, helpful, and practical.
+
+## Personality
+
+- Helpful and friendly
+- Concise and to the point
+- Curious and eager to learn
+- Honest and transparent
+- Calm under uncertainty
+
+## Values
+
+- Accuracy over speed
+- User privacy and safety
+- Transparency in actions
+- Continuous improvement
+- Simplicity over unnecessary complexity

--- a/workspace/USER.md
+++ b/workspace/USER.md
@@ -1,0 +1,21 @@
+# User
+
+Information about the user goes here.
+
+## Preferences
+
+- Communication style: (casual/formal)
+- Timezone: (your timezone)
+- Language: (your preferred language)
+
+## Personal Information
+
+- Name: (optional)
+- Location: (optional)
+- Occupation: (optional)
+
+## Learning Goals
+
+- What the user wants to learn from AI
+- Preferred interaction style
+- Areas of interest

--- a/workspace/memory/MEMORY.md
+++ b/workspace/memory/MEMORY.md
@@ -1,0 +1,21 @@
+# Long-term Memory
+
+This file stores important information that should persist across sessions.
+
+## User Information
+
+(Important facts about user)
+
+## Preferences
+
+(User preferences learned over time)
+
+## Important Notes
+
+(Things to remember)
+
+## Configuration
+
+- Model preferences
+- Channel settings
+- Skills enabled

--- a/workspace/skills/agent-browser/SKILL.md
+++ b/workspace/skills/agent-browser/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: agent-browser
+description: "Browser automation via agent-browser CLI. Use when the user needs to navigate websites, fill forms, click buttons, take screenshots, extract data, or test web apps."
+metadata: {"nanobot":{"emoji":"🌐","requires":{"bins":["agent-browser"]},"install":[{"id":"npm","kind":"npm","package":"agent-browser","global":true,"bins":["agent-browser"],"label":"Install agent-browser (npm)"}]}}
+---
+
+# Agent Browser
+
+CLI browser automation via Chrome/Chromium CDP. Install: `npm i -g agent-browser && agent-browser install`.
+
+**Before using this skill**, verify the tool is available by running `which agent-browser`. If the command is not found, tell the user that browser automation requires the `agent-browser` CLI and Chromium, which are only available in the heavy container image. Do not attempt to install it at runtime.
+
+## Core Workflow
+
+1. `agent-browser open <url>` — navigate
+2. `agent-browser snapshot -i` — get interactive elements with refs (`@e1`, `@e2`, ...)
+3. Interact using refs — `click @e1`, `fill @e2 "text"`
+4. Re-snapshot after any navigation or DOM change — refs are invalidated
+
+```bash
+agent-browser open https://example.com/form
+agent-browser snapshot -i
+# @e1 [input] "Email", @e2 [input] "Password", @e3 [button] "Submit"
+agent-browser fill @e1 "user@example.com"
+agent-browser fill @e2 "secret"
+agent-browser click @e3
+agent-browser wait --load networkidle
+agent-browser snapshot -i
+```
+
+Chain commands with `&&` when you don't need intermediate output:
+```bash
+agent-browser open https://example.com && agent-browser wait --load networkidle && agent-browser snapshot -i
+```
+
+## Commands
+
+```bash
+# Navigation
+agent-browser open <url>
+agent-browser close
+
+# Snapshot
+agent-browser snapshot -i                # Interactive elements with refs
+agent-browser snapshot -s "#selector"    # Scope to CSS selector
+
+# Interaction (use @refs from snapshot)
+agent-browser click @e1
+agent-browser fill @e2 "text"            # Clear + type
+agent-browser type @e2 "text"            # Type without clearing
+agent-browser select @e1 "option"
+agent-browser check @e1
+agent-browser press Enter
+agent-browser scroll down 500
+
+# Get info
+agent-browser get text @e1
+agent-browser get url
+agent-browser get title
+
+# Wait
+agent-browser wait @e1                   # Wait for element
+agent-browser wait --load networkidle    # Wait for network idle
+agent-browser wait --url "**/dashboard"  # Wait for URL pattern
+agent-browser wait --text "Welcome"      # Wait for text
+agent-browser wait 2000                  # Wait ms
+
+# Capture
+agent-browser screenshot                 # Screenshot to temp dir
+agent-browser screenshot --full          # Full page
+agent-browser screenshot --annotate      # With numbered element labels ([N] -> @eN)
+agent-browser pdf output.pdf
+
+# Semantic locators (when refs unavailable)
+agent-browser find text "Sign In" click
+agent-browser find label "Email" fill "user@test.com"
+agent-browser find role button click --name "Submit"
+```
+
+## Authentication
+
+```bash
+# Option 1: Import from user's running Chrome
+agent-browser --auto-connect state save ./auth.json
+agent-browser --state ./auth.json open https://app.example.com
+
+# Option 2: Persistent profile
+agent-browser --profile ~/.myapp open https://app.example.com/login
+# ... login once, all future runs are authenticated
+
+# Option 3: Session name (auto-save/restore)
+agent-browser --session-name myapp open https://app.example.com/login
+# ... login, close, next run state is restored
+
+# Option 4: State file
+agent-browser state save auth.json
+agent-browser state load auth.json
+```
+
+## Iframes
+
+Iframe content is inlined in snapshots. Interact with iframe refs directly — no frame switch needed.
+
+## Parallel Sessions
+
+```bash
+agent-browser --session s1 open https://site-a.com
+agent-browser --session s2 open https://site-b.com
+agent-browser session list
+```
+
+## JavaScript Eval
+
+```bash
+agent-browser eval 'document.title'
+
+# Complex JS — use --stdin to avoid shell quoting issues
+agent-browser eval --stdin <<'EVALEOF'
+JSON.stringify(Array.from(document.querySelectorAll("a")).map(a => a.href))
+EVALEOF
+```
+
+## Cleanup
+
+Always close sessions when done:
+```bash
+agent-browser close
+agent-browser --session s1 close
+```

--- a/workspace/skills/github/SKILL.md
+++ b/workspace/skills/github/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: github
+description: "Interact with GitHub using the `gh` CLI. Use `gh issue`, `gh pr`, `gh run`, and `gh api` for issues, PRs, CI runs, and advanced queries."
+metadata: {"nanobot":{"emoji":"🐙","requires":{"bins":["gh"]},"install":[{"id":"brew","kind":"brew","formula":"gh","bins":["gh"],"label":"Install GitHub CLI (brew)"},{"id":"apt","kind":"apt","package":"gh","bins":["gh"],"label":"Install GitHub CLI (apt)"}]}}
+---
+
+# GitHub Skill
+
+Use the `gh` CLI to interact with GitHub. Always specify `--repo owner/repo` when not in a git directory, or use URLs directly.
+
+## Pull Requests
+
+Check CI status on a PR:
+```bash
+gh pr checks 55 --repo owner/repo
+```
+
+List recent workflow runs:
+```bash
+gh run list --repo owner/repo --limit 10
+```
+
+View a run and see which steps failed:
+```bash
+gh run view <run-id> --repo owner/repo
+```
+
+View logs for failed steps only:
+```bash
+gh run view <run-id> --repo owner/repo --log-failed
+```
+
+## API for Advanced Queries
+
+The `gh api` command is useful for accessing data not available through other subcommands.
+
+Get PR with specific fields:
+```bash
+gh api repos/owner/repo/pulls/55 --jq '.title, .state, .user.login'
+```
+
+## JSON Output
+
+Most commands support `--json` for structured output.  You can use `--jq` to filter:
+
+```bash
+gh issue list --repo owner/repo --json number,title --jq '.[] | "\(.number): \(.title)"'
+```

--- a/workspace/skills/hardware/SKILL.md
+++ b/workspace/skills/hardware/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: hardware
+description: Read and control I2C and SPI peripherals on Sipeed boards (LicheeRV Nano, MaixCAM, NanoKVM).
+homepage: https://wiki.sipeed.com/hardware/en/lichee/RV_Nano/1_intro.html
+metadata: {"nanobot":{"emoji":"🔧","requires":{"tools":["i2c","spi"]}}}
+---
+
+# Hardware (I2C / SPI)
+
+Use the `i2c` and `spi` tools to interact with sensors, displays, and other peripherals connected to the board.
+
+## Quick Start
+
+```
+# 1. Find available buses
+i2c detect
+
+# 2. Scan for connected devices
+i2c scan  (bus: "1")
+
+# 3. Read from a sensor (e.g. AHT20 temperature/humidity)
+i2c read  (bus: "1", address: 0x38, register: 0xAC, length: 6)
+
+# 4. SPI devices
+spi list
+spi read  (device: "2.0", length: 4)
+```
+
+## Before You Start — Pinmux Setup
+
+Most I2C/SPI pins are shared with WiFi on Sipeed boards. You must configure pinmux before use.
+
+See `references/board-pinout.md` for board-specific commands.
+
+**Common steps:**
+1. Stop WiFi if using shared pins: `/etc/init.d/S30wifi stop`
+2. Load i2c-dev module: `modprobe i2c-dev`
+3. Configure pinmux with `devmem` (board-specific)
+4. Verify with `i2c detect` and `i2c scan`
+
+## Safety
+
+- **Write operations** require `confirm: true` — always confirm with the user first
+- I2C addresses are validated to 7-bit range (0x03-0x77)
+- SPI modes are validated (0-3 only)
+- Maximum per-transaction: 256 bytes (I2C), 4096 bytes (SPI)
+
+## Common Devices
+
+See `references/common-devices.md` for register maps and usage of popular sensors:
+AHT20, BME280, SSD1306 OLED, MPU6050 IMU, DS3231 RTC, INA219 power monitor, PCA9685 PWM, and more.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| No I2C buses found | `modprobe i2c-dev` and check device tree |
+| Permission denied | Run as root or add user to `i2c` group |
+| No devices on scan | Check wiring, pull-up resistors (4.7k typical), and pinmux |
+| Bus number changed | I2C adapter numbers can shift between boots; use `i2c detect` to find current assignment |
+| WiFi stopped working | I2C-1/SPI-2 share pins with WiFi SDIO; can't use both simultaneously |
+| `devmem` not found | Download separately or use `busybox devmem` |
+| SPI transfer returns all zeros | Check MISO wiring and device power |
+| SPI transfer returns all 0xFF | Device not responding; check CS pin and clock polarity (mode) |

--- a/workspace/skills/hardware/references/board-pinout.md
+++ b/workspace/skills/hardware/references/board-pinout.md
@@ -1,0 +1,131 @@
+# Board Pinout & Pinmux Reference
+
+## LicheeRV Nano (SG2002)
+
+### I2C Buses
+
+| Bus | Pins | Notes |
+|-----|------|-------|
+| I2C-1 | P18 (SCL), P21 (SDA) | **Shared with WiFi SDIO** — must stop WiFi first |
+| I2C-3 | Available on header | Check device tree for pin assignment |
+| I2C-5 | Software (BitBang) | Slower but no pin conflicts |
+
+### SPI Buses
+
+| Bus | Pins | Notes |
+|-----|------|-------|
+| SPI-2 | P18 (CS), P21 (MISO), P22 (MOSI), P23 (SCK) | **Shared with WiFi** — must stop WiFi first |
+| SPI-4 | Software (BitBang) | Slower but no pin conflicts |
+
+### Setup Steps for I2C-1
+
+```bash
+# 1. Stop WiFi (shares pins with I2C-1)
+/etc/init.d/S30wifi stop
+
+# 2. Configure pinmux for I2C-1
+devmem 0x030010D0 b 0x2   # P18 → I2C1_SCL
+devmem 0x030010DC b 0x2   # P21 → I2C1_SDA
+
+# 3. Load i2c-dev module
+modprobe i2c-dev
+
+# 4. Verify
+ls /dev/i2c-*
+```
+
+### Setup Steps for SPI-2
+
+```bash
+# 1. Stop WiFi (shares pins with SPI-2)
+/etc/init.d/S30wifi stop
+
+# 2. Configure pinmux for SPI-2
+devmem 0x030010D0 b 0x1   # P18 → SPI2_CS
+devmem 0x030010DC b 0x1   # P21 → SPI2_MISO
+devmem 0x030010E0 b 0x1   # P22 → SPI2_MOSI
+devmem 0x030010E4 b 0x1   # P23 → SPI2_SCK
+
+# 3. Verify
+ls /dev/spidev*
+```
+
+### Max Tested SPI Speed
+- SPI-2 hardware: tested up to **93 MHz**
+- `spidev_test` is pre-installed on the official image for loopback testing
+
+---
+
+## MaixCAM
+
+### I2C Buses
+
+| Bus | Pins | Notes |
+|-----|------|-------|
+| I2C-1 | Overlaps with WiFi | Not recommended |
+| I2C-3 | Overlaps with WiFi | Not recommended |
+| I2C-5 | A15 (SCL), A27 (SDA) | **Recommended** — software I2C, no conflicts |
+
+### Setup Steps for I2C-5
+
+```bash
+# Configure pins using pinmap utility
+# (MaixCAM uses a pinmap tool instead of devmem)
+# Refer to: https://wiki.sipeed.com/hardware/en/maixcam/gpio.html
+
+# Load i2c-dev
+modprobe i2c-dev
+
+# Verify
+ls /dev/i2c-*
+```
+
+---
+
+## MaixCAM2
+
+### I2C Buses
+
+| Bus | Pins | Notes |
+|-----|------|-------|
+| I2C-6 | A1 (SCL), A0 (SDA) | Available on header |
+| I2C-7 | Available | Check device tree |
+
+### Setup Steps
+
+```bash
+# Configure pinmap for I2C-6
+# A1 → I2C6_SCL, A0 → I2C6_SDA
+# Refer to MaixCAM2 documentation for pinmap commands
+
+modprobe i2c-dev
+ls /dev/i2c-*
+```
+
+---
+
+## NanoKVM
+
+Uses the same SG2002 SoC as LicheeRV Nano. GPIO and I2C access follows the same pinmux procedure. Refer to the LicheeRV Nano section above.
+
+Check NanoKVM-specific pin headers for available I2C/SPI lines:
+- https://wiki.sipeed.com/hardware/en/kvm/NanoKVM/introduction.html
+
+---
+
+## Common Issues
+
+### devmem not found
+The `devmem` utility may not be in the default image. Options:
+- Use `busybox devmem` if busybox is installed
+- Download devmem from the Sipeed package repository
+- Cross-compile from source (single C file)
+
+### Dynamic bus numbering
+I2C adapter numbers can change between boots depending on driver load order. Always use `i2c detect` to find current bus assignments rather than hardcoding bus numbers.
+
+### Permissions
+`/dev/i2c-*` and `/dev/spidev*` typically require root access. Options:
+- Run picoclaw as root
+- Add user to `i2c` and `spi` groups
+- Create udev rules: `SUBSYSTEM=="i2c-dev", MODE="0666"`

--- a/workspace/skills/hardware/references/common-devices.md
+++ b/workspace/skills/hardware/references/common-devices.md
@@ -1,0 +1,78 @@
+# Common I2C/SPI Device Reference
+
+## I2C Devices
+
+### AHT20 — Temperature & Humidity
+- **Address:** 0x38
+- **Init:** Write `[0xBE, 0x08, 0x00]` then wait 10ms
+- **Measure:** Write `[0xAC, 0x33, 0x00]`, wait 80ms, read 6 bytes
+- **Parse:** Status=byte[0], Humidity=(byte[1]<<12|byte[2]<<4|byte[3]>>4)/2^20*100, Temp=(byte[3]&0x0F<<16|byte[4]<<8|byte[5])/2^20*200-50
+- **Notes:** No register addressing — write command bytes directly (omit `register` param)
+
+### BME280 / BMP280 — Temperature, Humidity, Pressure
+- **Address:** 0x76 or 0x77 (SDO pin selects)
+- **Chip ID register:** 0xD0 → BMP280=0x58, BME280=0x60
+- **Data registers:** 0xF7-0xFE (pressure, temperature, humidity)
+- **Config:** Write 0xF2 (humidity oversampling), 0xF4 (temp/press oversampling + mode), 0xF5 (standby, filter)
+- **Forced measurement:** Write `[0x25]` to register 0xF4, wait 40ms, read 8 bytes from 0xF7
+- **Calibration:** Read 26 bytes from 0x88 and 7 bytes from 0xE1 for compensation formulas
+- **Also available via SPI** (mode 0 or 3)
+
+### SSD1306 — 128x64 OLED Display
+- **Address:** 0x3C (or 0x3D if SA0 high)
+- **Command prefix:** 0x00 (write to register 0x00)
+- **Data prefix:** 0x40 (write to register 0x40)
+- **Init sequence:** `[0xAE, 0xD5, 0x80, 0xA8, 0x3F, 0xD3, 0x00, 0x40, 0x8D, 0x14, 0x20, 0x00, 0xA1, 0xC8, 0xDA, 0x12, 0x81, 0xCF, 0xD9, 0xF1, 0xDB, 0x40, 0xA4, 0xA6, 0xAF]`
+- **Display on:** 0xAF, **Display off:** 0xAE
+- **Also available via SPI** (faster, recommended for animations)
+
+### MPU6050 — 6-axis Accelerometer + Gyroscope
+- **Address:** 0x68 (or 0x69 if AD0 high)
+- **WHO_AM_I:** Register 0x75 → should return 0x68
+- **Wake up:** Write `[0x00]` to register 0x6B (clear sleep bit)
+- **Read accel:** 6 bytes from register 0x3B (XH,XL,YH,YL,ZH,ZL) — signed 16-bit, default ±2g
+- **Read gyro:** 6 bytes from register 0x43 — signed 16-bit, default ±250°/s
+- **Read temp:** 2 bytes from register 0x41 — Temp°C = value/340 + 36.53
+
+### DS3231 — Real-Time Clock
+- **Address:** 0x68
+- **Read time:** 7 bytes from register 0x00 (seconds, minutes, hours, day, date, month, year) — BCD encoded
+- **Set time:** Write 7 BCD bytes to register 0x00
+- **Temperature:** 2 bytes from register 0x11 (signed, 0.25°C resolution)
+- **Status:** Register 0x0F — bit 2 = busy, bit 0 = alarm 1 flag
+
+### INA219 — Current & Power Monitor
+- **Address:** 0x40-0x4F (A0,A1 pin selectable)
+- **Config:** Register 0x00 — set voltage range, gain, ADC resolution
+- **Shunt voltage:** Register 0x01 (signed 16-bit, LSB=10µV)
+- **Bus voltage:** Register 0x02 (bits 15:3, LSB=4mV)
+- **Power:** Register 0x03 (after calibration)
+- **Current:** Register 0x04 (after calibration)
+- **Calibration:** Register 0x05 — set based on shunt resistor value
+
+### PCA9685 — 16-Channel PWM / Servo Controller
+- **Address:** 0x40-0x7F (A0-A5 selectable, default 0x40)
+- **Mode 1:** Register 0x00 — bit 4=sleep, bit 5=auto-increment
+- **Set PWM freq:** Sleep → write prescale to 0xFE → wake. Prescale = round(25MHz / (4096 × freq)) - 1
+- **Channel N on/off:** Registers 0x06+4*N to 0x09+4*N (ON_L, ON_H, OFF_L, OFF_H)
+- **Servo 0°-180°:** ON=0, OFF=150-600 (at 50Hz). Typical: 0°=150, 90°=375, 180°=600
+
+### AT24C256 — 256Kbit EEPROM
+- **Address:** 0x50-0x57 (A0-A2 selectable)
+- **Read:** Write 2-byte address (high, low), then read N bytes
+- **Write:** Write 2-byte address + up to 64 bytes (page write), wait 5ms for write cycle
+- **Page size:** 64 bytes. Writes that cross page boundary wrap around.
+
+## SPI Devices
+
+### MCP3008 — 8-Channel 10-bit ADC
+- **Interface:** SPI mode 0, max 3.6 MHz @ 5V
+- **Read channel N:** Send `[0x01, (0x80 | N<<4), 0x00]`, result in last 10 bits of bytes 1-2
+- **Formula:** value = ((byte[1] & 0x03) << 8) | byte[2]
+- **Voltage:** value × Vref / 1024
+
+### W25Q128 — 128Mbit SPI Flash
+- **Interface:** SPI mode 0 or 3, up to 104 MHz
+- **Read ID:** Send `[0x9F, 0, 0, 0]` → manufacturer + device ID
+- **Read data:** Send `[0x03, addr_high, addr_mid, addr_low]` + N zero bytes
+- **Status:** Send `[0x05, 0]` → bit 0 = BUSY

--- a/workspace/skills/skill-creator/SKILL.md
+++ b/workspace/skills/skill-creator/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: skill-creator
+description: Create or update AgentSkills. Use when designing, structuring, or packaging skills with scripts, references, and assets.
+---
+
+# Skill Creator
+
+This skill provides guidance for creating effective skills.
+
+## About Skills
+
+Skills are modular, self-contained packages that extend the agent's capabilities by providing
+specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific
+domains or tasks—they transform the agent from a general-purpose agent into a specialized agent
+equipped with procedural knowledge that no model can fully possess.
+
+### What Skills Provide
+
+1. Specialized workflows - Multi-step procedures for specific domains
+2. Tool integrations - Instructions for working with specific file formats or APIs
+3. Domain expertise - Company-specific knowledge, schemas, business logic
+4. Bundled resources - Scripts, references, and assets for complex and repetitive tasks
+
+## Core Principles
+
+### Concise is Key
+
+The context window is a public good. Skills share the context window with everything else the agent needs: system prompt, conversation history, other Skills' metadata, and the actual user request.
+
+**Default assumption: the agent is already very smart.** Only add context the agent doesn't already have. Challenge each piece of information: "Does the agent really need this explanation?" and "Does this paragraph justify its token cost?"
+
+Prefer concise examples over verbose explanations.
+
+### Set Appropriate Degrees of Freedom
+
+Match the level of specificity to the task's fragility and variability:
+
+**High freedom (text-based instructions)**: Use when multiple approaches are valid, decisions depend on context, or heuristics guide the approach.
+
+**Medium freedom (pseudocode or scripts with parameters)**: Use when a preferred pattern exists, some variation is acceptable, or configuration affects behavior.
+
+**Low freedom (specific scripts, few parameters)**: Use when operations are fragile and error-prone, consistency is critical, or a specific sequence must be followed.
+
+Think of the agent as exploring a path: a narrow bridge with cliffs needs specific guardrails (low freedom), while an open field allows many routes (high freedom).
+
+### Anatomy of a Skill
+
+Every skill consists of a required SKILL.md file and optional bundled resources:
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter metadata (required)
+│   │   ├── name: (required)
+│   │   └── description: (required)
+│   └── Markdown instructions (required)
+└── Bundled Resources (optional)
+    ├── scripts/          - Executable code (Python/Bash/etc.)
+    ├── references/       - Documentation intended to be loaded into context as needed
+    └── assets/           - Files used in output (templates, icons, fonts, etc.)
+```
+
+#### SKILL.md (required)
+
+Every SKILL.md consists of:
+
+- **Frontmatter** (YAML): Contains `name` and `description` fields. These are the only fields that the agent reads to determine when the skill gets used, thus it is very important to be clear and comprehensive in describing what the skill is, and when it should be used.
+- **Body** (Markdown): Instructions and guidance for using the skill. Only loaded AFTER the skill triggers (if at all).
+
+#### Bundled Resources (optional)
+
+##### Scripts (`scripts/`)
+
+Executable code (Python/Bash/etc.) for tasks that require deterministic reliability or are repeatedly rewritten.
+
+- **When to include**: When the same code is being rewritten repeatedly or deterministic reliability is needed
+- **Example**: `scripts/rotate_pdf.py` for PDF rotation tasks
+- **Benefits**: Token efficient, deterministic, may be executed without loading into context
+- **Note**: Scripts may still need to be read by the agent for patching or environment-specific adjustments
+
+##### References (`references/`)
+
+Documentation and reference material intended to be loaded as needed into context to inform the agent's process and thinking.
+
+- **When to include**: For documentation that the agent should reference while working
+- **Examples**: `references/finance.md` for financial schemas, `references/mnda.md` for company NDA template, `references/policies.md` for company policies, `references/api_docs.md` for API specifications
+- **Use cases**: Database schemas, API documentation, domain knowledge, company policies, detailed workflow guides
+- **Benefits**: Keeps SKILL.md lean, loaded only when the agent determines it's needed
+- **Best practice**: If files are large (>10k words), include grep search patterns in SKILL.md
+- **Avoid duplication**: Information should live in either SKILL.md or references files, not both. Prefer references files for detailed information unless it's truly core to the skill—this keeps SKILL.md lean while making information discoverable without hogging the context window. Keep only essential procedural instructions and workflow guidance in SKILL.md; move detailed reference material, schemas, and examples to references files.
+
+##### Assets (`assets/`)
+
+Files not intended to be loaded into context, but rather used within the output the agent produces.
+
+- **When to include**: When the skill needs files that will be used in the final output
+- **Examples**: `assets/logo.png` for brand assets, `assets/slides.pptx` for PowerPoint templates, `assets/frontend-template/` for HTML/React boilerplate, `assets/font.ttf` for typography
+- **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
+- **Benefits**: Separates output resources from documentation, enables the agent to use files without loading them into context
+
+#### What to Not Include in a Skill
+
+A skill should only contain essential files that directly support its functionality. Do NOT create extraneous documentation or auxiliary files, including:
+
+- README.md
+- INSTALLATION_GUIDE.md
+- QUICK_REFERENCE.md
+- CHANGELOG.md
+- etc.
+
+The skill should only contain the information needed for an AI agent to do the job at hand. It should not contain auxiliary context about the process that went into creating it, setup and testing procedures, user-facing documentation, etc. Creating additional documentation files just adds clutter and confusion.
+
+### Progressive Disclosure Design Principle
+
+Skills use a three-level loading system to manage context efficiently:
+
+1. **Metadata (name + description)** - Always in context (~100 words)
+2. **SKILL.md body** - When skill triggers (<5k words)
+3. **Bundled resources** - As needed by the agent (Unlimited because scripts can be executed without reading into context window)
+
+#### Progressive Disclosure Patterns
+
+Keep SKILL.md body to the essentials and under 500 lines to minimize context bloat. Split content into separate files when approaching this limit. When splitting out content into other files, it is very important to reference them from SKILL.md and describe clearly when to read them, to ensure the reader of the skill knows they exist and when to use them.
+
+**Key principle:** When a skill supports multiple variations, frameworks, or options, keep only the core workflow and selection guidance in SKILL.md. Move variant-specific details (patterns, examples, configuration) into separate reference files.
+
+**Pattern 1: High-level guide with references**
+
+```markdown
+# PDF Processing
+
+## Quick start
+
+Extract text with pdfplumber:
+[code example]
+
+## Advanced features
+
+- **Form filling**: See [FORMS.md](FORMS.md) for complete guide
+- **API reference**: See [REFERENCE.md](REFERENCE.md) for all methods
+- **Examples**: See [EXAMPLES.md](EXAMPLES.md) for common patterns
+```
+
+the agent loads FORMS.md, REFERENCE.md, or EXAMPLES.md only when needed.
+
+**Pattern 2: Domain-specific organization**
+
+For Skills with multiple domains, organize content by domain to avoid loading irrelevant context:
+
+```
+bigquery-skill/
+├── SKILL.md (overview and navigation)
+└── reference/
+    ├── finance.md (revenue, billing metrics)
+    ├── sales.md (opportunities, pipeline)
+    ├── product.md (API usage, features)
+    └── marketing.md (campaigns, attribution)
+```
+
+When a user asks about sales metrics, the agent only reads sales.md.
+
+Similarly, for skills supporting multiple frameworks or variants, organize by variant:
+
+```
+cloud-deploy/
+├── SKILL.md (workflow + provider selection)
+└── references/
+    ├── aws.md (AWS deployment patterns)
+    ├── gcp.md (GCP deployment patterns)
+    └── azure.md (Azure deployment patterns)
+```
+
+When the user chooses AWS, the agent only reads aws.md.
+
+**Pattern 3: Conditional details**
+
+Show basic content, link to advanced content:
+
+```markdown
+# DOCX Processing
+
+## Creating documents
+
+Use docx-js for new documents. See [DOCX-JS.md](DOCX-JS.md).
+
+## Editing documents
+
+For simple edits, modify the XML directly.
+
+**For tracked changes**: See [REDLINING.md](REDLINING.md)
+**For OOXML details**: See [OOXML.md](OOXML.md)
+```
+
+the agent reads REDLINING.md or OOXML.md only when the user needs those features.
+
+**Important guidelines:**
+
+- **Avoid deeply nested references** - Keep references one level deep from SKILL.md. All reference files should link directly from SKILL.md.
+- **Structure longer reference files** - For files longer than 100 lines, include a table of contents at the top so the agent can see the full scope when previewing.
+
+## Skill Creation Process
+
+Skill creation involves these steps:
+
+1. Understand the skill with concrete examples
+2. Plan reusable skill contents (scripts, references, assets)
+3. Initialize the skill (run init_skill.py)
+4. Edit the skill (implement resources and write SKILL.md)
+5. Package the skill (run package_skill.py)
+6. Iterate based on real usage
+
+Follow these steps in order, skipping only if there is a clear reason why they are not applicable.
+
+### Skill Naming
+
+- Use lowercase letters, digits, and hyphens only; normalize user-provided titles to hyphen-case (e.g., "Plan Mode" -> `plan-mode`).
+- When generating names, generate a name under 64 characters (letters, digits, hyphens).
+- Prefer short, verb-led phrases that describe the action.
+- Namespace by tool when it improves clarity or triggering (e.g., `gh-address-comments`, `linear-address-issue`).
+- Name the skill folder exactly after the skill name.
+
+### Step 1: Understanding the Skill with Concrete Examples
+
+Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
+
+To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
+
+For example, when building an image-editor skill, relevant questions include:
+
+- "What functionality should the image-editor skill support? Editing, rotating, anything else?"
+- "Can you give some examples of how this skill would be used?"
+- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
+- "What would a user say that should trigger this skill?"
+
+To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
+
+Conclude this step when there is a clear sense of the functionality the skill should support.
+
+### Step 2: Planning the Reusable Skill Contents
+
+To turn concrete examples into an effective skill, analyze each example by:
+
+1. Considering how to execute on the example from scratch
+2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
+
+Example: When building a `pdf-editor` skill to handle queries like "Help me rotate this PDF," the analysis shows:
+
+1. Rotating a PDF requires re-writing the same code each time
+2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
+
+Example: When designing a `frontend-webapp-builder` skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
+
+1. Writing a frontend webapp requires the same boilerplate HTML/React each time
+2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful to store in the skill
+
+Example: When building a `big-query` skill to handle queries like "How many users have logged in today?" the analysis shows:
+
+1. Querying BigQuery requires re-discovering the table schemas and relationships each time
+2. A `references/schema.md` file documenting the table schemas would be helpful to store in the skill
+
+To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
+
+### Step 3: Initializing the Skill
+
+At this point, it is time to actually create the skill.
+
+Skip this step only if the skill being developed already exists, and iteration or packaging is needed. In this case, continue to the next step.
+
+When creating a new skill from scratch, always run the `init_skill.py` script. The script conveniently generates a new template skill directory that automatically includes everything a skill requires, making the skill creation process much more efficient and reliable.
+
+Usage:
+
+```bash
+scripts/init_skill.py <skill-name> --path <output-directory> [--resources scripts,references,assets] [--examples]
+```
+
+Examples:
+
+```bash
+scripts/init_skill.py my-skill --path skills/public
+scripts/init_skill.py my-skill --path skills/public --resources scripts,references
+scripts/init_skill.py my-skill --path skills/public --resources scripts --examples
+```
+
+The script:
+
+- Creates the skill directory at the specified path
+- Generates a SKILL.md template with proper frontmatter and TODO placeholders
+- Optionally creates resource directories based on `--resources`
+- Optionally adds example files when `--examples` is set
+
+After initialization, customize the SKILL.md and add resources as needed. If you used `--examples`, replace or delete placeholder files.
+
+### Step 4: Edit the Skill
+
+When editing the (newly-generated or existing) skill, remember that the skill is being created for another instance of the agent to use. Include information that would be beneficial and non-obvious to the agent. Consider what procedural knowledge, domain-specific details, or reusable assets would help another the agent instance execute these tasks more effectively.
+
+#### Learn Proven Design Patterns
+
+Consult these helpful guides based on your skill's needs:
+
+- **Multi-step processes**: See references/workflows.md for sequential workflows and conditional logic
+- **Specific output formats or quality standards**: See references/output-patterns.md for template and example patterns
+
+These files contain established best practices for effective skill design.
+
+#### Start with Reusable Skill Contents
+
+To begin implementation, start with the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input. For example, when implementing a `brand-guidelines` skill, the user may need to provide brand assets or templates to store in `assets/`, or documentation to store in `references/`.
+
+Added scripts must be tested by actually running them to ensure there are no bugs and that the output matches what is expected. If there are many similar scripts, only a representative sample needs to be tested to ensure confidence that they all work while balancing time to completion.
+
+If you used `--examples`, delete any placeholder files that are not needed for the skill. Only create resource directories that are actually required.
+
+#### Update SKILL.md
+
+**Writing Guidelines:** Always use imperative/infinitive form.
+
+##### Frontmatter
+
+Write the YAML frontmatter with `name` and `description`:
+
+- `name`: The skill name
+- `description`: This is the primary triggering mechanism for your skill, and helps the agent understand when to use the skill.
+  - Include both what the Skill does and specific triggers/contexts for when to use it.
+  - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to the agent.
+  - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when the agent needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
+
+Do not include any other fields in YAML frontmatter.
+
+##### Body
+
+Write instructions for using the skill and its bundled resources.
+
+### Step 5: Packaging a Skill
+
+Once development of the skill is complete, it must be packaged into a distributable .skill file that gets shared with the user. The packaging process automatically validates the skill first to ensure it meets all requirements:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder>
+```
+
+Optional output directory specification:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder> ./dist
+```
+
+The packaging script will:
+
+1. **Validate** the skill automatically, checking:
+
+   - YAML frontmatter format and required fields
+   - Skill naming conventions and directory structure
+   - Description completeness and quality
+   - File organization and resource references
+
+2. **Package** the skill if validation passes, creating a .skill file named after the skill (e.g., `my-skill.skill`) that includes all files and maintains the proper directory structure for distribution. The .skill file is a zip file with a .skill extension.
+
+If validation fails, the script will report the errors and exit without creating a package. Fix any validation errors and run the packaging command again.
+
+### Step 6: Iterate
+
+After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
+
+**Iteration workflow:**
+
+1. Use the skill on real tasks
+2. Notice struggles or inefficiencies
+3. Identify how SKILL.md or bundled resources should be updated
+4. Implement changes and test again

--- a/workspace/skills/summarize/SKILL.md
+++ b/workspace/skills/summarize/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: summarize
+description: Summarize or extract text/transcripts from URLs, podcasts, and local files (great fallback for “transcribe this YouTube/video”).
+homepage: https://summarize.sh
+metadata: {"nanobot":{"emoji":"🧾","requires":{"bins":["summarize"]},"install":[{"id":"brew","kind":"brew","formula":"steipete/tap/summarize","bins":["summarize"],"label":"Install summarize (brew)"}]}}
+---
+
+# Summarize
+
+Fast CLI to summarize URLs, local files, and YouTube links.
+
+## When to use (trigger phrases)
+
+Use this skill immediately when the user asks any of:
+- “use summarize.sh”
+- “what’s this link/video about?”
+- “summarize this URL/article”
+- “transcribe this YouTube/video” (best-effort transcript extraction; no `yt-dlp` needed)
+
+## Quick start
+
+```bash
+summarize "https://example.com" --model google/gemini-3-flash-preview
+summarize "/path/to/file.pdf" --model google/gemini-3-flash-preview
+summarize "https://youtu.be/dQw4w9WgXcQ" --youtube auto
+```
+
+## YouTube: summary vs transcript
+
+Best-effort transcript (URLs only):
+
+```bash
+summarize "https://youtu.be/dQw4w9WgXcQ" --youtube auto --extract-only
+```
+
+If the user asked for a transcript but it’s huge, return a tight summary first, then ask which section/time range to expand.
+
+## Model + keys
+
+Set the API key for your chosen provider:
+- OpenAI: `OPENAI_API_KEY`
+- Anthropic: `ANTHROPIC_API_KEY`
+- xAI: `XAI_API_KEY`
+- Google: `GEMINI_API_KEY` (aliases: `GOOGLE_GENERATIVE_AI_API_KEY`, `GOOGLE_API_KEY`)
+
+Default model is `google/gemini-3-flash-preview` if none is set.
+
+## Useful flags
+
+- `--length short|medium|long|xl|xxl|<chars>`
+- `--max-output-tokens <count>`
+- `--extract-only` (URLs only)
+- `--json` (machine readable)
+- `--firecrawl auto|off|always` (fallback extraction)
+- `--youtube auto` (Apify fallback if `APIFY_API_TOKEN` set)
+
+## Config
+
+Optional config file: `~/.summarize/config.json`
+
+```json
+{ "model": "openai/gpt-5.4" }
+```
+
+Optional services:
+- `FIRECRAWL_API_KEY` for blocked sites
+- `APIFY_API_TOKEN` for YouTube fallback

--- a/workspace/skills/tmux/SKILL.md
+++ b/workspace/skills/tmux/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: tmux
+description: Remote-control tmux sessions for interactive CLIs by sending keystrokes and scraping pane output.
+metadata: {"nanobot":{"emoji":"🧵","os":["darwin","linux"],"requires":{"bins":["tmux"]}}}
+---
+
+# tmux Skill
+
+Use tmux only when you need an interactive TTY. Prefer exec background mode for long-running, non-interactive tasks.
+
+## Quickstart (isolated socket, exec tool)
+
+```bash
+SOCKET_DIR="${NANOBOT_TMUX_SOCKET_DIR:-${TMPDIR:-/tmp}/nanobot-tmux-sockets}"
+mkdir -p "$SOCKET_DIR"
+SOCKET="$SOCKET_DIR/nanobot.sock"
+SESSION=nanobot-python
+
+tmux -S "$SOCKET" new -d -s "$SESSION" -n shell
+tmux -S "$SOCKET" send-keys -t "$SESSION":0.0 -- 'PYTHON_BASIC_REPL=1 python3 -q' Enter
+tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":0.0 -S -200
+```
+
+After starting a session, always print monitor commands:
+
+```
+To monitor:
+  tmux -S "$SOCKET" attach -t "$SESSION"
+  tmux -S "$SOCKET" capture-pane -p -J -t "$SESSION":0.0 -S -200
+```
+
+## Socket convention
+
+- Use `NANOBOT_TMUX_SOCKET_DIR` environment variable.
+- Default socket path: `"$NANOBOT_TMUX_SOCKET_DIR/nanobot.sock"`.
+
+## Targeting panes and naming
+
+- Target format: `session:window.pane` (defaults to `:0.0`).
+- Keep names short; avoid spaces.
+- Inspect: `tmux -S "$SOCKET" list-sessions`, `tmux -S "$SOCKET" list-panes -a`.
+
+## Finding sessions
+
+- List sessions on your socket: `{baseDir}/scripts/find-sessions.sh -S "$SOCKET"`.
+- Scan all sockets: `{baseDir}/scripts/find-sessions.sh --all` (uses `NANOBOT_TMUX_SOCKET_DIR`).
+
+## Sending input safely
+
+- Prefer literal sends: `tmux -S "$SOCKET" send-keys -t target -l -- "$cmd"`.
+- Control keys: `tmux -S "$SOCKET" send-keys -t target C-c`.
+
+## Watching output
+
+- Capture recent history: `tmux -S "$SOCKET" capture-pane -p -J -t target -S -200`.
+- Wait for prompts: `{baseDir}/scripts/wait-for-text.sh -t session:0.0 -p 'pattern'`.
+- Attaching is OK; detach with `Ctrl+b d`.
+
+## Spawning processes
+
+- For python REPLs, set `PYTHON_BASIC_REPL=1` (non-basic REPL breaks send-keys flows).
+
+## Windows / WSL
+
+- tmux is supported on macOS/Linux. On Windows, use WSL and install tmux inside WSL.
+- This skill is gated to `darwin`/`linux` and requires `tmux` on PATH.
+
+## Orchestrating Coding Agents (Codex, Claude Code)
+
+tmux excels at running multiple coding agents in parallel:
+
+```bash
+SOCKET="${TMPDIR:-/tmp}/codex-army.sock"
+
+# Create multiple sessions
+for i in 1 2 3 4 5; do
+  tmux -S "$SOCKET" new-session -d -s "agent-$i"
+done
+
+# Launch agents in different workdirs
+tmux -S "$SOCKET" send-keys -t agent-1 "cd /tmp/project1 && codex --yolo 'Fix bug X'" Enter
+tmux -S "$SOCKET" send-keys -t agent-2 "cd /tmp/project2 && codex --yolo 'Fix bug Y'" Enter
+
+# Poll for completion (check if prompt returned)
+for sess in agent-1 agent-2; do
+  if tmux -S "$SOCKET" capture-pane -p -t "$sess" -S -3 | grep -q "❯"; then
+    echo "$sess: DONE"
+  else
+    echo "$sess: Running..."
+  fi
+done
+
+# Get full output from completed session
+tmux -S "$SOCKET" capture-pane -p -t agent-1 -S -500
+```
+
+**Tips:**
+- Use separate git worktrees for parallel fixes (no branch conflicts)
+- `pnpm install` first before running codex in fresh clones
+- Check for shell prompt (`❯` or `$`) to detect completion
+- Codex needs `--yolo` or `--full-auto` for non-interactive fixes
+
+## Cleanup
+
+- Kill a session: `tmux -S "$SOCKET" kill-session -t "$SESSION"`.
+- Kill all sessions on a socket: `tmux -S "$SOCKET" list-sessions -F '#{session_name}' | xargs -r -n1 tmux -S "$SOCKET" kill-session -t`.
+- Remove everything on the private socket: `tmux -S "$SOCKET" kill-server`.
+
+## Helper: wait-for-text.sh
+
+`{baseDir}/scripts/wait-for-text.sh` polls a pane for a regex (or fixed string) with a timeout.
+
+```bash
+{baseDir}/scripts/wait-for-text.sh -t session:0.0 -p 'pattern' [-F] [-T 20] [-i 0.5] [-l 2000]
+```
+
+- `-t`/`--target` pane target (required)
+- `-p`/`--pattern` regex to match (required); add `-F` for fixed string
+- `-T` timeout seconds (integer, default 15)
+- `-i` poll interval seconds (default 0.5)
+- `-l` history lines to search (integer, default 1000)

--- a/workspace/skills/tmux/scripts/find-sessions.sh
+++ b/workspace/skills/tmux/scripts/find-sessions.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: find-sessions.sh [-L socket-name|-S socket-path|-A] [-q pattern]
+
+List tmux sessions on a socket (default tmux socket if none provided).
+
+Options:
+  -L, --socket       tmux socket name (passed to tmux -L)
+  -S, --socket-path  tmux socket path (passed to tmux -S)
+  -A, --all          scan all sockets under NANOBOT_TMUX_SOCKET_DIR
+  -q, --query        case-insensitive substring to filter session names
+  -h, --help         show this help
+USAGE
+}
+
+socket_name=""
+socket_path=""
+query=""
+scan_all=false
+socket_dir="${NANOBOT_TMUX_SOCKET_DIR:-${TMPDIR:-/tmp}/nanobot-tmux-sockets}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -L|--socket)      socket_name="${2-}"; shift 2 ;;
+    -S|--socket-path) socket_path="${2-}"; shift 2 ;;
+    -A|--all)         scan_all=true; shift ;;
+    -q|--query)       query="${2-}"; shift 2 ;;
+    -h|--help)        usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ "$scan_all" == true && ( -n "$socket_name" || -n "$socket_path" ) ]]; then
+  echo "Cannot combine --all with -L or -S" >&2
+  exit 1
+fi
+
+if [[ -n "$socket_name" && -n "$socket_path" ]]; then
+  echo "Use either -L or -S, not both" >&2
+  exit 1
+fi
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux not found in PATH" >&2
+  exit 1
+fi
+
+list_sessions() {
+  local label="$1"; shift
+  local tmux_cmd=(tmux "$@")
+
+  if ! sessions="$("${tmux_cmd[@]}" list-sessions -F '#{session_name}\t#{session_attached}\t#{session_created_string}' 2>/dev/null)"; then
+    echo "No tmux server found on $label" >&2
+    return 1
+  fi
+
+  if [[ -n "$query" ]]; then
+    sessions="$(printf '%s\n' "$sessions" | grep -i -- "$query" || true)"
+  fi
+
+  if [[ -z "$sessions" ]]; then
+    echo "No sessions found on $label"
+    return 0
+  fi
+
+  echo "Sessions on $label:"
+  printf '%s\n' "$sessions" | while IFS=$'\t' read -r name attached created; do
+    attached_label=$([[ "$attached" == "1" ]] && echo "attached" || echo "detached")
+    printf '  - %s (%s, started %s)\n' "$name" "$attached_label" "$created"
+  done
+}
+
+if [[ "$scan_all" == true ]]; then
+  if [[ ! -d "$socket_dir" ]]; then
+    echo "Socket directory not found: $socket_dir" >&2
+    exit 1
+  fi
+
+  shopt -s nullglob
+  sockets=("$socket_dir"/*)
+  shopt -u nullglob
+
+  if [[ "${#sockets[@]}" -eq 0 ]]; then
+    echo "No sockets found under $socket_dir" >&2
+    exit 1
+  fi
+
+  exit_code=0
+  for sock in "${sockets[@]}"; do
+    if [[ ! -S "$sock" ]]; then
+      continue
+    fi
+    list_sessions "socket path '$sock'" -S "$sock" || exit_code=$?
+  done
+  exit "$exit_code"
+fi
+
+tmux_cmd=(tmux)
+socket_label="default socket"
+
+if [[ -n "$socket_name" ]]; then
+  tmux_cmd+=(-L "$socket_name")
+  socket_label="socket name '$socket_name'"
+elif [[ -n "$socket_path" ]]; then
+  tmux_cmd+=(-S "$socket_path")
+  socket_label="socket path '$socket_path'"
+fi
+
+list_sessions "$socket_label" "${tmux_cmd[@]:1}"

--- a/workspace/skills/tmux/scripts/wait-for-text.sh
+++ b/workspace/skills/tmux/scripts/wait-for-text.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: wait-for-text.sh -t target -p pattern [options]
+
+Poll a tmux pane for text and exit when found.
+
+Options:
+  -t, --target    tmux target (session:window.pane), required
+  -p, --pattern   regex pattern to look for, required
+  -F, --fixed     treat pattern as a fixed string (grep -F)
+  -T, --timeout   seconds to wait (integer, default: 15)
+  -i, --interval  poll interval in seconds (default: 0.5)
+  -l, --lines     number of history lines to inspect (integer, default: 1000)
+  -h, --help      show this help
+USAGE
+}
+
+target=""
+pattern=""
+grep_flag="-E"
+timeout=15
+interval=0.5
+lines=1000
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -t|--target)   target="${2-}"; shift 2 ;;
+    -p|--pattern)  pattern="${2-}"; shift 2 ;;
+    -F|--fixed)    grep_flag="-F"; shift ;;
+    -T|--timeout)  timeout="${2-}"; shift 2 ;;
+    -i|--interval) interval="${2-}"; shift 2 ;;
+    -l|--lines)    lines="${2-}"; shift 2 ;;
+    -h|--help)     usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$target" || -z "$pattern" ]]; then
+  echo "target and pattern are required" >&2
+  usage
+  exit 1
+fi
+
+if ! [[ "$timeout" =~ ^[0-9]+$ ]]; then
+  echo "timeout must be an integer number of seconds" >&2
+  exit 1
+fi
+
+if ! [[ "$lines" =~ ^[0-9]+$ ]]; then
+  echo "lines must be an integer" >&2
+  exit 1
+fi
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux not found in PATH" >&2
+  exit 1
+fi
+
+# End time in epoch seconds (integer, good enough for polling)
+start_epoch=$(date +%s)
+deadline=$((start_epoch + timeout))
+
+while true; do
+  # -J joins wrapped lines, -S uses negative index to read last N lines
+  pane_text="$(tmux capture-pane -p -J -t "$target" -S "-${lines}" 2>/dev/null || true)"
+
+  if printf '%s\n' "$pane_text" | grep $grep_flag -- "$pattern" >/dev/null 2>&1; then
+    exit 0
+  fi
+
+  now=$(date +%s)
+  if (( now >= deadline )); then
+    echo "Timed out after ${timeout}s waiting for pattern: $pattern" >&2
+    echo "Last ${lines} lines from $target:" >&2
+    printf '%s\n' "$pane_text" >&2
+    exit 1
+  fi
+
+  sleep "$interval"
+done

--- a/workspace/skills/weather/SKILL.md
+++ b/workspace/skills/weather/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: weather
+description: Get current weather and forecasts with verified location matching (no API key required).
+homepage: https://wttr.in/:help
+metadata: {"nanobot":{"emoji":"🌤️","requires":{"bins":["curl"]}}}
+---
+
+# Weather
+
+Use the most reliable location match first. For Chinese city names or other non-Latin input, prefer `wttr.in` with the original query because it resolves native names directly. Use Open-Meteo for structured current conditions and forecasts only after you have confirmed the exact city.
+
+## Accuracy Rules
+
+- Always restate the matched location, region/country, and observation time in the final answer.
+- Do not trust the first geocoding hit blindly. Check `country`, `admin1`, `admin2`, and `population`.
+- For Chinese city queries, do not send Hanzi directly to Open-Meteo geocoding unless the top result is obviously correct. Prefer `wttr.in` with the original Chinese name, or geocode the English/pinyin city name instead.
+- If multiple plausible matches remain, ask a follow-up question or state the assumption clearly.
+- Use `timezone=auto` when calling Open-Meteo so the reported time matches the location.
+
+## wttr.in (best for direct city-name queries)
+
+Quick current conditions:
+```bash
+curl -s "https://wttr.in/London?format=%l:+%c+%t+%h+%w"
+```
+
+Chinese city example:
+```bash
+curl -s "https://wttr.in/%E6%88%90%E9%83%BD?format=%l:+%c+%t+%h+%w"
+curl -s "https://wttr.in/%E4%B8%8A%E6%B5%B7?format=%l:+%c+%t+%h+%w"
+```
+
+JSON output if you need more detail:
+```bash
+curl -s "https://wttr.in/Chengdu?format=j1"
+```
+
+Tips:
+- URL-encode spaces: `New York` -> `New+York`
+- URL-encode non-ASCII text before sending the request
+- Use `?m` for metric units and `?u` for US units
+
+## Open-Meteo (best for structured forecasts)
+
+1. Geocode the city and verify the returned location metadata:
+```bash
+curl -s "https://geocoding-api.open-meteo.com/v1/search?name=Chengdu&count=3&language=en&format=json"
+```
+
+2. Query current weather and today's forecast with the verified coordinates:
+```bash
+curl -s "https://api.open-meteo.com/v1/forecast?latitude=30.66667&longitude=104.06667&current=temperature_2m,relative_humidity_2m,weather_code,wind_speed_10m&daily=weather_code,temperature_2m_max,temperature_2m_min&forecast_days=1&timezone=auto"
+```
+
+Important:
+- For Chinese inputs like `成都`, geocoding `name=%E6%88%90%E9%83%BD` may return smaller homonym locations first. Prefer `Chengdu` after verifying it matches Sichuan, China.
+- If geocoding looks suspicious, fall back to `wttr.in` for the original city name instead of presenting a likely wrong result.
+
+Docs: https://open-meteo.com/en/docs


### PR DESCRIPTION
## Summary
- Implements `ContextBuilder` in `internal/agent/context.go` that reads `AGENT.md`, `SOUL.md`, `USER.md`, and `skills/*/SKILL.md` from the workspace directory and assembles them into the agent system prompt
- Fixes `~` expansion in `WorkspacePath()` so config values like `~/.picoclaw/workspace` resolve correctly in Go (Go does not expand `~` natively)
- Adds debug log at agent build time showing workspace path, prompt length, and registered tools
- Commits the sample `workspace/` directory with AGENT.md, SOUL.md, USER.md, and 6 skill definitions

## How it works
Prompt assembly order, joined with `\n\n---\n\n`:
1. `AGENT.md` body (YAML frontmatter stripped)
2. `SOUL.md` content
3. `## User Profile` section from `USER.md`
4. `## Skills` summary (name + first description line from each `SKILL.md`)

Prompt is mtime-cached; any file creation, deletion, or modification invalidates it.

## Test plan
- [x] `make test` — all 21 packages pass
- [x] `make build` — clean
- [x] `golangci-lint run ./internal/agent/... ./pkg/config/...` — no issues
- [x] Manual: `./sushiclaw chat` with workspace configured shows `prompt_length` >> 51 in debug logs

Closes #70