### PR TITLE
fix: add /model and /debug slash command handlers

### DIFF
--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -67,6 +67,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	cmdFilter := commandfilter.NewCommandFilter()
 
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	dm := NewDebugManager(messageBus)
 	rt := &commands.Runtime{
 		ListDefinitions: reg.Definitions,
 	}
@@ -137,6 +138,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	rt.ToggleDebug = dm.Toggle
 	if sessionMgr != nil {
 		rt.ClearHistory = sessionMgr.ClearHistory
 		rt.GetModelInfo = sessionMgr.GetModelInfo
@@ -246,4 +248,3 @@ func GetConfigPath() string {
 	}
 	return filepath.Join(GetHome(), "config.json")
 }
-

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -58,6 +58,7 @@ type Runtime struct {
 	ListDefinitions func() []Definition
 	ListModels      func() []string
 	ClearHistory    func() error
+	ToggleDebug     func(ctx context.Context, channel, chatID string) string
 }
 
 // Registry stores command definitions indexed by name and alias.
@@ -246,8 +247,8 @@ func BuiltinDefinitions() []Definition {
 		{Name: "start", Description: "Start the bot", Handler: startHandler},
 		{Name: "help", Description: "Show this help message", Handler: helpHandler},
 		{Name: "clear", Description: "Clear conversation history", Handler: clearHandler},
-		{Name: "debug", Description: "Toggle debug event forwarding"},
-		{Name: "model", Description: "Show or switch model"},
+		{Name: "debug", Description: "Toggle debug event forwarding", Handler: debugHandler},
+		{Name: "model", Description: "Show or switch model", Handler: modelHandler},
 		{Name: "show", Description: "Show current configuration"},
 		{Name: "list", Description: "List available options", SubCommands: []SubCommand{
 			{Name: "models", Description: "List configured models", Handler: listModelsHandler},
@@ -314,4 +315,23 @@ func clearHandler(_ context.Context, req Request, rt *Runtime) error {
 		}
 	}
 	return req.Reply("History cleared.")
+}
+
+func modelHandler(_ context.Context, req Request, rt *Runtime) error {
+	if rt == nil || rt.GetModelInfo == nil {
+		return req.Reply("Model info unavailable.")
+	}
+	name, provider := rt.GetModelInfo()
+	if name == "" {
+		return req.Reply("No model configured.")
+	}
+	return req.Reply(fmt.Sprintf("Current model: %s (%s)", name, provider))
+}
+
+func debugHandler(ctx context.Context, req Request, rt *Runtime) error {
+	if rt == nil || rt.ToggleDebug == nil {
+		return req.Reply("Debug toggle unavailable.")
+	}
+	reply := rt.ToggleDebug(ctx, req.Channel, req.ChatID)
+	return req.Reply(reply)
 }

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -104,6 +104,67 @@ func TestExecuteClearCallsCallback(t *testing.T) {
 	assert.Contains(t, replied, "cleared")
 }
 
+func TestExecuteModel(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{
+		GetModelInfo: func() (name, provider string) { return "gpt-4", "openai" },
+	}
+	exec := commands.NewExecutor(reg, rt)
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/model",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Contains(t, replied, "gpt-4")
+	assert.Contains(t, replied, "openai")
+}
+
+func TestExecuteModelNoRuntime(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{})
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/model",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Contains(t, replied, "unavailable")
+}
+
+func TestExecuteDebug(t *testing.T) {
+	toggled := false
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{
+		ToggleDebug: func(_ context.Context, _, _ string) string { toggled = true; return "Debug toggled." },
+	}
+	exec := commands.NewExecutor(reg, rt)
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/debug",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.True(t, toggled)
+	assert.Equal(t, "Debug toggled.", replied)
+}
+
+func TestExecuteDebugNoRuntime(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{})
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/debug",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Contains(t, replied, "unavailable")
+}
+
 func TestExecutePassthroughNoHandler(t *testing.T) {
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
 	exec := commands.NewExecutor(reg, &commands.Runtime{})


### PR DESCRIPTION
## Summary
- intercept `/model` locally and reply with the configured model name and provider instead of forwarding it to the agent
- intercept `/debug` locally by wiring the gateway debug manager into command runtime state
- add executor tests covering both commands and their unavailable-runtime fallbacks

## Test plan
- `make test`
- `make lint`

Closes #83.