### PR TITLE
feat(onboarding): add first-run onboarding and /welcome command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,7 @@ can report this as an error.
 | `channels` | Map of channel configs (WhatsApp native, Telegram). Email is **not** here — see `email_channel` |
 | `email_channel` | Top-level email config (SMTP + IMAP). See `pkg/channels/email/` |
 | `gateway` | `host`, `port`, `log_level` |
+| `onboarding` | `auto.enabled` — show onboarding on first Telegram/WhatsApp direct message |
 | `tools` | `exec.enabled`, `media_cleanup.enabled`, `media_cleanup.max_age`, `media_cleanup.interval` |
 
 ### Workspace files
@@ -223,6 +224,7 @@ Built-in commands (defined in `pkg/commands/commands.go`):
 | Command | Description |
 |---------|-------------|
 | `/start` | Greeting |
+| `/welcome` | Show onboarding and quick actions |
 | `/help` | List available commands |
 | `/clear` | Clear conversation history |
 | `/debug` | Toggle debug event forwarding |

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Copy `config.example.json` to `~/.picoclaw/config.json`. Key sections:
   "model_list": [{ "model_name": "claude-sonnet", "api_key": "env://ANTHROPIC_API_KEY" }],
   "channels": { ... },
   "email_channel": { ... },
+  "onboarding": { "auto": { "enabled": true } },
   "tools": { ... }
 }
 ```
@@ -114,9 +115,9 @@ Resolved at load time by `pkg/config.SecureString` during JSON unmarshal.
 
 ---
 
-### MCP server support
+### Onboarding
 
-Connect the agent to [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers for external tools (filesystem, GitHub, databases, etc.).
+Enable `onboarding.auto.enabled` to send a welcome message on the first direct message from Telegram or WhatsApp. Use `/welcome` at any time to see it again.
 
 ```json
 {

--- a/config.example.json
+++ b/config.example.json
@@ -64,6 +64,11 @@
     "port": 18800,
     "log_level": "info"
   },
+  "onboarding": {
+    "auto": {
+      "enabled": false
+    }
+  },
   "tools": {
     "web": {
       "enabled": true,

--- a/config_example_sushi30_test.go
+++ b/config_example_sushi30_test.go
@@ -35,6 +35,9 @@ func TestExampleConfigLoadsAsV2(t *testing.T) {
 	if cfg.Version != 2 {
 		t.Errorf("Version = %d, want 2", cfg.Version)
 	}
+	if cfg.Onboarding.Auto.Enabled {
+		t.Error("onboarding.auto.enabled should default to false in example config")
+	}
 
 	if len(cfg.ModelList) == 0 {
 		t.Error("model_list is empty")

--- a/internal/commandfilter/commandfilter_test.go
+++ b/internal/commandfilter/commandfilter_test.go
@@ -33,7 +33,7 @@ func TestFilter_SystemChannel(t *testing.T) {
 func TestFilter_KnownCommands(t *testing.T) {
 	f := NewCommandFilter()
 	cases := []string{
-		"/start", "/help", "/show", "/list", "/use",
+		"/start", "/help", "/welcome", "/show", "/list", "/use",
 		"/switch", "/check", "/clear", "/subagents", "/reload",
 	}
 	for _, cmd := range cases {
@@ -99,6 +99,11 @@ func TestFilter_BangPrefix(t *testing.T) {
 	dec := f.Filter(msg("!help"))
 	if dec.Result != Pass {
 		t.Errorf("!help should pass as known command, got %v", dec.Result)
+	}
+
+	dec = f.Filter(msg("!welcome"))
+	if dec.Result != Pass {
+		t.Errorf("!welcome should pass as known command, got %v", dec.Result)
 	}
 
 	dec = f.Filter(msg("!unknown"))

--- a/internal/gateway/config_test.go
+++ b/internal/gateway/config_test.go
@@ -48,4 +48,7 @@ func TestLoadExampleConfig(t *testing.T) {
 	if cfg.Gateway.Port != 18800 {
 		t.Errorf("gateway.port = %d, want 18800", cfg.Gateway.Port)
 	}
+	if cfg.Onboarding.Auto.Enabled {
+		t.Error("onboarding.auto.enabled = true, want false")
+	}
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -67,6 +67,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	cmdFilter := commandfilter.NewCommandFilter()
 
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	dm := NewDebugManager(messageBus)
 	rt := &commands.Runtime{
 		ListDefinitions: reg.Definitions,
 	}
@@ -137,12 +138,24 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	rt.ToggleDebug = dm.Toggle
 	if sessionMgr != nil {
 		rt.ClearHistory = sessionMgr.ClearHistory
 		rt.GetModelInfo = sessionMgr.GetModelInfo
 		rt.ListModels = sessionMgr.ListModels
 	}
 	executor := commands.NewExecutor(reg, rt)
+	router := &inboundRouter{
+		messageBus:     messageBus,
+		cmdFilter:      cmdFilter,
+		executor:       executor,
+		autoOnboarding: newOnboardingState(cfg.Onboarding),
+	}
+	if sessionMgr != nil {
+		router.sessionDispatcher = func(ctx context.Context, msg bus.InboundMessage) {
+			go sessionMgr.Dispatch(ctx, msg)
+		}
+	}
 
 	// Inbound processing: filter commands, execute handled ones locally,
 	// forward the rest to the agent session.
@@ -155,61 +168,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 				if !ok {
 					return
 				}
-				dec := cmdFilter.Filter(msg)
-				logger.DebugCF("commandfilter", "Filtered message",
-					map[string]any{
-						"text":    msg.Content,
-						"result":  dec.Result,
-						"command": dec.Command,
-					})
-				if dec.Result == commandfilter.Block {
-					logger.InfoCF("commandfilter", "Blocked unrecognized slash command",
-						map[string]any{
-							"channel": msg.Channel,
-							"chat_id": msg.ChatID,
-							"command": dec.Command,
-						})
-					_ = messageBus.PublishOutbound(ctx, bus.OutboundMessage{
-						Channel: msg.Channel,
-						ChatID:  msg.ChatID,
-						Content: dec.ErrMsg,
-					})
-					continue
-				}
-
-				if commands.HasCommandPrefix(msg.Content) {
-					var reply string
-					result := executor.Execute(ctx, commands.Request{
-						Channel:  msg.Channel,
-						ChatID:   msg.ChatID,
-						SenderID: msg.SenderID,
-						Text:     msg.Content,
-						Reply:    func(text string) error { reply = text; return nil },
-					})
-					logger.DebugCF("executor", "Command executed",
-						map[string]any{
-							"text":    msg.Content,
-							"command": result.Command,
-							"outcome": result.Outcome,
-							"handled": result.Outcome == commands.OutcomeHandled,
-						})
-					if result.Outcome == commands.OutcomeHandled {
-						if reply != "" {
-							_ = messageBus.PublishOutbound(ctx, bus.OutboundMessage{
-								Channel: msg.Channel,
-								ChatID:  msg.ChatID,
-								Content: reply,
-							})
-						}
-						continue
-					}
-					// OutcomePassthrough: forward to agent.
-				}
-
-				// Dispatch to agent session directly (avoids bus read race).
-				if sessionMgr != nil {
-					go sessionMgr.Dispatch(ctx, msg)
-				}
+				router.handleMessage(ctx, msg)
 			}
 		}
 	}()
@@ -246,4 +205,3 @@ func GetConfigPath() string {
 	}
 	return filepath.Join(GetHome(), "config.json")
 }
-

--- a/internal/gateway/onboarding.go
+++ b/internal/gateway/onboarding.go
@@ -1,0 +1,140 @@
+package gateway
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sushi30/sushiclaw/internal/commandfilter"
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/commands"
+	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/logger"
+)
+
+type onboardingState struct {
+	enabled bool
+	shown   bool
+}
+
+func newOnboardingState(cfg config.OnboardingConfig) *onboardingState {
+	return &onboardingState{enabled: cfg.Auto.Enabled}
+}
+
+func (o *onboardingState) consume(msg bus.InboundMessage) (string, bool) {
+	if !o.shouldAutoReply(msg) {
+		return "", false
+	}
+	o.shown = true
+	return commands.OnboardingMessage(), true
+}
+
+func (o *onboardingState) shouldAutoReply(msg bus.InboundMessage) bool {
+	if o == nil || !o.enabled || o.shown {
+		return false
+	}
+	if commands.HasCommandPrefix(msg.Content) {
+		return false
+	}
+	channel := inboundChannel(msg)
+	if channel == "system" {
+		return false
+	}
+	if channel != config.ChannelTelegram && channel != config.ChannelWhatsAppNative {
+		return false
+	}
+	return inboundChatType(msg) == "direct"
+}
+
+type inboundRouter struct {
+	messageBus        *bus.MessageBus
+	cmdFilter         *commandfilter.CommandFilter
+	executor          *commands.Executor
+	sessionDispatcher func(context.Context, bus.InboundMessage)
+	autoOnboarding    *onboardingState
+}
+
+func (r *inboundRouter) handleMessage(ctx context.Context, msg bus.InboundMessage) {
+	dec := r.cmdFilter.Filter(msg)
+	logger.DebugCF("commandfilter", "Filtered message",
+		map[string]any{
+			"text":    msg.Content,
+			"result":  dec.Result,
+			"command": dec.Command,
+		})
+	if dec.Result == commandfilter.Block {
+		logger.InfoCF("commandfilter", "Blocked unrecognized slash command",
+			map[string]any{
+				"channel": inboundChannel(msg),
+				"chat_id": inboundChatID(msg),
+				"command": dec.Command,
+			})
+		r.publishReply(ctx, msg, dec.ErrMsg)
+		return
+	}
+
+	if commands.HasCommandPrefix(msg.Content) {
+		var reply string
+		result := r.executor.Execute(ctx, commands.Request{
+			Channel:  inboundChannel(msg),
+			ChatID:   inboundChatID(msg),
+			SenderID: inboundSenderID(msg),
+			Text:     msg.Content,
+			Reply:    func(text string) error { reply = text; return nil },
+		})
+		logger.DebugCF("executor", "Command executed",
+			map[string]any{
+				"text":    msg.Content,
+				"command": result.Command,
+				"outcome": result.Outcome,
+				"handled": result.Outcome == commands.OutcomeHandled,
+			})
+		if result.Outcome == commands.OutcomeHandled {
+			if reply != "" {
+				r.publishReply(ctx, msg, reply)
+			}
+			return
+		}
+	}
+
+	if reply, ok := r.autoOnboarding.consume(msg); ok {
+		r.publishReply(ctx, msg, reply)
+		return
+	}
+
+	if r.sessionDispatcher != nil {
+		r.sessionDispatcher(ctx, msg)
+	}
+}
+
+func (r *inboundRouter) publishReply(ctx context.Context, msg bus.InboundMessage, content string) {
+	_ = r.messageBus.PublishOutbound(ctx, bus.OutboundMessage{
+		Channel: inboundChannel(msg),
+		ChatID:  inboundChatID(msg),
+		Content: content,
+	})
+}
+
+func inboundChannel(msg bus.InboundMessage) string {
+	if msg.Context.Channel != "" {
+		return msg.Context.Channel
+	}
+	return strings.TrimSpace(msg.Channel)
+}
+
+func inboundChatID(msg bus.InboundMessage) string {
+	if msg.Context.ChatID != "" {
+		return msg.Context.ChatID
+	}
+	return strings.TrimSpace(msg.ChatID)
+}
+
+func inboundSenderID(msg bus.InboundMessage) string {
+	if msg.Context.SenderID != "" {
+		return msg.Context.SenderID
+	}
+	return strings.TrimSpace(msg.SenderID)
+}
+
+func inboundChatType(msg bus.InboundMessage) string {
+	return strings.ToLower(strings.TrimSpace(msg.Context.ChatType))
+}

--- a/internal/gateway/onboarding_test.go
+++ b/internal/gateway/onboarding_test.go
@@ -1,0 +1,224 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sushi30/sushiclaw/internal/commandfilter"
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/commands"
+	"github.com/sushi30/sushiclaw/pkg/config"
+)
+
+func TestInboundRouter_AutoOnboardsFirstQualifyingMessage(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	defer messageBus.Close()
+
+	dispatched := false
+	router := newTestInboundRouter(messageBus, true, func(context.Context, bus.InboundMessage) {
+		dispatched = true
+	})
+
+	router.handleMessage(context.Background(), bus.InboundMessage{
+		Channel: config.ChannelTelegram,
+		ChatID:  "123",
+		Content: "hello there",
+		Context: bus.InboundContext{
+			Channel:  config.ChannelTelegram,
+			ChatID:   "123",
+			ChatType: "direct",
+		},
+	})
+
+	msg := mustReadOutbound(t, messageBus)
+	if msg.Content != commands.OnboardingMessage() {
+		t.Fatalf("got onboarding %q, want shared onboarding message", msg.Content)
+	}
+	if dispatched {
+		t.Fatal("expected first qualifying message to be consumed before agent dispatch")
+	}
+}
+
+func TestInboundRouter_AutoOnboardsOnlyOncePerProcess(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	defer messageBus.Close()
+
+	dispatches := 0
+	router := newTestInboundRouter(messageBus, true, func(context.Context, bus.InboundMessage) {
+		dispatches++
+	})
+
+	first := bus.InboundMessage{
+		Channel: config.ChannelTelegram,
+		ChatID:  "123",
+		Content: "hello",
+		Context: bus.InboundContext{
+			Channel:  config.ChannelTelegram,
+			ChatID:   "123",
+			ChatType: "direct",
+		},
+	}
+	second := bus.InboundMessage{
+		Channel: config.ChannelWhatsAppNative,
+		ChatID:  "456",
+		Content: "hello again",
+		Context: bus.InboundContext{
+			Channel:  config.ChannelWhatsAppNative,
+			ChatID:   "456",
+			ChatType: "direct",
+		},
+	}
+
+	router.handleMessage(context.Background(), first)
+	_ = mustReadOutbound(t, messageBus)
+
+	router.handleMessage(context.Background(), second)
+	assertNoOutbound(t, messageBus)
+	if dispatches != 1 {
+		t.Fatalf("dispatches = %d, want 1", dispatches)
+	}
+}
+
+func TestInboundRouter_DoesNotAutoOnboardEmailOrGroupMessages(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  bus.InboundMessage
+	}{
+		{
+			name: "email direct",
+			msg: bus.InboundMessage{
+				Channel: config.ChannelEmail,
+				ChatID:  "person@example.com",
+				Content: "hello",
+				Context: bus.InboundContext{
+					Channel:  config.ChannelEmail,
+					ChatID:   "person@example.com",
+					ChatType: "direct",
+				},
+			},
+		},
+		{
+			name: "telegram group",
+			msg: bus.InboundMessage{
+				Channel: config.ChannelTelegram,
+				ChatID:  "-100123",
+				Content: "hello",
+				Context: bus.InboundContext{
+					Channel:  config.ChannelTelegram,
+					ChatID:   "-100123",
+					ChatType: "group",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			messageBus := bus.NewMessageBus()
+			defer messageBus.Close()
+
+			dispatches := 0
+			router := newTestInboundRouter(messageBus, true, func(context.Context, bus.InboundMessage) {
+				dispatches++
+			})
+
+			router.handleMessage(context.Background(), tc.msg)
+
+			assertNoOutbound(t, messageBus)
+			if dispatches != 1 {
+				t.Fatalf("dispatches = %d, want 1", dispatches)
+			}
+		})
+	}
+}
+
+func TestInboundRouter_UnknownCommandStaysBlocked(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	defer messageBus.Close()
+
+	dispatched := false
+	router := newTestInboundRouter(messageBus, true, func(context.Context, bus.InboundMessage) {
+		dispatched = true
+	})
+
+	router.handleMessage(context.Background(), bus.InboundMessage{
+		Channel: config.ChannelTelegram,
+		ChatID:  "123",
+		Content: "/nope",
+		Context: bus.InboundContext{
+			Channel:  config.ChannelTelegram,
+			ChatID:   "123",
+			ChatType: "direct",
+		},
+	})
+
+	msg := mustReadOutbound(t, messageBus)
+	if msg.Content != "Unknown command: /nope" {
+		t.Fatalf("got %q, want unknown-command reply", msg.Content)
+	}
+	if dispatched {
+		t.Fatal("expected blocked unknown command not to dispatch to agent")
+	}
+}
+
+func TestInboundRouter_WelcomeCommandWorksWhenAutoOnboardingDisabled(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	defer messageBus.Close()
+
+	dispatched := false
+	router := newTestInboundRouter(messageBus, false, func(context.Context, bus.InboundMessage) {
+		dispatched = true
+	})
+
+	router.handleMessage(context.Background(), bus.InboundMessage{
+		Channel: config.ChannelTelegram,
+		ChatID:  "123",
+		Content: "/welcome",
+		Context: bus.InboundContext{
+			Channel:  config.ChannelTelegram,
+			ChatID:   "123",
+			ChatType: "direct",
+		},
+	})
+
+	msg := mustReadOutbound(t, messageBus)
+	if msg.Content != commands.OnboardingMessage() {
+		t.Fatalf("got welcome reply %q, want shared onboarding message", msg.Content)
+	}
+	if dispatched {
+		t.Fatal("expected /welcome to be handled locally")
+	}
+}
+
+func newTestInboundRouter(messageBus *bus.MessageBus, autoEnabled bool, dispatch func(context.Context, bus.InboundMessage)) *inboundRouter {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{ListDefinitions: reg.Definitions}
+	return &inboundRouter{
+		messageBus:        messageBus,
+		cmdFilter:         commandfilter.NewCommandFilter(),
+		executor:          commands.NewExecutor(reg, rt),
+		sessionDispatcher: dispatch,
+		autoOnboarding:    newOnboardingState(config.OnboardingConfig{Auto: config.AutoOnboardingConfig{Enabled: autoEnabled}}),
+	}
+}
+
+func mustReadOutbound(t *testing.T, messageBus *bus.MessageBus) bus.OutboundMessage {
+	t.Helper()
+	select {
+	case msg := <-messageBus.OutboundChan():
+		return msg
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for outbound message")
+		return bus.OutboundMessage{}
+	}
+}
+
+func assertNoOutbound(t *testing.T, messageBus *bus.MessageBus) {
+	t.Helper()
+	select {
+	case msg := <-messageBus.OutboundChan():
+		t.Fatalf("unexpected outbound message: %q", msg.Content)
+	default:
+	}
+}

--- a/pkg/bus/types.go
+++ b/pkg/bus/types.go
@@ -35,11 +35,11 @@ type InboundContext struct {
 
 type InboundMessage struct {
 	Context    InboundContext `json:"context"`
-	Sender     SenderInfo    `json:"sender"`
-	Content    string        `json:"content"`
-	Media      []string      `json:"media,omitempty"`
-	MediaScope string        `json:"media_scope,omitempty"`
-	SessionKey string        `json:"session_key"`
+	Sender     SenderInfo     `json:"sender"`
+	Content    string         `json:"content"`
+	Media      []string       `json:"media,omitempty"`
+	MediaScope string         `json:"media_scope,omitempty"`
+	SessionKey string         `json:"session_key"`
 
 	Channel   string `json:"channel"`
 	SenderID  string `json:"sender_id"`

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -17,10 +17,10 @@ var ErrSendFailed = errors.New("channel send failed")
 
 // Manager owns the channel set and dispatches outbound messages from the bus.
 type Manager struct {
-	mu          sync.RWMutex
-	channels    map[string]Channel
-	bus         *bus.MessageBus
-	mediaStore  media.MediaStore
+	mu         sync.RWMutex
+	channels   map[string]Channel
+	bus        *bus.MessageBus
+	mediaStore media.MediaStore
 
 	placeholders  sync.Map // "channel:chatID" → placeholderID (string)
 	typingStops   sync.Map // "channel:chatID" → func()
@@ -34,9 +34,9 @@ type Manager struct {
 // NewManager creates a Manager, creates channels from config factories, and sets up media/placeholders.
 func NewManager(cfg *config.Config, messageBus *bus.MessageBus, ms media.MediaStore) (*Manager, error) {
 	m := &Manager{
-		channels:    make(map[string]Channel),
-		bus:         messageBus,
-		mediaStore:  ms,
+		channels:     make(map[string]Channel),
+		bus:          messageBus,
+		mediaStore:   ms,
 		dispatchDone: make(chan struct{}),
 	}
 

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -58,6 +58,7 @@ type Runtime struct {
 	ListDefinitions func() []Definition
 	ListModels      func() []string
 	ClearHistory    func() error
+	ToggleDebug     func(ctx context.Context, channel, chatID string) string
 }
 
 // Registry stores command definitions indexed by name and alias.
@@ -239,15 +240,33 @@ func normalize(name string) string {
 	return strings.ToLower(strings.TrimSpace(name))
 }
 
+// OnboardingMessage returns the shared onboarding copy used by /welcome and
+// first-run auto-onboarding.
+func OnboardingMessage() string {
+	return strings.Join([]string{
+		"Welcome to sushiclaw.",
+		"I can help with:",
+		"- answering questions and explaining code",
+		"- inspecting files and debugging issues",
+		"- using configured tools and commands",
+		"Try one of these:",
+		"- /help",
+		"- /model",
+		"- Ask: summarize this repo",
+		"- Ask: debug this error",
+	}, "\n")
+}
+
 // BuiltinDefinitions returns sushiclaw's recognized slash commands.
 // These are used by the command filter to allow/block commands.
 func BuiltinDefinitions() []Definition {
 	return []Definition{
 		{Name: "start", Description: "Start the bot", Handler: startHandler},
 		{Name: "help", Description: "Show this help message", Handler: helpHandler},
+		{Name: "welcome", Description: "Show onboarding and quick actions", Handler: welcomeHandler},
 		{Name: "clear", Description: "Clear conversation history", Handler: clearHandler},
-		{Name: "debug", Description: "Toggle debug event forwarding"},
-		{Name: "model", Description: "Show or switch model"},
+		{Name: "debug", Description: "Toggle debug event forwarding", Handler: debugHandler},
+		{Name: "model", Description: "Show or switch model", Handler: modelHandler},
 		{Name: "show", Description: "Show current configuration"},
 		{Name: "list", Description: "List available options", SubCommands: []SubCommand{
 			{Name: "models", Description: "List configured models", Handler: listModelsHandler},
@@ -291,6 +310,10 @@ func helpHandler(_ context.Context, req Request, rt *Runtime) error {
 	return req.Reply(strings.TrimRight(sb.String(), "\n"))
 }
 
+func welcomeHandler(_ context.Context, req Request, _ *Runtime) error {
+	return req.Reply(OnboardingMessage())
+}
+
 func listModelsHandler(_ context.Context, req Request, rt *Runtime) error {
 	if rt == nil || rt.ListModels == nil {
 		return req.Reply("Model list unavailable.")
@@ -314,4 +337,23 @@ func clearHandler(_ context.Context, req Request, rt *Runtime) error {
 		}
 	}
 	return req.Reply("History cleared.")
+}
+
+func modelHandler(_ context.Context, req Request, rt *Runtime) error {
+	if rt == nil || rt.GetModelInfo == nil {
+		return req.Reply("Model info unavailable.")
+	}
+	name, provider := rt.GetModelInfo()
+	if name == "" {
+		return req.Reply("No model configured.")
+	}
+	return req.Reply(fmt.Sprintf("Current model: %s (%s)", name, provider))
+}
+
+func debugHandler(ctx context.Context, req Request, rt *Runtime) error {
+	if rt == nil || rt.ToggleDebug == nil {
+		return req.Reply("Debug toggle unavailable.")
+	}
+	reply := rt.ToggleDebug(ctx, req.Channel, req.ChatID)
+	return req.Reply(reply)
 }

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -58,6 +58,7 @@ func TestExecuteHelp(t *testing.T) {
 	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
 	assert.Contains(t, replied, "/help")
 	assert.Contains(t, replied, "/clear")
+	assert.Contains(t, replied, "/welcome")
 }
 
 func TestExecuteHelpNoRuntime(t *testing.T) {
@@ -86,6 +87,20 @@ func TestExecuteStart(t *testing.T) {
 	assert.NotEmpty(t, replied)
 }
 
+func TestExecuteWelcome(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{})
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/welcome",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Contains(t, replied, "I can help with")
+	assert.Contains(t, replied, "/help")
+}
+
 func TestExecuteClearCallsCallback(t *testing.T) {
 	cleared := false
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
@@ -102,6 +117,67 @@ func TestExecuteClearCallsCallback(t *testing.T) {
 	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
 	assert.True(t, cleared)
 	assert.Contains(t, replied, "cleared")
+}
+
+func TestExecuteModel(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{
+		GetModelInfo: func() (name, provider string) { return "gpt-4", "openai" },
+	}
+	exec := commands.NewExecutor(reg, rt)
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/model",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Contains(t, replied, "gpt-4")
+	assert.Contains(t, replied, "openai")
+}
+
+func TestExecuteModelNoRuntime(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{})
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/model",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Contains(t, replied, "unavailable")
+}
+
+func TestExecuteDebug(t *testing.T) {
+	toggled := false
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{
+		ToggleDebug: func(_ context.Context, _, _ string) string { toggled = true; return "Debug toggled." },
+	}
+	exec := commands.NewExecutor(reg, rt)
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/debug",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.True(t, toggled)
+	assert.Equal(t, "Debug toggled.", replied)
+}
+
+func TestExecuteDebugNoRuntime(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{})
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/debug",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Contains(t, replied, "unavailable")
 }
 
 func TestExecutePassthroughNoHandler(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,14 +17,15 @@ const (
 
 // Config is the top-level sushiclaw configuration.
 type Config struct {
-	Version      int            `json:"version,omitempty"`
-	Agents       AgentsConfig   `json:"agents"`
-	ModelList    []ModelConfig  `json:"model_list"`
-	Channels     ChannelsConfig `json:"channels"`
-	EmailChannel *EmailChanCfg  `json:"email_channel,omitempty"`
-	Gateway      GatewayConfig  `json:"gateway"`
-	Tools        ToolsConfig    `json:"tools"`
-	MCP          MCPConfig      `json:"mcp,omitempty"`
+	Version      int              `json:"version,omitempty"`
+	Agents       AgentsConfig     `json:"agents"`
+	ModelList    []ModelConfig    `json:"model_list"`
+	Channels     ChannelsConfig   `json:"channels"`
+	EmailChannel *EmailChanCfg    `json:"email_channel,omitempty"`
+	Gateway      GatewayConfig    `json:"gateway"`
+	Onboarding   OnboardingConfig `json:"onboarding,omitempty"`
+	Tools        ToolsConfig      `json:"tools"`
+	MCP          MCPConfig        `json:"mcp,omitempty"`
 }
 
 // MCPConfig holds MCP server configuration.
@@ -80,6 +81,14 @@ type GatewayConfig struct {
 	Host     string `json:"host"`
 	Port     int    `json:"port"`
 	LogLevel string `json:"log_level"`
+}
+
+type OnboardingConfig struct {
+	Auto AutoOnboardingConfig `json:"auto,omitempty"`
+}
+
+type AutoOnboardingConfig struct {
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 type ToolsConfig struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,41 @@ func TestParseExampleConfig(t *testing.T) {
 	assert.NotEmpty(t, cfg.ModelList)
 	assert.Equal(t, "claude-sonnet", cfg.ModelList[0].ModelName)
 	assert.Equal(t, 18800, cfg.Gateway.Port)
+	assert.False(t, cfg.Onboarding.Auto.Enabled)
 	assert.NotNil(t, cfg.Channels["telegram"])
+}
+
+func TestOnboardingConfigDefaultsDisabledWhenMissing(t *testing.T) {
+	jsonData := `{
+		"version": 2,
+		"agents": {"defaults": {"model_name": "test"}},
+		"model_list": [{"model_name": "test", "model": "gpt-4", "api_key": "test-key"}],
+		"channels": {},
+		"gateway": {"host": "0.0.0.0", "port": 18800, "log_level": "info"},
+		"tools": {"media_cleanup": {"enabled": false}, "exec": {"enabled": false}}
+	}`
+
+	var cfg config.Config
+	err := json.Unmarshal([]byte(jsonData), &cfg)
+	require.NoError(t, err)
+	assert.False(t, cfg.Onboarding.Auto.Enabled)
+}
+
+func TestOnboardingConfigParsing(t *testing.T) {
+	jsonData := `{
+		"version": 2,
+		"agents": {"defaults": {"model_name": "test"}},
+		"model_list": [{"model_name": "test", "model": "gpt-4", "api_key": "test-key"}],
+		"channels": {},
+		"gateway": {"host": "0.0.0.0", "port": 18800, "log_level": "info"},
+		"onboarding": {"auto": {"enabled": true}},
+		"tools": {"media_cleanup": {"enabled": false}, "exec": {"enabled": false}}
+	}`
+
+	var cfg config.Config
+	err := json.Unmarshal([]byte(jsonData), &cfg)
+	require.NoError(t, err)
+	assert.True(t, cfg.Onboarding.Auto.Enabled)
 }
 
 func TestChannelDecode(t *testing.T) {


### PR DESCRIPTION
## Summary
Add a lightweight onboarding flow that auto-replies once on the first qualifying direct message from Telegram or WhatsApp Native, plus a manual `/welcome` command that always works.

## Changes
- **Config**: Added `onboarding.auto.enabled` flag (defaults to `false` for backward compatibility)
- **Commands**: Added `/welcome` command with shared onboarding copy
- **Gateway**: Refactored inbound routing into testable `inboundRouter` with auto-onboarding logic
  - Auto-triggers only on first direct message from `telegram` or `whatsapp_native`
  - Consumes the first qualifying message (does not forward to agent)
  - Groups, email, and slash commands are excluded
- **Tests**: Added tests for config parsing, command handling, and gateway routing behavior
- **Docs**: Updated `README.md` and `AGENTS.md`

## Test Plan
- `make test` — all 382 tests pass
- `make fmt` — formatted
- `go vet ./...` — clean

## Closes
#79