### PR TITLE
feat(agent): add MCP server support to agent session

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,28 @@ Resolved at startup by `internal/envresolve`. Fills a gap in upstream picoclaw (
 
 ---
 
+### MCP server support
+
+Connect the agent to [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers for external tools (filesystem, GitHub, databases, etc.).
+
+```json
+{
+  "mcp": {
+    "mcpServers": {
+      "github": {
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-github"],
+        "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "env://GITHUB_TOKEN" }
+      }
+    }
+  }
+}
+```
+
+See [docs/MCP.md](docs/MCP.md) for full configuration options and examples.
+
+---
+
 ### WhatsApp voice memo transcription
 
 Incoming WhatsApp audio messages are transcribed before reaching the agent. Powered by the ASR provider in the `voice` config block. Set `echo_transcription: true` to send the transcript back to the sender.

--- a/config.example.json
+++ b/config.example.json
@@ -81,5 +81,20 @@
       "max_age": 30,
       "interval": 5
     }
+  },
+  "mcp": {
+    "mcpServers": {
+      "github": {
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-github"],
+        "env": {
+          "GITHUB_PERSONAL_ACCESS_TOKEN": "env://GITHUB_TOKEN"
+        }
+      },
+      "filesystem": {
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/workspace"]
+      }
+    }
   }
 }

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,138 @@
+# MCP Server Support
+
+Sushiclaw can connect to [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers, giving the agent access to external tools such as filesystem access, GitHub operations, databases, and more.
+
+## Overview
+
+MCP configuration lives in your `config.json` under the `mcp` key. When the agent starts, it reads `mcpServers`, connects to each server, and makes the server's tools available to the agent automatically.
+
+## Quick Start
+
+Add an `mcp` section to `~/.picoclaw/config.json`:
+
+```json
+{
+  "mcp": {
+    "mcpServers": {
+      "filesystem": {
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/workspace"]
+      }
+    }
+  }
+}
+```
+
+Restart sushiclaw. The agent will discover and use the filesystem tools automatically.
+
+## Configuration Format
+
+### Top-level structure
+
+```json
+{
+  "mcp": {
+    "mcpServers": {
+      "<server-name>": { ... },
+      "<server-name>": { ... }
+    }
+  }
+}
+```
+
+Each entry under `mcpServers` is a named MCP server. The name is arbitrary and used only for logging.
+
+### Server types
+
+#### Stdio servers
+
+Local command-line MCP servers communicate over standard input/output.
+
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "env://GITHUB_TOKEN"
+  },
+  "allowedTools": ["search_issues", "create_issue"]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `command` | string | Executable to run |
+| `args` | string[] | Arguments passed to the executable |
+| `env` | object | Environment variables (`KEY: VALUE`) |
+| `allowedTools` | string[] | *(Optional)* Whitelist tools from this server |
+
+#### HTTP servers
+
+Remote MCP servers exposed over HTTP.
+
+```json
+{
+  "url": "http://localhost:3000/mcp",
+  "token": "env://MCP_REMOTE_TOKEN",
+  "allowedTools": ["query_database"]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `url` | string | HTTP(S) endpoint of the MCP server |
+| `token` | string | Bearer token for authentication |
+| `allowedTools` | string[] | *(Optional)* Whitelist tools from this server |
+
+## Environment Variables
+
+Use the `env://VAR_NAME` syntax for secrets. Sushiclaw resolves these at load time from the process environment.
+
+```json
+{
+  "token": "env://MCP_TOKEN"
+}
+```
+
+If the environment variable is not set, the literal string `env://VAR_NAME` is kept as-is and passed to the underlying SDK.
+
+## Tool Filtering
+
+The optional `allowedTools` array restricts which tools from a server are exposed to the agent. If omitted, all tools are available.
+
+```json
+{
+  "github": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-github"],
+    "allowedTools": ["search_issues", "get_issue"]
+  }
+}
+```
+
+## How It Works
+
+1. At startup, `BuildAgent` reads `cfg.MCP.MCPServers`.
+2. The config is converted to `agent-sdk-go`'s `MCPConfiguration`.
+3. `agentsdk.WithMCPConfig(...)` registers the servers with the agent.
+4. `agent-sdk-go` connects lazily and discovers available tools.
+5. Discovered tools are merged with native tools (e.g., `exec`) and passed to the LLM.
+
+## Example Configurations
+
+See [`examples/config/mcp.json`](../examples/config/mcp.json) for a complete example with stdio and HTTP servers.
+
+## Troubleshooting
+
+**Agent fails to start after adding MCP config**
+- Check that the `command` exists in `$PATH`.
+- Verify `env://` variables are exported in the environment.
+- Look for MCP initialization warnings in the logs.
+
+**Tools from MCP server are not available**
+- Ensure the server process starts successfully (stdio servers).
+- Verify the HTTP endpoint is reachable.
+- Check `allowedTools` is not accidentally filtering out the tool you need.
+
+**Secrets exposed in logs**
+- `token` values using `env://` are resolved at load time. The raw config file should never contain plaintext secrets.

--- a/examples/config/mcp.json
+++ b/examples/config/mcp.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/workspace"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "env://GITHUB_TOKEN"
+      }
+    },
+    "remote": {
+      "url": "http://localhost:3000/mcp",
+      "token": "env://MCP_REMOTE_TOKEN"
+    }
+  }
+}

--- a/internal/agent/mcp_config_test.go
+++ b/internal/agent/mcp_config_test.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sushi30/sushiclaw/pkg/config"
+)
+
+func TestToAgentSDKMCPConfig(t *testing.T) {
+	t.Run("empty config returns nil", func(t *testing.T) {
+		result := toAgentSDKMCPConfig(config.MCPConfig{})
+		assert.Nil(t, result)
+	})
+
+	t.Run("converts stdio and http servers", func(t *testing.T) {
+		cfg := config.MCPConfig{
+			MCPServers: map[string]config.MCPServerConfig{
+				"stdio-server": {
+					Command:      "npx",
+					Args:         []string{"-y", "@modelcontextprotocol/server-filesystem", "/tmp"},
+					Env:          map[string]string{"KEY": "value"},
+					AllowedTools: []string{"read_file"},
+				},
+				"http-server": {
+					URL:          "http://localhost:3000/mcp",
+					Token:        config.NewSecureString("bearer-token"),
+					AllowedTools: []string{"query"},
+				},
+			},
+		}
+
+		result := toAgentSDKMCPConfig(cfg)
+		require.NotNil(t, result)
+		require.Len(t, result.MCPServers, 2)
+
+		stdio := result.MCPServers["stdio-server"]
+		assert.Equal(t, "npx", stdio.Command)
+		assert.Equal(t, []string{"-y", "@modelcontextprotocol/server-filesystem", "/tmp"}, stdio.Args)
+		assert.Equal(t, map[string]string{"KEY": "value"}, stdio.Env)
+		assert.Equal(t, "", stdio.URL)
+		assert.Equal(t, "", stdio.Token)
+		assert.Equal(t, []string{"read_file"}, stdio.AllowedTools)
+
+		http := result.MCPServers["http-server"]
+		assert.Equal(t, "", http.Command)
+		assert.Equal(t, "http://localhost:3000/mcp", http.URL)
+		assert.Equal(t, "bearer-token", http.Token)
+		assert.Equal(t, []string{"query"}, http.AllowedTools)
+	})
+
+	t.Run("nil token becomes empty string", func(t *testing.T) {
+		cfg := config.MCPConfig{
+			MCPServers: map[string]config.MCPServerConfig{
+				"no-token": {
+					Command: "cmd",
+				},
+			},
+		}
+
+		result := toAgentSDKMCPConfig(cfg)
+		require.NotNil(t, result)
+		assert.Equal(t, "", result.MCPServers["no-token"].Token)
+	})
+}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -58,19 +58,49 @@ func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem *InMe
 		"tools":         toolNames,
 	})
 
-	a, err := agentsdk.NewAgent(
+	opts := []agentsdk.Option{
 		agentsdk.WithName("sushiclaw"),
 		agentsdk.WithLLM(llmClient),
 		agentsdk.WithSystemPrompt(systemPrompt),
 		agentsdk.WithTools(tools...),
 		agentsdk.WithMemory(mem),
 		agentsdk.WithRequirePlanApproval(false),
-	)
+	}
+	if mcpCfg := toAgentSDKMCPConfig(cfg.MCP); mcpCfg != nil {
+		opts = append(opts, agentsdk.WithMCPConfig(mcpCfg))
+	}
+
+	a, err := agentsdk.NewAgent(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("create agent: %w", err)
 	}
 
 	return a, nil
+}
+
+// toAgentSDKMCPConfig converts sushiclaw MCPConfig to agent-sdk-go MCPConfiguration.
+func toAgentSDKMCPConfig(cfg config.MCPConfig) *agentsdk.MCPConfiguration {
+	if len(cfg.MCPServers) == 0 {
+		return nil
+	}
+	servers := make(map[string]agentsdk.MCPServerConfig, len(cfg.MCPServers))
+	for name, s := range cfg.MCPServers {
+		var token string
+		if s.Token != nil {
+			token = s.Token.String()
+		}
+		servers[name] = agentsdk.MCPServerConfig{
+			Command:      s.Command,
+			Args:         s.Args,
+			Env:          s.Env,
+			URL:          s.URL,
+			Token:        token,
+			AllowedTools: s.AllowedTools,
+		}
+	}
+	return &agentsdk.MCPConfiguration{
+		MCPServers: servers,
+	}
 }
 
 // NewSessionManager creates a session manager from config.

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -15,11 +15,11 @@ import (
 
 type mockTool struct{ name string }
 
-func (m *mockTool) Name() string                                          { return m.name }
-func (m *mockTool) Description() string                                   { return "" }
-func (m *mockTool) Run(_ context.Context, _ string) (string, error)       { return "", nil }
-func (m *mockTool) Parameters() map[string]interfaces.ParameterSpec       { return nil }
-func (m *mockTool) Execute(_ context.Context, _ string) (string, error)   { return "", nil }
+func (m *mockTool) Name() string                                        { return m.name }
+func (m *mockTool) Description() string                                 { return "" }
+func (m *mockTool) Run(_ context.Context, _ string) (string, error)     { return "", nil }
+func (m *mockTool) Parameters() map[string]interfaces.ParameterSpec     { return nil }
+func (m *mockTool) Execute(_ context.Context, _ string) (string, error) { return "", nil }
 
 func TestBuildAgent_UnresolvedEnvKey(t *testing.T) {
 	_ = os.Unsetenv("MISSING_API_KEY")
@@ -166,4 +166,36 @@ func TestNewSessionManager_ToolsRegistered(t *testing.T) {
 	sm, err := agent.NewSessionManager(cfg, nil, []interfaces.Tool{tool})
 	require.NoError(t, err)
 	assert.Equal(t, []string{"test-tool"}, sm.ToolNames())
+}
+
+func TestBuildAgent_WithMCPConfig(t *testing.T) {
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{ModelName: "test-model"},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+		MCP: config.MCPConfig{
+			MCPServers: map[string]config.MCPServerConfig{
+				"filesystem": {
+					Command: "npx",
+					Args:    []string{"-y", "@modelcontextprotocol/server-filesystem", "/tmp"},
+				},
+				"remote": {
+					URL:   "http://localhost:3000/mcp",
+					Token: config.NewSecureString("secret-token"),
+				},
+			},
+		},
+	}
+
+	// BuildAgent should succeed with MCP config; agent-sdk-go uses lazy
+	// initialization so no actual server connection is attempted.
+	_, err := agent.BuildAgent(cfg, nil)
+	require.NoError(t, err, "expected BuildAgent to succeed with MCP config")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,22 @@ type Config struct {
 	EmailChannel *EmailChanCfg  `json:"email_channel,omitempty"`
 	Gateway      GatewayConfig  `json:"gateway"`
 	Tools        ToolsConfig    `json:"tools"`
+	MCP          MCPConfig      `json:"mcp,omitempty"`
+}
+
+// MCPConfig holds MCP server configuration.
+type MCPConfig struct {
+	MCPServers map[string]MCPServerConfig `json:"mcpServers"`
+}
+
+// MCPServerConfig represents a single MCP server configuration.
+type MCPServerConfig struct {
+	Command      string            `json:"command,omitempty"`
+	Args         []string          `json:"args,omitempty"`
+	Env          map[string]string `json:"env,omitempty"`
+	URL          string            `json:"url,omitempty"`
+	Token        *SecureString     `json:"token,omitzero"`
+	AllowedTools []string          `json:"allowedTools,omitempty"`
 }
 
 type AgentsConfig struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -48,4 +49,51 @@ func TestFlexibleStringSlice(t *testing.T) {
 	require.NotNil(t, tgCh)
 	// allow_from is [] in example config
 	assert.Empty(t, tgCh.AllowFrom)
+}
+
+func TestMCPConfigParsing(t *testing.T) {
+	cfg, err := config.LoadConfig("../../config.example.json")
+	require.NoError(t, err)
+
+	require.NotEmpty(t, cfg.MCP.MCPServers)
+	assert.Contains(t, cfg.MCP.MCPServers, "github")
+	assert.Contains(t, cfg.MCP.MCPServers, "filesystem")
+
+	gh := cfg.MCP.MCPServers["github"]
+	assert.Equal(t, "npx", gh.Command)
+	assert.Equal(t, []string{"-y", "@modelcontextprotocol/server-github"}, gh.Args)
+	assert.Equal(t, "env://GITHUB_TOKEN", gh.Env["GITHUB_PERSONAL_ACCESS_TOKEN"])
+
+	fs := cfg.MCP.MCPServers["filesystem"]
+	assert.Equal(t, "npx", fs.Command)
+	assert.Equal(t, []string{"-y", "@modelcontextprotocol/server-filesystem", "/home/user/workspace"}, fs.Args)
+}
+
+func TestMCPConfigTokenEnvResolve(t *testing.T) {
+	t.Setenv("MCP_TEST_TOKEN", "resolved-token")
+
+	jsonData := `{
+		"version": 2,
+		"agents": {"defaults": {"model_name": "test"}},
+		"model_list": [{"model_name": "test", "api_key": "test-key"}],
+		"channels": {},
+		"gateway": {"host": "0.0.0.0", "port": 18800, "log_level": "info"},
+		"tools": {"media_cleanup": {"enabled": false}, "exec": {"enabled": false}},
+		"mcp": {
+			"mcpServers": {
+				"remote": {
+					"url": "http://localhost:3000/mcp",
+					"token": "env://MCP_TEST_TOKEN"
+				}
+			}
+		}
+	}`
+
+	var cfg config.Config
+	err := json.Unmarshal([]byte(jsonData), &cfg)
+	require.NoError(t, err)
+
+	remote := cfg.MCP.MCPServers["remote"]
+	require.NotNil(t, remote.Token)
+	assert.Equal(t, "resolved-token", remote.Token.String())
 }


### PR DESCRIPTION
## Summary

Adds MCP (Model Context Protocol) server support to sushiclaw's agent session, resolving #76.

`agent-sdk-go` v0.2.44 already includes full MCP client support. This change wires it up by:

1. **New config types** (`pkg/config/config.go`):
   - `MCPConfig` / `MCPServerConfig` structs matching the agent-sdk-go shape
   - `Token` uses `*SecureString` so secrets can be resolved via `env://VAR_NAME`

2. **Agent wiring** (`internal/agent/session.go`):
   - `BuildAgent` now passes `agentsdk.WithMCPConfig(...)` when `mcpServers` are configured
   - `toAgentSDKMCPConfig` converts sushiclaw config to the SDK's `MCPConfiguration`

3. **Documentation** (`config.example.json`):
   - Added example `mcp` section with stdio (GitHub) and filesystem servers

## Test plan

- `make test` — all 22 packages pass
- `make lint` — no new issues introduced (13 pre-existing `errcheck` issues in unrelated files)
- Added tests:
  - `pkg/config/config_test.go`: `TestMCPConfigParsing`, `TestMCPConfigTokenEnvResolve`
  - `internal/agent/session_test.go`: `TestBuildAgent_WithMCPConfig`
  - `internal/agent/mcp_config_test.go`: unit tests for `toAgentSDKMCPConfig`

## Out of scope

- AGENT.md / SKILL.md frontmatter parsing (follow-up if desired)
- MCP global settings (timeout, retry, health check) — agent-sdk-go provides sensible defaults
- Dynamic MCP server registration after agent creation (blocked by agent-sdk-go design)