### PR TITLE
feat(commands): intercept slash commands pre-agent (fixes #81)

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,58 @@
+#:schema https://json.schemastore.org/any.json
+
+env_files = [".env"]
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -tags whatsapp_native -o ./tmp/main ."
+  delay = 1000
+  entrypoint = ["./tmp/main", "gateway", "--debug"]
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  ignore_dangerous_root_dir = false
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[proxy]
+  app_port = 0
+  app_start_timeout = 0
+  enabled = false
+  proxy_port = 0
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ go.work.sum
 
 coverage.html
 coverage.out
+
+# Air live-reload
+/tmp/
+build-errors.log

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -21,10 +21,16 @@ import (
 type SessionManager struct {
 	agent *agentsdk.Agent
 	bus   *bus.MessageBus
+	mem   *InMemoryMemory
+	cfg   *config.Config
 }
 
 // BuildAgent creates an agent-sdk-go Agent from config and tools.
 func BuildAgent(cfg *config.Config, tools []interfaces.Tool) (*agentsdk.Agent, error) {
+	return buildAgentWithMemory(cfg, tools, NewInMemoryMemory())
+}
+
+func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem *InMemoryMemory) (*agentsdk.Agent, error) {
 	llmClient, err := createLLM(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("create LLM: %w", err)
@@ -53,7 +59,7 @@ func BuildAgent(cfg *config.Config, tools []interfaces.Tool) (*agentsdk.Agent, e
 		agentsdk.WithLLM(llmClient),
 		agentsdk.WithSystemPrompt(systemPrompt),
 		agentsdk.WithTools(tools...),
-		agentsdk.WithMemory(NewInMemoryMemory()),
+		agentsdk.WithMemory(mem),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create agent: %w", err)
@@ -64,7 +70,8 @@ func BuildAgent(cfg *config.Config, tools []interfaces.Tool) (*agentsdk.Agent, e
 
 // NewSessionManager creates a session manager from config.
 func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus) (*SessionManager, error) {
-	a, err := BuildAgent(cfg, nil)
+	mem := NewInMemoryMemory()
+	a, err := buildAgentWithMemory(cfg, nil, mem)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +79,35 @@ func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus) (*Session
 	return &SessionManager{
 		agent: a,
 		bus:   messageBus,
+		mem:   mem,
+		cfg:   cfg,
 	}, nil
+}
+
+// ClearHistory resets the agent's conversation memory.
+func (sm *SessionManager) ClearHistory() error {
+	return sm.mem.Clear(context.Background())
+}
+
+// GetModelInfo returns the configured model name and its provider.
+func (sm *SessionManager) GetModelInfo() (name, provider string) {
+	name = sm.cfg.Agents.Defaults.ModelName
+	model := name
+	for i := range sm.cfg.ModelList {
+		if sm.cfg.ModelList[i].ModelName == name {
+			if sm.cfg.ModelList[i].Model != "" {
+				model = sm.cfg.ModelList[i].Model
+			}
+			break
+		}
+	}
+	switch {
+	case strings.HasPrefix(model, "openrouter/"):
+		provider = "openrouter"
+	default:
+		provider = "openai"
+	}
+	return
 }
 
 // RegisterTool registers a tool with the agent.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -89,6 +89,15 @@ func (sm *SessionManager) ClearHistory() error {
 	return sm.mem.Clear(context.Background())
 }
 
+// ListModels returns all configured model names.
+func (sm *SessionManager) ListModels() []string {
+	names := make([]string, 0, len(sm.cfg.ModelList))
+	for _, m := range sm.cfg.ModelList {
+		names = append(names, m.ModelName)
+	}
+	return names
+}
+
 // GetModelInfo returns the configured model name and its provider.
 func (sm *SessionManager) GetModelInfo() (name, provider string) {
 	name = sm.cfg.Agents.Defaults.ModelName
@@ -124,19 +133,10 @@ func (sm *SessionManager) Chat(ctx context.Context, input string) (string, error
 	return sm.agent.Run(actx, input)
 }
 
-// Run listens on the inbound bus channel and processes messages.
-func (sm *SessionManager) Run(ctx context.Context) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case msg, ok := <-sm.bus.InboundChan():
-			if !ok {
-				return
-			}
-			sm.handleInbound(ctx, msg)
-		}
-	}
+// Dispatch processes a single inbound message through the agent.
+// Called by the gateway after command filtering and local execution.
+func (sm *SessionManager) Dispatch(ctx context.Context, msg bus.InboundMessage) {
+	sm.handleInbound(ctx, msg)
 }
 
 func (sm *SessionManager) handleInbound(ctx context.Context, msg bus.InboundMessage) {

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/bus"
 	"github.com/sushi30/sushiclaw/pkg/channels"
 	"github.com/sushi30/sushiclaw/pkg/channels/email"
+	"github.com/sushi30/sushiclaw/pkg/commands"
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/logger"
 	"github.com/sushi30/sushiclaw/pkg/media"
@@ -63,6 +64,11 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	// Single bus architecture: all channels and the agent share one MessageBus.
 	messageBus := bus.NewMessageBus()
 	cmdFilter := commandfilter.NewCommandFilter()
+
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{
+		ListDefinitions: reg.Definitions,
+	}
 
 	sessionMgr, err := agent.NewSessionManager(cfg, messageBus)
 	if err != nil {
@@ -130,10 +136,17 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	defer cancel()
 
 	if sessionMgr != nil {
+		rt.ClearHistory = sessionMgr.ClearHistory
+		rt.GetModelInfo = sessionMgr.GetModelInfo
+	}
+	executor := commands.NewExecutor(reg, rt)
+
+	if sessionMgr != nil {
 		go sessionMgr.Run(ctx)
 	}
 
-	// Inbound processing: filter commands, then publish to bus for agent.
+	// Inbound processing: filter commands, execute handled ones locally,
+	// forward the rest to the agent session.
 	go func() {
 		for {
 			select {
@@ -158,6 +171,29 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 					})
 					continue
 				}
+
+				if commands.HasCommandPrefix(msg.Content) {
+					var reply string
+					result := executor.Execute(ctx, commands.Request{
+						Channel:  msg.Channel,
+						ChatID:   msg.ChatID,
+						SenderID: msg.SenderID,
+						Text:     msg.Content,
+						Reply:    func(text string) error { reply = text; return nil },
+					})
+					if result.Outcome == commands.OutcomeHandled {
+						if reply != "" {
+							_ = messageBus.PublishOutbound(ctx, bus.OutboundMessage{
+								Channel: msg.Channel,
+								ChatID:  msg.ChatID,
+								Content: reply,
+							})
+						}
+						continue
+					}
+					// OutcomePassthrough: forward to agent.
+				}
+
 				// Re-publish to bus so agent session can pick it up.
 				_ = messageBus.PublishInbound(ctx, msg)
 			}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -138,12 +138,9 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	if sessionMgr != nil {
 		rt.ClearHistory = sessionMgr.ClearHistory
 		rt.GetModelInfo = sessionMgr.GetModelInfo
+		rt.ListModels = sessionMgr.ListModels
 	}
 	executor := commands.NewExecutor(reg, rt)
-
-	if sessionMgr != nil {
-		go sessionMgr.Run(ctx)
-	}
 
 	// Inbound processing: filter commands, execute handled ones locally,
 	// forward the rest to the agent session.
@@ -157,6 +154,12 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 					return
 				}
 				dec := cmdFilter.Filter(msg)
+				logger.DebugCF("commandfilter", "Filtered message",
+					map[string]any{
+						"text":    msg.Content,
+						"result":  dec.Result,
+						"command": dec.Command,
+					})
 				if dec.Result == commandfilter.Block {
 					logger.InfoCF("commandfilter", "Blocked unrecognized slash command",
 						map[string]any{
@@ -181,6 +184,13 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 						Text:     msg.Content,
 						Reply:    func(text string) error { reply = text; return nil },
 					})
+					logger.DebugCF("executor", "Command executed",
+						map[string]any{
+							"text":    msg.Content,
+							"command": result.Command,
+							"outcome": result.Outcome,
+							"handled": result.Outcome == commands.OutcomeHandled,
+						})
 					if result.Outcome == commands.OutcomeHandled {
 						if reply != "" {
 							_ = messageBus.PublishOutbound(ctx, bus.OutboundMessage{
@@ -194,8 +204,10 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 					// OutcomePassthrough: forward to agent.
 				}
 
-				// Re-publish to bus so agent session can pick it up.
-				_ = messageBus.PublishInbound(ctx, msg)
+				// Dispatch to agent session directly (avoids bus read race).
+				if sessionMgr != nil {
+					go sessionMgr.Dispatch(ctx, msg)
+				}
 			}
 		}
 	}()

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -56,6 +56,7 @@ type Request struct {
 type Runtime struct {
 	GetModelInfo    func() (name, provider string)
 	ListDefinitions func() []Definition
+	ListModels      func() []string
 	ClearHistory    func() error
 }
 
@@ -248,7 +249,9 @@ func BuiltinDefinitions() []Definition {
 		{Name: "debug", Description: "Toggle debug event forwarding"},
 		{Name: "model", Description: "Show or switch model"},
 		{Name: "show", Description: "Show current configuration"},
-		{Name: "list", Description: "List available options"},
+		{Name: "list", Description: "List available options", SubCommands: []SubCommand{
+			{Name: "models", Description: "List configured models", Handler: listModelsHandler},
+		}},
 		{Name: "use", Description: "Use a specific configuration"},
 		{Name: "btw", Description: "Add a note to conversation context"},
 		{Name: "switch", Description: "Switch model or channel"},
@@ -267,17 +270,39 @@ func helpHandler(_ context.Context, req Request, rt *Runtime) error {
 	if rt != nil && rt.ListDefinitions != nil {
 		defs = rt.ListDefinitions()
 	}
-	if len(defs) == 0 {
+	var available []Definition
+	for _, d := range defs {
+		if d.Handler != nil || len(d.SubCommands) > 0 {
+			available = append(available, d)
+		}
+	}
+	if len(available) == 0 {
 		return req.Reply("No commands available.")
 	}
 	var sb strings.Builder
 	sb.WriteString("Available commands:\n")
-	for _, d := range defs {
+	for _, d := range available {
 		sb.WriteString("/" + d.Name)
 		if d.Description != "" {
 			sb.WriteString(" — " + d.Description)
 		}
 		sb.WriteByte('\n')
+	}
+	return req.Reply(strings.TrimRight(sb.String(), "\n"))
+}
+
+func listModelsHandler(_ context.Context, req Request, rt *Runtime) error {
+	if rt == nil || rt.ListModels == nil {
+		return req.Reply("Model list unavailable.")
+	}
+	models := rt.ListModels()
+	if len(models) == 0 {
+		return req.Reply("No models configured.")
+	}
+	var sb strings.Builder
+	sb.WriteString("Configured models:\n")
+	for _, m := range models {
+		sb.WriteString("• " + m + "\n")
 	}
 	return req.Reply(strings.TrimRight(sb.String(), "\n"))
 }

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -242,8 +242,8 @@ func normalize(name string) string {
 // These are used by the command filter to allow/block commands.
 func BuiltinDefinitions() []Definition {
 	return []Definition{
-		{Name: "start", Description: "Start the bot"},
-		{Name: "help", Description: "Show this help message"},
+		{Name: "start", Description: "Start the bot", Handler: startHandler},
+		{Name: "help", Description: "Show this help message", Handler: helpHandler},
 		{Name: "clear", Description: "Clear conversation history", Handler: clearHandler},
 		{Name: "debug", Description: "Toggle debug event forwarding"},
 		{Name: "model", Description: "Show or switch model"},
@@ -258,7 +258,31 @@ func BuiltinDefinitions() []Definition {
 	}
 }
 
-func clearHandler(ctx context.Context, req Request, rt *Runtime) error {
+func startHandler(_ context.Context, req Request, _ *Runtime) error {
+	return req.Reply("👋 Sushiclaw is running. Type /help for available commands.")
+}
+
+func helpHandler(_ context.Context, req Request, rt *Runtime) error {
+	var defs []Definition
+	if rt != nil && rt.ListDefinitions != nil {
+		defs = rt.ListDefinitions()
+	}
+	if len(defs) == 0 {
+		return req.Reply("No commands available.")
+	}
+	var sb strings.Builder
+	sb.WriteString("Available commands:\n")
+	for _, d := range defs {
+		sb.WriteString("/" + d.Name)
+		if d.Description != "" {
+			sb.WriteString(" — " + d.Description)
+		}
+		sb.WriteByte('\n')
+	}
+	return req.Reply(strings.TrimRight(sb.String(), "\n"))
+}
+
+func clearHandler(_ context.Context, req Request, rt *Runtime) error {
 	if rt != nil && rt.ClearHistory != nil {
 		if err := rt.ClearHistory(); err != nil {
 			return req.Reply("Failed to clear history: " + err.Error())

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -45,7 +45,7 @@ func TestCommandName(t *testing.T) {
 
 func TestExecuteHelp(t *testing.T) {
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
-	rt := &commands.Runtime{}
+	rt := &commands.Runtime{ListDefinitions: reg.Definitions}
 	exec := commands.NewExecutor(reg, rt)
 
 	var replied string
@@ -54,10 +54,63 @@ func TestExecuteHelp(t *testing.T) {
 		Reply: func(s string) error { replied = s; return nil },
 	}
 
-	// /help has no handler in builtins (passthrough to LLM)
 	result := exec.Execute(context.Background(), req)
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Contains(t, replied, "/help")
+	assert.Contains(t, replied, "/clear")
+}
+
+func TestExecuteHelpNoRuntime(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{})
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/help",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Contains(t, replied, "No commands available.")
+}
+
+func TestExecuteStart(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{})
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/start",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.NotEmpty(t, replied)
+}
+
+func TestExecuteClearCallsCallback(t *testing.T) {
+	cleared := false
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{
+		ClearHistory: func() error { cleared = true; return nil },
+	}
+	exec := commands.NewExecutor(reg, rt)
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/clear",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.True(t, cleared)
+	assert.Contains(t, replied, "cleared")
+}
+
+func TestExecutePassthroughNoHandler(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{})
+
+	// /use has no handler — should pass through to agent
+	result := exec.Execute(context.Background(), commands.Request{Text: "/use"})
 	assert.Equal(t, commands.OutcomePassthrough, result.Outcome)
-	_ = replied
 }
 
 func TestExecuteUnrecognizedReturnsPassthrough(t *testing.T) {


### PR DESCRIPTION
## Summary
- Slash commands now intercepted in the gateway before reaching the LLM
- Fixed bus read race: both gateway goroutine and SessionManager were competing on the same inbound channel — commands went straight to agent, bypassing executor
- Fix: gateway calls `sessionMgr.Dispatch()` directly; SessionManager no longer reads from bus

## Commands now handled locally
| Command | Behavior |
|---------|----------|
| `/start` | Greeting reply |
| `/help` | Lists commands with handlers (hides stub-only entries) |
| `/clear` | Clears conversation memory |
| `/list models` | Lists configured models from config |

Commands without handlers (`/use`, `/switch`, `/debug`, `/model`, etc.) pass through to the agent. Truly unknown commands are blocked by the existing CommandFilter.

## Changes
- `internal/agent/session.go` — replace `Run()` bus loop with `Dispatch(ctx, msg)`; add `ListModels()`, `ClearHistory()`, `GetModelInfo()`
- `internal/gateway/gateway.go` — build Runtime + Executor; dispatch directly to agent via goroutine; add debug logging for filter/executor decisions
- `pkg/commands/commands.go` — `helpHandler` filters to handler-only commands; add `/list models` subcommand; add `listModelsHandler`

## Test plan
- [x] `make test` — all 22 packages pass
- [x] `golangci-lint run ./internal/agent/... ./internal/gateway/... ./pkg/commands/...` — no issues
- [x] Manual: `/help` → local list (no LLM)
- [x] Manual: `/start` → greeting (no LLM)
- [x] Manual: `/clear` → history cleared
- [x] Manual: `/list models` → model list from config
- [x] Manual: `/use python` → forwarded to agent

## Known gaps
- #83 Add handlers for /model and /debug slash commands

Closes #81