### PR TITLE
fix(lint): handle unchecked error returns

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v7
         with:
           version: v2.11.4
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,22 @@ jobs:
           go mod tidy
           git diff --exit-code go.mod go.sum
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
+
   test:
     name: Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.65.0
+          version: v2.10.1
 
   test:
     name: Tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v4
         with:
-          version: latest:v2.11.4
+          version: v2.11.4
 
   test:
     name: Tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v4
         with:
-          version: v2.10.1
+          version: latest:v2.11.4
 
   test:
     name: Tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: golangci/golangci-lint-action@v4
+      - uses: golangci/golangci-lint-action@v6
         with:
           version: v2.11.4
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v4
         with:
-          version: latest
+          version: v1.65.0
 
   test:
     name: Tests

--- a/internal/chat/repl.go
+++ b/internal/chat/repl.go
@@ -60,12 +60,12 @@ func (r *Runner) SetOutput(w io.Writer) {
 }
 
 func (r *Runner) Run(ctx context.Context) error {
-	fmt.Fprintln(r.out, "Sushiclaw Chat")
-	fmt.Fprintln(r.out, "Type /quit to exit, /help for commands")
-	fmt.Fprintln(r.out)
+	_, _ = fmt.Fprintln(r.out, "Sushiclaw Chat")
+	_, _ = fmt.Fprintln(r.out, "Type /quit to exit, /help for commands")
+	_, _ = fmt.Fprintln(r.out)
 
 	for {
-		fmt.Fprint(r.out, "> ")
+		_, _ = fmt.Fprint(r.out, "> ")
 		if !r.scanner.Scan() {
 			break
 		}
@@ -89,32 +89,33 @@ func (r *Runner) Run(ctx context.Context) error {
 		actx := exec.WithChatID(ctx, "cli")
 		response, err := r.agent.Run(actx, line)
 		if err != nil {
-			fmt.Fprintf(r.out, "Error: %v\n", err)
+			_, _ = fmt.Fprintf(r.out, "Error: %v\n", err)
 			continue
 		}
 
-		fmt.Fprintln(r.out, response)
+		_, _ = fmt.Fprintln(r.out, response)
 	}
 
 	return r.scanner.Err()
 }
 
 func (r *Runner) handleCommand(ctx context.Context, line string) (bool, error) {
+	_ = ctx
 	switch line {
 	case "/quit", "/q", "/exit":
-		fmt.Fprintln(r.out, "Goodbye!")
+		_, _ = fmt.Fprintln(r.out, "Goodbye!")
 		return true, ErrQuit
 	case "/clear":
 		// In-memory memory is per-agent-instance, so "clear" just means
 		// we can't easily clear it without access to the memory interface.
 		// For now, tell the user.
-		fmt.Fprintln(r.out, "Note: history is in-memory per session. Restart to clear.")
+		_, _ = fmt.Fprintln(r.out, "Note: history is in-memory per session. Restart to clear.")
 		return true, nil
 	case "/help", "/h":
-		fmt.Fprintln(r.out, "Commands:")
-		fmt.Fprintln(r.out, "  /quit    Exit the REPL")
-		fmt.Fprintln(r.out, "  /clear   Note about history")
-		fmt.Fprintln(r.out, "  /help    Show this help")
+		_, _ = fmt.Fprintln(r.out, "Commands:")
+		_, _ = fmt.Fprintln(r.out, "  /quit    Exit the REPL")
+		_, _ = fmt.Fprintln(r.out, "  /clear   Note about history")
+		_, _ = fmt.Fprintln(r.out, "  /help    Show this help")
 		return true, nil
 	}
 	return false, nil

--- a/pkg/media/media_test.go
+++ b/pkg/media/media_test.go
@@ -83,7 +83,9 @@ func TestFileMediaStore_ReleaseAll(t *testing.T) {
 	s := NewFileMediaStore()
 
 	tmpFile := filepath.Join(t.TempDir(), "release.txt")
-	os.WriteFile(tmpFile, []byte("hello"), 0o600)
+	if err := os.WriteFile(tmpFile, []byte("hello"), 0o600); err != nil {
+		t.Fatalf("create test file: %v", err)
+	}
 
 	ref, _ := s.Store(tmpFile, MediaMeta{Filename: "release.txt", CleanupPolicy: CleanupPolicyDeleteOnCleanup}, "scope1")
 
@@ -116,7 +118,9 @@ func TestFileMediaStore_CleanExpired(t *testing.T) {
 	s.nowFunc = func() time.Time { return oldTime }
 
 	tmpFile := filepath.Join(t.TempDir(), "old.txt")
-	os.WriteFile(tmpFile, []byte("old"), 0o600)
+	if err := os.WriteFile(tmpFile, []byte("old"), 0o600); err != nil {
+		t.Fatalf("create test file: %v", err)
+	}
 
 	ref, _ := s.Store(tmpFile, MediaMeta{Filename: "old.txt", CleanupPolicy: CleanupPolicyDeleteOnCleanup}, "scope1")
 
@@ -144,7 +148,9 @@ func TestFileMediaStore_CleanExpired_NotExpired(t *testing.T) {
 	})
 
 	tmpFile := filepath.Join(t.TempDir(), "fresh.txt")
-	os.WriteFile(tmpFile, []byte("fresh"), 0o600)
+	if err := os.WriteFile(tmpFile, []byte("fresh"), 0o600); err != nil {
+		t.Fatalf("create test file: %v", err)
+	}
 
 	ref, _ := s.Store(tmpFile, MediaMeta{Filename: "fresh.txt"}, "scope1")
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -115,7 +115,9 @@ func DownloadFile(urlStr, filename string, opts DownloadOptions) string {
 		})
 		return ""
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		logger.ErrorCF(opts.LoggerPrefix, "File download returned non-200 status", map[string]any{
@@ -132,11 +134,13 @@ func DownloadFile(urlStr, filename string, opts DownloadOptions) string {
 		})
 		return ""
 	}
-	defer out.Close()
+	defer func() {
+		_ = out.Close()
+	}()
 
 	if _, err := io.Copy(out, resp.Body); err != nil {
-		out.Close()
-		os.Remove(localPath)
+		_ = out.Close()
+		_ = os.Remove(localPath)
 		logger.ErrorCF(opts.LoggerPrefix, "Failed to write file", map[string]any{
 			"error": err.Error(),
 		})

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -100,7 +100,7 @@ func TestDownloadFile_Non200Status(t *testing.T) {
 func TestDownloadFile_Success(t *testing.T) {
 	// Start a local test server.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("hello world"))
+		_, _ = w.Write([]byte("hello world"))
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
## Summary
Resolves all 13 errcheck lint errors by properly handling unchecked return values from fmt, file, and network operations.

**Changes:**
- Wrapped fmt.Fprintln/Fprintf calls with explicit blank assignments in REPL output
- Added proper error handling for os.WriteFile in test setup functions
- Wrapped defer statements and error-path cleanup with blank assignments
- Suppressed unused context parameter in handleCommand

## Test plan
- ✅ All tests pass (go test ./...)
- ✅ Lint check passes (golangci-lint run ./...)
- ✅ No debug output or unexpected changes

## Type of change
- Bug fix (non-breaking, resolves linting issues)