### PR TITLE
feat(agent): wire max_tool_iterations config to agent-sdk-go WithMaxIterations

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -32,6 +32,11 @@ func BuildAgent(cfg *config.Config, tools []interfaces.Tool) (*agentsdk.Agent, e
 }
 
 func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem *InMemoryMemory) (*agentsdk.Agent, error) {
+	maxToolIterations := cfg.Agents.Defaults.MaxToolIterations
+	if maxToolIterations < 0 {
+		return nil, fmt.Errorf("invalid max_tool_iterations %d: must be >= 0", maxToolIterations)
+	}
+
 	llmClient, err := createLLM(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("create LLM: %w", err)
@@ -65,6 +70,9 @@ func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem *InMe
 		agentsdk.WithTools(tools...),
 		agentsdk.WithMemory(mem),
 		agentsdk.WithRequirePlanApproval(false),
+	}
+	if maxToolIterations > 0 {
+		opts = append(opts, agentsdk.WithMaxIterations(maxToolIterations))
 	}
 	if mcpCfg := toAgentSDKMCPConfig(cfg.MCP); mcpCfg != nil {
 		opts = append(opts, agentsdk.WithMCPConfig(mcpCfg))

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -3,8 +3,10 @@ package agent_test
 import (
 	"context"
 	"os"
+	"reflect"
 	"testing"
 
+	agentsdk "github.com/Ingenimax/agent-sdk-go/pkg/agent"
 	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,6 +22,14 @@ func (m *mockTool) Description() string                                 { return
 func (m *mockTool) Run(_ context.Context, _ string) (string, error)     { return "", nil }
 func (m *mockTool) Parameters() map[string]interfaces.ParameterSpec     { return nil }
 func (m *mockTool) Execute(_ context.Context, _ string) (string, error) { return "", nil }
+
+func agentMaxIterations(t *testing.T, a *agentsdk.Agent) int {
+	t.Helper()
+
+	v := reflect.ValueOf(a).Elem().FieldByName("maxIterations")
+	require.True(t, v.IsValid(), "expected maxIterations field to exist")
+	return int(v.Int())
+}
 
 func TestBuildAgent_UnresolvedEnvKey(t *testing.T) {
 	_ = os.Unsetenv("MISSING_API_KEY")
@@ -131,6 +141,73 @@ func TestBuildAgent_DefaultOpenAI(t *testing.T) {
 	// BuildAgent should succeed for default (non-OpenRouter) models.
 	_, err := agent.BuildAgent(cfg, nil)
 	require.NoError(t, err, "expected BuildAgent to succeed with default OpenAI provider")
+}
+
+func TestBuildAgent_MaxToolIterationsApplied(t *testing.T) {
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				ModelName:         "test-model",
+				MaxToolIterations: 7,
+			},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+	}
+
+	a, err := agent.BuildAgent(cfg, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 7, agentMaxIterations(t, a))
+}
+
+func TestBuildAgent_MaxToolIterationsZeroUsesDefault(t *testing.T) {
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				ModelName:         "test-model",
+				MaxToolIterations: 0,
+			},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+	}
+
+	a, err := agent.BuildAgent(cfg, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, agentMaxIterations(t, a))
+}
+
+func TestBuildAgent_MaxToolIterationsNegative(t *testing.T) {
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				ModelName:         "test-model",
+				MaxToolIterations: -1,
+			},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+	}
+
+	_, err := agent.BuildAgent(cfg, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "max_tool_iterations")
+	assert.Contains(t, err.Error(), "must be >= 0")
 }
 
 func TestBuildAgent_NoAPIKey(t *testing.T) {

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -246,4 +246,3 @@ func GetConfigPath() string {
 	}
 	return filepath.Join(GetHome(), "config.json")
 }
-

--- a/pkg/bus/types.go
+++ b/pkg/bus/types.go
@@ -35,11 +35,11 @@ type InboundContext struct {
 
 type InboundMessage struct {
 	Context    InboundContext `json:"context"`
-	Sender     SenderInfo    `json:"sender"`
-	Content    string        `json:"content"`
-	Media      []string      `json:"media,omitempty"`
-	MediaScope string        `json:"media_scope,omitempty"`
-	SessionKey string        `json:"session_key"`
+	Sender     SenderInfo     `json:"sender"`
+	Content    string         `json:"content"`
+	Media      []string       `json:"media,omitempty"`
+	MediaScope string         `json:"media_scope,omitempty"`
+	SessionKey string         `json:"session_key"`
 
 	Channel   string `json:"channel"`
 	SenderID  string `json:"sender_id"`

--- a/pkg/channels/manager.go
+++ b/pkg/channels/manager.go
@@ -17,10 +17,10 @@ var ErrSendFailed = errors.New("channel send failed")
 
 // Manager owns the channel set and dispatches outbound messages from the bus.
 type Manager struct {
-	mu          sync.RWMutex
-	channels    map[string]Channel
-	bus         *bus.MessageBus
-	mediaStore  media.MediaStore
+	mu         sync.RWMutex
+	channels   map[string]Channel
+	bus        *bus.MessageBus
+	mediaStore media.MediaStore
 
 	placeholders  sync.Map // "channel:chatID" → placeholderID (string)
 	typingStops   sync.Map // "channel:chatID" → func()
@@ -34,9 +34,9 @@ type Manager struct {
 // NewManager creates a Manager, creates channels from config factories, and sets up media/placeholders.
 func NewManager(cfg *config.Config, messageBus *bus.MessageBus, ms media.MediaStore) (*Manager, error) {
 	m := &Manager{
-		channels:    make(map[string]Channel),
-		bus:         messageBus,
-		mediaStore:  ms,
+		channels:     make(map[string]Channel),
+		bus:          messageBus,
+		mediaStore:   ms,
 		dispatchDone: make(chan struct{}),
 	}
 

--- a/pkg/config/config_extra_test.go
+++ b/pkg/config/config_extra_test.go
@@ -132,6 +132,7 @@ func TestLoadConfig_ValidFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, cfg.Version)
 	assert.Equal(t, "test-model", cfg.Agents.Defaults.ModelName)
+	assert.Equal(t, 5, cfg.Agents.Defaults.MaxToolIterations)
 	assert.Equal(t, 8080, cfg.Gateway.Port)
 	assert.NotNil(t, cfg.Channels["telegram"])
 	assert.Equal(t, "telegram", cfg.Channels["telegram"].Name())


### PR DESCRIPTION
## Summary
Wire the `agents.defaults.max_tool_iterations` config field to `agent-sdk-go`'s `WithMaxIterations` option.

- Validates that `max_tool_iterations` is >= 0, returning a clear error on negative values.
- Only passes `WithMaxIterations` when the value is > 0, preserving the SDK default (2) when set to 0.
- Adds unit tests for positive, zero, and negative values.

## Test plan
- `make test` passes (all packages).
- `go vet ./...` and `golangci-lint run ./...` pass.
- Added `TestBuildAgent_MaxToolIterationsApplied` — verifies the configured value is passed to the SDK.
- Added `TestBuildAgent_MaxToolIterationsZeroUsesDefault` — verifies 0 preserves the SDK default.
- Added `TestBuildAgent_MaxToolIterationsNegative` — verifies negative values return an error.