### PR TITLE
docs: expand README + fix multi-arch Docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,71 +2,158 @@
 
 Personal AI agent built on top of [picoclaw](https://github.com/sipeed/picoclaw).
 
-For general setup, configuration, and picoclaw concepts see the [picoclaw docs](https://github.com/sipeed/picoclaw).
-This README documents only what sushiclaw adds on top. See [RELEASE.md](RELEASE.md) for versioning and release instructions.
+Runs on WhatsApp, Telegram, and Email. Customizable via workspace files and skills.
+
+For general picoclaw concepts see the [picoclaw docs](https://github.com/sipeed/picoclaw).
+This README documents what sushiclaw adds on top.
+
+---
+
+## Quick start
+
+### 1. Clone
+
+```bash
+git clone --recurse-submodules https://github.com/sushi30/sushiclaw.git
+cd sushiclaw
+```
+
+### 2. Configure
+
+```bash
+mkdir -p ~/.picoclaw
+cp config.example.json ~/.picoclaw/config.json
+# Edit config.json — set your model API key and enable at least one channel
+```
+
+### 3. Build and run
+
+```bash
+make build
+./sushiclaw gateway
+```
+
+Or install to `~/.local/bin`:
+
+```bash
+make install
+sushiclaw gateway
+```
+
+---
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `sushiclaw gateway` | Start the full gateway (all channels) |
+| `sushiclaw chat` | Interactive terminal chat with the agent |
+| `sushiclaw version` | Print build version info |
+
+### `gateway` flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-d, --debug` | false | Enable debug logging |
+| `-E, --allow-empty` | false | Start even without a default model configured |
+
+### `chat` flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-d, --debug` | false | Enable debug logging |
+
+---
+
+## Docker
+
+```bash
+docker pull ghcr.io/sushi30/sushiclaw:latest
+
+docker run -d \
+  -v ~/.picoclaw:/home/sushiclaw/.picoclaw \
+  -e ANTHROPIC_API_KEY=sk-... \
+  ghcr.io/sushi30/sushiclaw:latest gateway
+```
+
+Health check hits `http://localhost:18790/health` (picoclaw health server).
+
+---
+
+## Configuration
+
+Copy `config.example.json` to `~/.picoclaw/config.json`. Key sections:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "workspace": "~/.picoclaw/workspace",
+      "model_name": "claude-sonnet"
+    }
+  },
+  "model_list": [{ "model_name": "claude-sonnet", "api_key": "env://ANTHROPIC_API_KEY" }],
+  "channels": { ... },
+  "email_channel": { ... },
+  "tools": { ... }
+}
+```
+
+Override config path with `$SUSHICLAW_CONFIG`.
 
 ---
 
 ## Added features
 
-### WhatsApp voice memo transcription
-
-Incoming WhatsApp audio messages (voice notes) are transcribed to text before being forwarded to the agent. Transcription is powered by the ASR provider configured in `voice` config block. When `echo_transcription` is enabled in `voice` config, the transcript is echoed back to the sender alongside the agent reply.
-
-Build requirement: the `whatsapp_native` build tag must be set.
-
-```bash
-go build -tags whatsapp_native -o sushiclaw .
-# or just:
-make build
-```
-
 ### `env://` config resolver
 
-API keys and secrets in `config.json` can reference environment variables instead of being stored as plaintext:
+API keys in `config.json` can reference environment variables:
 
 ```json
-{
-  "model_list": [
-    {
-      "api_keys": ["env://OPENAI_API_KEY"]
-    }
-  ]
-}
+{ "api_key": "env://ANTHROPIC_API_KEY" }
 ```
 
-The `env://VAR_NAME` scheme is resolved at startup by `internal/envresolve`. This fills a gap in upstream picoclaw which handles `enc://` and `file://` but not `env://`.
+Resolved at startup by `internal/envresolve`. Fills a gap in upstream picoclaw (which handles `enc://` and `file://` but not `env://`).
 
-### WhatsApp interactive widgets (buttons and lists)
+---
 
-When the agent sets MIME-style metadata on an outbound message, the WhatsApp channel renders native interactive widgets instead of plain text.
+### WhatsApp voice memo transcription
 
-**Outbound metadata schema:**
+Incoming WhatsApp audio messages are transcribed before reaching the agent. Powered by the ASR provider in the `voice` config block. Set `echo_transcription: true` to send the transcript back to the sender.
+
+Requires the `whatsapp_native` build tag (included in `make build`).
+
+---
+
+### WhatsApp interactive widgets
+
+When the agent sets MIME-style metadata on an outbound message, the WhatsApp channel renders native interactive widgets.
+
+**Metadata schema:**
 
 | Key | Value |
 |-----|-------|
 | `Content-Type` | `application/x-wa-buttons` or `application/x-wa-list` |
-| `X-WA-Body` | Body text shown above the options (falls back to `Content` if absent) |
-| `X-WA-Option-0`, `X-WA-Option-1`, … | Individual option labels (0-indexed, contiguous) |
+| `X-WA-Body` | Body text above options (falls back to `Content`) |
+| `X-WA-Option-0`, `X-WA-Option-1`, … | Option labels (0-indexed, contiguous) |
 
-- `application/x-wa-buttons` renders a WhatsApp `ButtonsMessage` (max 3 tappable buttons). If more than 3 options are provided, the first 2 are kept and the rest are collapsed into a synthetic "Other (chat about this)" button.
-- `application/x-wa-list` renders a `ListMessage` with a single-select row list (no limit on rows).
-- If `Content-Type` is absent, unknown, or options are empty, the message falls back to plain text.
+- `application/x-wa-buttons` → WhatsApp `ButtonsMessage` (max 3). More than 3 options: first 2 kept, rest collapsed into "Other (chat about this)".
+- `application/x-wa-list` → `ListMessage` with single-select rows (no row limit).
+- Missing/unknown `Content-Type` or no options → plain text fallback.
 
-**Inbound widget replies:**
+Tapped replies arrive as plain `Content` with `metadata["wa_reply_type"] = "button"`.
 
-When the user taps a button or selects a list row, the reply is forwarded to the agent as plain `Content` (the selected label text) with `metadata["wa_reply_type"] = "button"` attached.
+---
 
 ### Unauthorized sender reply
 
-When a message arrives from a sender not listed in `allow_from`, sushiclaw replies with a rejection message ("You are not authorized to use this bot.") instead of silently dropping the message. Applies to the WhatsApp native channel.
+Messages from senders not in `allow_from` receive a rejection reply instead of being silently dropped. Applies to the WhatsApp native channel.
+
+---
 
 ### Email channel
 
-SMTP (outbound) + IMAP polling (inbound) channel. The agent can receive and reply to emails.
-
-Email is wired as a sidecar outside picoclaw's channel registry. Its config lives under a
-top-level `email_channel` key — **not** inside `channels`:
+SMTP (outbound) + IMAP polling (inbound). Config lives under `email_channel` (not inside `channels`):
 
 ```json
 {
@@ -88,10 +175,69 @@ top-level `email_channel` key — **not** inside `channels`:
 }
 ```
 
-- Port 465 → implicit TLS. Port 587 (default) → STARTTLS.
-- Port 993 (default) → implicit TLS for IMAP.
-- Polled messages are marked `\Seen` after processing.
-- `allow_from` restricts which sender addresses the agent will respond to.
+- Port 465 → implicit TLS (SMTP). Port 587 → STARTTLS.
+- Port 993 → implicit TLS (IMAP).
+- Processed messages are marked `\Seen`.
 
-> **Migrating from an older config?** See [RELEASE_NOTES.md](RELEASE_NOTES.md) for
-> step-by-step instructions if your config uses the old `channels.email` format.
+> **Migrating from an older config?** See [RELEASE_NOTES.md](RELEASE_NOTES.md) for step-by-step instructions if your config uses the old `channels.email` format.
+
+---
+
+## Workspace customization
+
+The agent loads three Markdown files from `agents.defaults.workspace` at startup:
+
+| File | Purpose |
+|------|---------|
+| `AGENT.md` | Agent name, role, mission, capabilities |
+| `SOUL.md` | Personality and communication style |
+| `USER.md` | Information about you (name, timezone, preferences) |
+
+Edit these to shape how the agent behaves and presents itself.
+
+### Skills
+
+Drop skill directories into `workspace/skills/`. Each skill is a folder with a descriptor that the agent can invoke. Built-in skills: `weather`, `summarize`, `github`, `hardware`, `tmux`, `agent-browser`, `skill-creator`.
+
+---
+
+## Development
+
+```bash
+make build          # Build binary (whatsapp_native tag required)
+make test           # Run tests
+make lint           # golangci-lint
+make deps           # go mod tidy
+make sync-picoclaw  # Update picoclaw submodule to latest upstream
+```
+
+### picoclaw submodule
+
+picoclaw is a git submodule at `picoclaw/`. The `go.mod` replace directive points to it:
+
+```
+replace github.com/sipeed/picoclaw => ./picoclaw
+```
+
+To update:
+
+```bash
+make sync-picoclaw
+# commit: picoclaw submodule pointer + go.mod + go.sum
+```
+
+### Syncing channel fixes from upstream
+
+```bash
+git -C picoclaw diff <old-sha>..<new-sha> -- pkg/channels/whatsapp_native/
+git -C picoclaw diff <old-sha>..<new-sha> -- pkg/channels/telegram/
+git -C picoclaw diff <old-sha>..<new-sha> -- pkg/channels/email/
+```
+
+Apply patches manually. Watch for interface changes in:
+- `pkg/channels/base.go` (`channels.Channel`)
+- `pkg/bus/types.go` (`bus.OutboundMessage` / `bus.InboundMessage`)
+
+---
+
+See [RELEASE.md](RELEASE.md) for versioning and release instructions.

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -5,7 +5,8 @@ RUN apk add --no-cache ca-certificates tzdata
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
     CMD wget -q --spider http://localhost:18790/health || exit 1
 
-COPY sushiclaw /usr/local/bin/sushiclaw
+ARG TARGETARCH
+COPY linux/${TARGETARCH}/sushiclaw /usr/local/bin/sushiclaw
 
 RUN addgroup -g 1000 sushiclaw && \
     adduser -D -u 1000 -G sushiclaw sushiclaw


### PR DESCRIPTION
## Summary
- Expanded README with quick-start, commands reference, Docker usage, configuration overview, and workspace/skills customization sections
- Fixed goreleaser multi-arch Docker build: `dockers_v2` places binaries at `linux/<arch>/sushiclaw` in the build context, but `Dockerfile.goreleaser` was doing `COPY sushiclaw` (root path) — added `ARG TARGETARCH` so BuildKit resolves the correct arch binary

## Test plan
- [ ] All existing tests pass (`make test`)
- [ ] CI release job should now succeed for both `linux/amd64` and `linux/arm64` Docker targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)