### PR TITLE
fix(agent): wire exec tool correctly end-to-end

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -49,6 +49,9 @@ func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem *InMe
 	for i, t := range tools {
 		toolNames[i] = t.Name()
 	}
+	if len(tools) == 0 {
+		systemPrompt += "\n\nIMPORTANT: You have no tools available. You cannot execute commands, run code, or take real-world actions. If asked to do any of these, tell the user you are unable to in the current configuration — do not simulate or pretend to execute anything."
+	}
 	logger.DebugCF("agent", "Building agent", map[string]any{
 		"workspace":     cfg.WorkspacePath(),
 		"prompt_length": len(systemPrompt),

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -23,6 +23,7 @@ type SessionManager struct {
 	bus   *bus.MessageBus
 	mem   *InMemoryMemory
 	cfg   *config.Config
+	tools []interfaces.Tool
 }
 
 // BuildAgent creates an agent-sdk-go Agent from config and tools.
@@ -69,9 +70,9 @@ func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem *InMe
 }
 
 // NewSessionManager creates a session manager from config.
-func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus) (*SessionManager, error) {
+func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus, tools []interfaces.Tool) (*SessionManager, error) {
 	mem := NewInMemoryMemory()
-	a, err := buildAgentWithMemory(cfg, nil, mem)
+	a, err := buildAgentWithMemory(cfg, tools, mem)
 	if err != nil {
 		return nil, err
 	}
@@ -81,6 +82,7 @@ func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus) (*Session
 		bus:   messageBus,
 		mem:   mem,
 		cfg:   cfg,
+		tools: tools,
 	}, nil
 }
 
@@ -119,11 +121,13 @@ func (sm *SessionManager) GetModelInfo() (name, provider string) {
 	return
 }
 
-// RegisterTool registers a tool with the agent.
-// Note: agent-sdk-go does not support dynamic tool registration after creation.
-// This is a no-op; tools must be passed during construction.
-func (sm *SessionManager) RegisterTool(t interfaces.Tool) {
-	logger.WarnC("agent", "RegisterTool is a no-op with agent-sdk-go; tools must be passed during construction")
+// ToolNames returns the names of the tools registered with this session manager.
+func (sm *SessionManager) ToolNames() []string {
+	names := make([]string, len(sm.tools))
+	for i, t := range sm.tools {
+		names[i] = t.Name()
+	}
+	return names
 }
 
 // Chat runs a single turn against the agent and returns the response.

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -64,6 +64,7 @@ func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem *InMe
 		agentsdk.WithSystemPrompt(systemPrompt),
 		agentsdk.WithTools(tools...),
 		agentsdk.WithMemory(mem),
+		agentsdk.WithRequirePlanApproval(false),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create agent: %w", err)

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -1,15 +1,25 @@
 package agent_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/sushi30/sushiclaw/internal/agent"
 	"github.com/sushi30/sushiclaw/pkg/config"
 )
+
+type mockTool struct{ name string }
+
+func (m *mockTool) Name() string                                          { return m.name }
+func (m *mockTool) Description() string                                   { return "" }
+func (m *mockTool) Run(_ context.Context, _ string) (string, error)       { return "", nil }
+func (m *mockTool) Parameters() map[string]interfaces.ParameterSpec       { return nil }
+func (m *mockTool) Execute(_ context.Context, _ string) (string, error)   { return "", nil }
 
 func TestBuildAgent_UnresolvedEnvKey(t *testing.T) {
 	_ = os.Unsetenv("MISSING_API_KEY")
@@ -136,4 +146,24 @@ func TestBuildAgent_NoAPIKey(t *testing.T) {
 	_, err := agent.BuildAgent(cfg, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no API key")
+}
+
+func TestNewSessionManager_ToolsRegistered(t *testing.T) {
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{ModelName: "test-model"},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+	}
+
+	tool := &mockTool{name: "test-tool"}
+	sm, err := agent.NewSessionManager(cfg, nil, []interfaces.Tool{tool})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test-tool"}, sm.ToolNames())
 }

--- a/internal/chat/repl.go
+++ b/internal/chat/repl.go
@@ -31,7 +31,7 @@ type Runner struct {
 func NewRunner(cfg *config.Config) (*Runner, error) {
 	var tools []interfaces.Tool
 	if cfg.Tools.IsToolEnabled("exec") {
-		wd := cfg.Agents.Defaults.Workspace
+		wd := cfg.WorkspacePath()
 		restrict := cfg.Agents.Defaults.RestrictToWorkspace
 		tools = append(tools, exec.NewExecTool(wd, restrict, true))
 	}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
 	"github.com/sushi30/sushiclaw/internal/agent"
 	"github.com/sushi30/sushiclaw/internal/commandfilter"
 	"github.com/sushi30/sushiclaw/internal/envresolve"
@@ -70,15 +71,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 		ListDefinitions: reg.Definitions,
 	}
 
-	sessionMgr, err := agent.NewSessionManager(cfg, messageBus)
-	if err != nil {
-		if allowEmptyStartup {
-			logger.WarnC("gateway", fmt.Sprintf("Failed to create agent session: %v", err))
-		} else {
-			return fmt.Errorf("error creating agent session: %w", err)
-		}
-	}
-
+	var tools []interfaces.Tool
 	if allowedSenders := sushitools.ParseAllowedSenders(); len(allowedSenders) > 0 {
 		if cfg.Tools.IsToolEnabled("exec") {
 			workingDir := cfg.Agents.Defaults.Workspace
@@ -88,10 +81,19 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 				logger.WarnCF("gateway", "Failed to init trusted exec tool",
 					map[string]any{"error": err.Error()})
 			} else {
-				sessionMgr.RegisterTool(trustedExec)
+				tools = append(tools, trustedExec)
 				logger.InfoCF("gateway", "Trusted exec registered",
 					map[string]any{"senders": allowedSenders})
 			}
+		}
+	}
+
+	sessionMgr, err := agent.NewSessionManager(cfg, messageBus, tools)
+	if err != nil {
+		if allowEmptyStartup {
+			logger.WarnC("gateway", fmt.Sprintf("Failed to create agent session: %v", err))
+		} else {
+			return fmt.Errorf("error creating agent session: %w", err)
 		}
 	}
 

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -74,7 +74,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	var tools []interfaces.Tool
 	if allowedSenders := sushitools.ParseAllowedSenders(); len(allowedSenders) > 0 {
 		if cfg.Tools.IsToolEnabled("exec") {
-			workingDir := cfg.Agents.Defaults.Workspace
+			workingDir := cfg.WorkspacePath()
 			restrict := cfg.Agents.Defaults.RestrictToWorkspace
 			trustedExec, err := sushitools.NewTrustedExecTool(cfg, workingDir, restrict, allowedSenders)
 			if err != nil {


### PR DESCRIPTION
## Summary

Four fixes to get the exec tool working end-to-end from gateway mode:

- **Pass tools at construction time** — `NewSessionManager` was calling `BuildAgent(cfg, nil)`, then the gateway tried to add tools via the no-op `RegisterTool`. Tools are now passed as a parameter at construction. Removes `RegisterTool`, adds `ToolNames()` for test introspection.
- **Disable plan approval gate** — agent-sdk-go defaults to `requirePlanApproval: true`, causing a multi-turn approval loop that never resolves because sushiclaw dispatches each message as a separate `agent.Run()` call. Disabled with `WithRequirePlanApproval(false)`.
- **Honest no-tools message** — when no tools are registered, inject a system-prompt constraint so the model says it can't execute commands rather than hallucinating execution.
- **Expand `~` in workspace path** — gateway and REPL were reading `cfg.Agents.Defaults.Workspace` directly; Go's `chdir` doesn't expand `~`. Fixed to use `cfg.WorkspacePath()` which calls `expandHome()`.

## Test plan
- `TestNewSessionManager_ToolsRegistered`: mock tool passed at construction, `sm.ToolNames()` asserts it's present
- `make test` — all packages pass
- `make lint` — 0 issues
- End-to-end: exec tool executes `go version` and `ls` in workspace over Telegram after setting `SUSHICLAW_EXEC_ALLOWED_SENDERS` + `tools.exec.enabled: true` in config

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)