### PR TITLE
Add release publishing script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LDFLAGS     := -X $(VERSION_PKG).Version=$(VERSION) \
                -X $(VERSION_PKG).BuildTime=$(BUILDTIME) \
                -X $(VERSION_PKG).GoVersion=$(GOVER)
 
-.PHONY: build test install lint fmt vet deps test-integration release-check
+.PHONY: build test install lint fmt vet deps test-integration release-check publish-version publish-version-dry-run
 
 build:
 	CGO_ENABLED=0 go build -tags whatsapp_native -ldflags "$(LDFLAGS)" -o $(BINARY) .
@@ -51,3 +51,9 @@ test-integration:
 release-check:
 	@test "$(VERSION)" != "dev" || (echo "ERROR: no git tag found, set VERSION= explicitly" && exit 1)
 	@echo "Releasing $(VERSION) from commit $(COMMIT)"
+
+publish-version:
+	./scripts/publish-version.sh
+
+publish-version-dry-run:
+	./scripts/publish-version.sh --dry-run

--- a/scripts/publish-version.sh
+++ b/scripts/publish-version.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dry_run=false
+
+case "${1:-}" in
+	--dry-run)
+		dry_run=true
+		;;
+	"")
+		;;
+	*)
+		echo "Usage: $0 [--dry-run]" >&2
+		exit 2
+		;;
+esac
+
+git fetch --tags --prune-tags origin
+
+prefix="$(date -u +%Y.%m)"
+next_iter="$(
+	git ls-remote --tags --refs origin "refs/tags/${prefix}.*" |
+		awk -F/ '{print $3}' |
+		awk -F. -v prefix="${prefix}" '$1 "." $2 == prefix && $3 ~ /^[0-9]+$/ { if ($3 > max) max = $3; found = 1 } END { print found ? max + 1 : 0 }'
+)"
+version="${prefix}.${next_iter}"
+remote_head="$(git rev-parse --short=8 origin/main)"
+head="$(git rev-parse --short=8 HEAD)"
+
+echo "Next release tag: ${version}"
+echo "Current commit:   ${head}"
+echo "origin/main:      ${remote_head}"
+
+if [[ "${dry_run}" == true ]]; then
+	echo "Dry run: would create annotated tag ${version} and push it to origin."
+	echo "Command: git tag -a ${version} -m \"Release ${version}\""
+	echo "Command: git push origin ${version}"
+	exit 0
+fi
+
+printf "Publish %s from HEAD by pushing this tag to GitHub? [y/N] " "${version}"
+read -r answer
+
+case "${answer}" in
+	y | Y | yes | YES) ;;
+	*)
+		echo "Cancelled."
+		exit 1
+		;;
+esac
+
+git tag -a "${version}" -m "Release ${version}"
+git push origin "${version}"
+echo "Published ${version}."


### PR DESCRIPTION
## Summary
- Add a publish-version Make target that delegates to a Bash script.
- Compute the next calendar release tag from GitHub tags and ask for confirmation before pushing.
- Add a dry-run target for previewing the tag and commands without publishing.

## Test plan
- make test
- make lint
- git diff --check main...HEAD
- make publish-version-dry-run

## Known gaps
- None.