### PR TITLE
feat(tools): add read_file, write_file, and list_dir filesystem tools

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -80,6 +80,15 @@
       "enabled": true,
       "max_age": 30,
       "interval": 5
+    },
+    "read_file": {
+      "enabled": true
+    },
+    "write_file": {
+      "enabled": true
+    },
+    "list_dir": {
+      "enabled": true
     }
   },
   "mcp": {

--- a/internal/chat/repl.go
+++ b/internal/chat/repl.go
@@ -10,10 +10,10 @@ import (
 	"os"
 
 	agentsdk "github.com/Ingenimax/agent-sdk-go/pkg/agent"
-	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
 
 	"github.com/sushi30/sushiclaw/internal/agent"
 	"github.com/sushi30/sushiclaw/pkg/config"
+	sushitools "github.com/sushi30/sushiclaw/pkg/tools"
 	"github.com/sushi30/sushiclaw/pkg/tools/exec"
 )
 
@@ -29,12 +29,7 @@ type Runner struct {
 
 // NewRunner creates a chat runner from config.
 func NewRunner(cfg *config.Config) (*Runner, error) {
-	var tools []interfaces.Tool
-	if cfg.Tools.IsToolEnabled("exec") {
-		wd := cfg.WorkspacePath()
-		restrict := cfg.Agents.Defaults.RestrictToWorkspace
-		tools = append(tools, exec.NewExecTool(wd, restrict, true))
-	}
+	tools := sushitools.NewChatTools(cfg)
 
 	agentsdkAgent, err := agent.BuildAgent(cfg, tools)
 	if err != nil {

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -9,7 +9,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
 	"github.com/sushi30/sushiclaw/internal/agent"
 	"github.com/sushi30/sushiclaw/internal/commandfilter"
 	"github.com/sushi30/sushiclaw/internal/envresolve"
@@ -71,21 +70,15 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 		ListDefinitions: reg.Definitions,
 	}
 
-	var tools []interfaces.Tool
-	if allowedSenders := sushitools.ParseAllowedSenders(); len(allowedSenders) > 0 {
-		if cfg.Tools.IsToolEnabled("exec") {
-			workingDir := cfg.WorkspacePath()
-			restrict := cfg.Agents.Defaults.RestrictToWorkspace
-			trustedExec, err := sushitools.NewTrustedExecTool(cfg, workingDir, restrict, allowedSenders)
-			if err != nil {
-				logger.WarnCF("gateway", "Failed to init trusted exec tool",
-					map[string]any{"error": err.Error()})
-			} else {
-				tools = append(tools, trustedExec)
-				logger.InfoCF("gateway", "Trusted exec registered",
-					map[string]any{"senders": allowedSenders})
-			}
-		}
+	allowedSenders := sushitools.ParseAllowedSenders()
+	tools, err := sushitools.NewGatewayTools(cfg, allowedSenders)
+	if err != nil {
+		logger.WarnCF("gateway", "Failed to init trusted exec tool",
+			map[string]any{"error": err.Error()})
+	}
+	if cfg.Tools.IsToolEnabled("exec") && len(allowedSenders) > 0 && err == nil {
+		logger.InfoCF("gateway", "Trusted exec registered",
+			map[string]any{"senders": allowedSenders})
 	}
 
 	sessionMgr, err := agent.NewSessionManager(cfg, messageBus, tools)
@@ -246,4 +239,3 @@ func GetConfigPath() string {
 	}
 	return filepath.Join(GetHome(), "config.json")
 }
-

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -85,13 +85,27 @@ type GatewayConfig struct {
 type ToolsConfig struct {
 	MediaCleanup MediaCleanupCfg `json:"media_cleanup"`
 	Exec         ExecToolConfig  `json:"exec"`
+	ReadFile     ToolConfig      `json:"read_file"`
+	WriteFile    ToolConfig      `json:"write_file"`
+	ListDir      ToolConfig      `json:"list_dir"`
 }
 
 func (t ToolsConfig) IsToolEnabled(name string) bool {
-	if name == "exec" {
+	switch name {
+	case "exec":
 		return t.Exec.Enabled
+	case "read_file":
+		return t.ReadFile.Enabled
+	case "write_file":
+		return t.WriteFile.Enabled
+	case "list_dir":
+		return t.ListDir.Enabled
 	}
 	return false
+}
+
+type ToolConfig struct {
+	Enabled bool `json:"enabled"`
 }
 
 type ExecToolConfig struct {

--- a/pkg/config/config_extra_test.go
+++ b/pkg/config/config_extra_test.go
@@ -138,8 +138,16 @@ func TestLoadConfig_ValidFile(t *testing.T) {
 }
 
 func TestToolsConfig_IsToolEnabled(t *testing.T) {
-	cfg := config.ToolsConfig{Exec: config.ExecToolConfig{Enabled: true}}
+	cfg := config.ToolsConfig{
+		Exec:      config.ExecToolConfig{Enabled: true},
+		ReadFile:  config.ToolConfig{Enabled: true},
+		WriteFile: config.ToolConfig{Enabled: true},
+		ListDir:   config.ToolConfig{Enabled: true},
+	}
 	assert.True(t, cfg.IsToolEnabled("exec"))
+	assert.True(t, cfg.IsToolEnabled("read_file"))
+	assert.True(t, cfg.IsToolEnabled("write_file"))
+	assert.True(t, cfg.IsToolEnabled("list_dir"))
 	assert.False(t, cfg.IsToolEnabled("other"))
 }
 

--- a/pkg/tools/builder.go
+++ b/pkg/tools/builder.go
@@ -1,0 +1,58 @@
+package tools
+
+import (
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/tools/exec"
+	fstools "github.com/sushi30/sushiclaw/pkg/tools/fs"
+)
+
+// NewChatTools returns tools available to the local terminal chat.
+func NewChatTools(cfg *config.Config) []interfaces.Tool {
+	out := newFileTools(cfg)
+	if cfg.Tools.IsToolEnabled("exec") {
+		out = append(out, exec.NewExecTool(workspacePath(cfg), restrictToWorkspace(cfg), true))
+	}
+	return out
+}
+
+// NewGatewayTools returns tools available to remote gateway sessions.
+func NewGatewayTools(cfg *config.Config, execAllowedSenders []string) ([]interfaces.Tool, error) {
+	out := newFileTools(cfg)
+	if cfg.Tools.IsToolEnabled("exec") && len(execAllowedSenders) > 0 {
+		trustedExec, err := NewTrustedExecTool(cfg, workspacePath(cfg), restrictToWorkspace(cfg), execAllowedSenders)
+		if err != nil {
+			return out, err
+		}
+		out = append(out, trustedExec)
+	}
+	return out, nil
+}
+
+func newFileTools(cfg *config.Config) []interfaces.Tool {
+	workspace := workspacePath(cfg)
+	restrict := restrictToWorkspace(cfg)
+
+	var out []interfaces.Tool
+	if cfg.Tools.IsToolEnabled("read_file") {
+		out = append(out, fstools.NewReadFileTool(workspace, restrict, 0))
+	}
+	if cfg.Tools.IsToolEnabled("write_file") {
+		out = append(out, fstools.NewWriteFileTool(workspace, restrict))
+	}
+	if cfg.Tools.IsToolEnabled("list_dir") {
+		out = append(out, fstools.NewListDirTool(workspace, restrict))
+	}
+	return out
+}
+
+func workspacePath(cfg *config.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.WorkspacePath()
+}
+
+func restrictToWorkspace(cfg *config.Config) bool {
+	return cfg != nil && cfg.Agents.Defaults.RestrictToWorkspace
+}

--- a/pkg/tools/builder_test.go
+++ b/pkg/tools/builder_test.go
@@ -1,0 +1,89 @@
+package tools_test
+
+import (
+	"testing"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/tools"
+)
+
+func TestNewChatTools_RegistersEnabledTools(t *testing.T) {
+	cfg := newToolsConfig(t)
+	cfg.Tools.Exec.Enabled = true
+	cfg.Tools.ReadFile.Enabled = true
+	cfg.Tools.WriteFile.Enabled = true
+	cfg.Tools.ListDir.Enabled = true
+
+	got := toolNames(tools.NewChatTools(cfg))
+	want := []string{"read_file", "write_file", "list_dir", "exec"}
+	if !equalStrings(got, want) {
+		t.Fatalf("tool names = %v, want %v", got, want)
+	}
+}
+
+func TestNewGatewayTools_RegistersFileToolsWithoutExecAllowlist(t *testing.T) {
+	cfg := newToolsConfig(t)
+	cfg.Tools.Exec.Enabled = true
+	cfg.Tools.ReadFile.Enabled = true
+	cfg.Tools.ListDir.Enabled = true
+
+	built, err := tools.NewGatewayTools(cfg, nil)
+	if err != nil {
+		t.Fatalf("NewGatewayTools: %v", err)
+	}
+
+	got := toolNames(built)
+	want := []string{"read_file", "list_dir"}
+	if !equalStrings(got, want) {
+		t.Fatalf("tool names = %v, want %v", got, want)
+	}
+}
+
+func TestNewGatewayTools_RegistersTrustedExecWithAllowlist(t *testing.T) {
+	cfg := newToolsConfig(t)
+	cfg.Tools.Exec.Enabled = true
+
+	built, err := tools.NewGatewayTools(cfg, []string{"chat-1"})
+	if err != nil {
+		t.Fatalf("NewGatewayTools: %v", err)
+	}
+
+	got := toolNames(built)
+	want := []string{"exec"}
+	if !equalStrings(got, want) {
+		t.Fatalf("tool names = %v, want %v", got, want)
+	}
+}
+
+func newToolsConfig(t *testing.T) *config.Config {
+	t.Helper()
+	return &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace:           t.TempDir(),
+				RestrictToWorkspace: true,
+			},
+		},
+	}
+}
+
+func toolNames(tools []interfaces.Tool) []string {
+	names := make([]string, len(tools))
+	for i, tool := range tools {
+		names[i] = tool.Name()
+	}
+	return names
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/tools/fs/filesystem.go
+++ b/pkg/tools/fs/filesystem.go
@@ -1,0 +1,413 @@
+package fs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+const defaultMaxReadFileSize int64 = 64 * 1024
+
+type fileToolsFS struct {
+	workspace string
+	restrict  bool
+}
+
+func newFileToolsFS(workspace string, restrict bool) fileToolsFS {
+	return fileToolsFS{workspace: workspace, restrict: restrict}
+}
+
+func (f fileToolsFS) open(path string) (*os.File, error) {
+	if !f.restrict {
+		return os.Open(f.resolveHostPath(path))
+	}
+
+	root, rel, err := f.openRoot(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = root.Close() }()
+
+	file, err := root.Open(rel)
+	if err != nil {
+		return nil, formatAccessError("open file", err)
+	}
+	return file, nil
+}
+
+func (f fileToolsFS) writeFile(path string, content []byte) error {
+	if !f.restrict {
+		target := f.resolveHostPath(path)
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("failed to create parent directories: %w", err)
+		}
+		return os.WriteFile(target, content, 0o600)
+	}
+
+	root, rel, err := f.openRoot(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+
+	if dir := filepath.Dir(rel); dir != "." {
+		if err := root.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("failed to create parent directories: %w", err)
+		}
+	}
+	if err := root.WriteFile(rel, content, 0o600); err != nil {
+		return formatAccessError("write file", err)
+	}
+	return nil
+}
+
+func (f fileToolsFS) exists(path string) (bool, error) {
+	if !f.restrict {
+		_, err := os.Stat(f.resolveHostPath(path))
+		if err == nil {
+			return true, nil
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	root, rel, err := f.openRoot(path)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = root.Close() }()
+
+	_, err = root.Stat(rel)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, formatAccessError("stat file", err)
+}
+
+func (f fileToolsFS) readDir(path string) ([]os.DirEntry, error) {
+	if path == "" {
+		path = "."
+	}
+	if !f.restrict {
+		return os.ReadDir(f.resolveHostPath(path))
+	}
+
+	root, rel, err := f.openRoot(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = root.Close() }()
+
+	entries, err := fs.ReadDir(root.FS(), rel)
+	if err != nil {
+		return nil, formatAccessError("read directory", err)
+	}
+	return entries, nil
+}
+
+func (f fileToolsFS) resolveHostPath(path string) string {
+	if filepath.IsAbs(path) || f.workspace == "" {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(f.workspace, path))
+}
+
+func (f fileToolsFS) openRoot(path string) (*os.Root, string, error) {
+	if f.workspace == "" {
+		return nil, "", fmt.Errorf("workspace is not defined")
+	}
+
+	workspace, err := filepath.Abs(f.workspace)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to resolve workspace path: %w", err)
+	}
+
+	root, err := os.OpenRoot(workspace)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to open workspace: %w", err)
+	}
+
+	rel, err := safeRelPath(workspace, path)
+	if err != nil {
+		_ = root.Close()
+		return nil, "", err
+	}
+	return root, rel, nil
+}
+
+func safeRelPath(workspace, path string) (string, error) {
+	if path == "" {
+		path = "."
+	}
+
+	cleaned := filepath.Clean(path)
+	if filepath.IsAbs(cleaned) {
+		rel, err := filepath.Rel(workspace, cleaned)
+		if err != nil {
+			return "", fmt.Errorf("failed to calculate relative path: %w", err)
+		}
+		cleaned = rel
+	}
+	if !filepath.IsLocal(cleaned) {
+		return "", fmt.Errorf("access denied: path is outside the workspace")
+	}
+	return cleaned, nil
+}
+
+func formatAccessError(action string, err error) error {
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to %s: file not found: %w", action, err)
+	}
+	if errors.Is(err, os.ErrPermission) ||
+		strings.Contains(err.Error(), "escapes from parent") ||
+		strings.Contains(err.Error(), "permission denied") ||
+		strings.Contains(err.Error(), "invalid argument") {
+		return fmt.Errorf("failed to %s: access denied: %w", action, err)
+	}
+	return fmt.Errorf("failed to %s: %w", action, err)
+}
+
+type ReadFileTool struct {
+	fs      fileToolsFS
+	maxSize int64
+}
+
+func NewReadFileTool(workspace string, restrict bool, maxReadFileSize int64) *ReadFileTool {
+	if maxReadFileSize <= 0 {
+		maxReadFileSize = defaultMaxReadFileSize
+	}
+	return &ReadFileTool{fs: newFileToolsFS(workspace, restrict), maxSize: maxReadFileSize}
+}
+
+func (t *ReadFileTool) Name() string { return "read_file" }
+
+func (t *ReadFileTool) Description() string {
+	return "Read the contents of a file. Supports pagination via offset and length."
+}
+
+func (t *ReadFileTool) Parameters() map[string]interfaces.ParameterSpec {
+	return map[string]interfaces.ParameterSpec{
+		"path": {
+			Type:        "string",
+			Description: "Path to the file to read.",
+			Required:    true,
+		},
+		"offset": {
+			Type:        "integer",
+			Description: "Byte offset to start reading from.",
+			Required:    false,
+		},
+		"length": {
+			Type:        "integer",
+			Description: "Maximum number of bytes to read.",
+			Required:    false,
+		},
+	}
+}
+
+func (t *ReadFileTool) Run(ctx context.Context, input string) (string, error) {
+	return t.Execute(ctx, input)
+}
+
+func (t *ReadFileTool) Execute(_ context.Context, args string) (string, error) {
+	var req struct {
+		Path   string `json:"path"`
+		Offset int64  `json:"offset"`
+		Length int64  `json:"length"`
+	}
+	if err := json.Unmarshal([]byte(args), &req); err != nil {
+		return "", fmt.Errorf("invalid read_file arguments: %w", err)
+	}
+	if req.Path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if req.Offset < 0 {
+		return "", fmt.Errorf("offset must be >= 0")
+	}
+	if req.Length <= 0 || req.Length > t.maxSize {
+		req.Length = t.maxSize
+	}
+
+	file, err := t.fs.open(req.Path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = file.Close() }()
+
+	info, err := file.Stat()
+	if err != nil {
+		return "", fmt.Errorf("failed to stat file: %w", err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("failed to open file: path is a directory: %s", req.Path)
+	}
+
+	if _, err = file.Seek(req.Offset, io.SeekStart); err != nil {
+		return "", fmt.Errorf("failed to seek to offset %d: %w", req.Offset, err)
+	}
+
+	data := make([]byte, req.Length+1)
+	n, err := file.Read(data)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", fmt.Errorf("failed to read file content: %w", err)
+	}
+
+	hasMore := int64(n) > req.Length
+	if hasMore {
+		data = data[:req.Length]
+	} else {
+		data = data[:n]
+	}
+
+	if len(data) == 0 {
+		return "[END OF FILE - no content at this offset]", nil
+	}
+
+	end := req.Offset + int64(len(data))
+	header := fmt.Sprintf("[file: %s | total: %d bytes | read: bytes %d-%d]", filepath.Base(req.Path), info.Size(), req.Offset, end-1)
+	if hasMore {
+		header += fmt.Sprintf("\n[TRUNCATED - file has more content. Call read_file again with offset=%d to continue.]", end)
+	} else {
+		header += "\n[END OF FILE - no further content.]"
+	}
+	return header + "\n\n" + string(data), nil
+}
+
+type WriteFileTool struct {
+	fs fileToolsFS
+}
+
+func NewWriteFileTool(workspace string, restrict bool) *WriteFileTool {
+	return &WriteFileTool{fs: newFileToolsFS(workspace, restrict)}
+}
+
+func (t *WriteFileTool) Name() string { return "write_file" }
+
+func (t *WriteFileTool) Description() string {
+	return "Write content to a file. If the file already exists, overwrite must be true."
+}
+
+func (t *WriteFileTool) Parameters() map[string]interfaces.ParameterSpec {
+	return map[string]interfaces.ParameterSpec{
+		"path": {
+			Type:        "string",
+			Description: "Path to the file to write.",
+			Required:    true,
+		},
+		"content": {
+			Type:        "string",
+			Description: "Content to write to the file.",
+			Required:    true,
+		},
+		"overwrite": {
+			Type:        "boolean",
+			Description: "Set to true to overwrite an existing file.",
+			Required:    false,
+		},
+	}
+}
+
+func (t *WriteFileTool) Run(ctx context.Context, input string) (string, error) {
+	return t.Execute(ctx, input)
+}
+
+func (t *WriteFileTool) Execute(_ context.Context, args string) (string, error) {
+	var req struct {
+		Path      string  `json:"path"`
+		Content   *string `json:"content"`
+		Overwrite bool    `json:"overwrite"`
+	}
+	if err := json.Unmarshal([]byte(args), &req); err != nil {
+		return "", fmt.Errorf("invalid write_file arguments: %w", err)
+	}
+	if req.Path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if req.Content == nil {
+		return "", fmt.Errorf("content is required")
+	}
+
+	exists, err := t.fs.exists(req.Path)
+	if err != nil {
+		return "", err
+	}
+	if exists && !req.Overwrite {
+		return "", fmt.Errorf("file %s already exists. Set overwrite=true to replace", req.Path)
+	}
+	if err = t.fs.writeFile(req.Path, []byte(*req.Content)); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("File written: %s", req.Path), nil
+}
+
+type ListDirTool struct {
+	fs fileToolsFS
+}
+
+func NewListDirTool(workspace string, restrict bool) *ListDirTool {
+	return &ListDirTool{fs: newFileToolsFS(workspace, restrict)}
+}
+
+func (t *ListDirTool) Name() string { return "list_dir" }
+
+func (t *ListDirTool) Description() string {
+	return "List files and directories in a path."
+}
+
+func (t *ListDirTool) Parameters() map[string]interfaces.ParameterSpec {
+	return map[string]interfaces.ParameterSpec{
+		"path": {
+			Type:        "string",
+			Description: "Path to list. Defaults to the workspace root.",
+			Required:    false,
+		},
+	}
+}
+
+func (t *ListDirTool) Run(ctx context.Context, input string) (string, error) {
+	return t.Execute(ctx, input)
+}
+
+func (t *ListDirTool) Execute(_ context.Context, args string) (string, error) {
+	var req struct {
+		Path string `json:"path"`
+	}
+	if strings.TrimSpace(args) != "" {
+		if err := json.Unmarshal([]byte(args), &req); err != nil {
+			return "", fmt.Errorf("invalid list_dir arguments: %w", err)
+		}
+	}
+	if req.Path == "" {
+		req.Path = "."
+	}
+
+	entries, err := t.fs.readDir(req.Path)
+	if err != nil {
+		return "", err
+	}
+
+	var out strings.Builder
+	for _, entry := range entries {
+		if entry.IsDir() {
+			out.WriteString("DIR:  ")
+		} else {
+			out.WriteString("FILE: ")
+		}
+		out.WriteString(entry.Name())
+		out.WriteByte('\n')
+	}
+	return out.String(), nil
+}

--- a/pkg/tools/fs/filesystem_test.go
+++ b/pkg/tools/fs/filesystem_test.go
@@ -1,0 +1,181 @@
+package fs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadFileTool_ReadsContent(t *testing.T) {
+	dir := t.TempDir()
+	requireWriteFile(t, filepath.Join(dir, "notes.txt"), "hello world")
+
+	tool := NewReadFileTool(dir, true, 64)
+	out, err := tool.Execute(context.Background(), `{"path":"notes.txt"}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if !strings.Contains(out, "hello world") {
+		t.Fatalf("output = %q, want file content", out)
+	}
+	if !strings.Contains(out, "[END OF FILE") {
+		t.Fatalf("output = %q, want EOF marker", out)
+	}
+}
+
+func TestReadFileTool_PaginatesByOffsetAndLength(t *testing.T) {
+	dir := t.TempDir()
+	requireWriteFile(t, filepath.Join(dir, "long.txt"), "abcdef")
+
+	tool := NewReadFileTool(dir, true, 4)
+	out, err := tool.Execute(context.Background(), `{"path":"long.txt","offset":1,"length":3}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if !strings.Contains(out, "bcd") {
+		t.Fatalf("output = %q, want requested slice", out)
+	}
+	if !strings.Contains(out, "TRUNCATED") {
+		t.Fatalf("output = %q, want truncation marker", out)
+	}
+}
+
+func TestReadFileTool_BlocksWorkspaceEscape(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	requireWriteFile(t, filepath.Join(outside, "secret.txt"), "secret")
+
+	tool := NewReadFileTool(dir, true, 64)
+	_, err := tool.Execute(context.Background(), `{"path":"../secret.txt"}`)
+	if err == nil {
+		t.Fatal("expected workspace escape error")
+	}
+	if !strings.Contains(err.Error(), "outside the workspace") && !strings.Contains(err.Error(), "escapes workspace") {
+		t.Fatalf("error = %v, want workspace denial", err)
+	}
+}
+
+func TestReadFileTool_BlocksSymlinkEscape(t *testing.T) {
+	dir := t.TempDir()
+	outside := t.TempDir()
+	requireWriteFile(t, filepath.Join(outside, "secret.txt"), "secret")
+	if err := os.Symlink(filepath.Join(outside, "secret.txt"), filepath.Join(dir, "link.txt")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	tool := NewReadFileTool(dir, true, 64)
+	_, err := tool.Execute(context.Background(), `{"path":"link.txt"}`)
+	if err == nil {
+		t.Fatal("expected symlink escape error")
+	}
+	if !strings.Contains(err.Error(), "access denied") && !strings.Contains(err.Error(), "outside the workspace") {
+		t.Fatalf("error = %v, want symlink denial", err)
+	}
+}
+
+func TestWriteFileTool_WritesNewFileAndCreatesParents(t *testing.T) {
+	dir := t.TempDir()
+	tool := NewWriteFileTool(dir, true)
+
+	out, err := tool.Execute(context.Background(), `{"path":"nested/out.txt","content":"hello\r\nworld"}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "File written") {
+		t.Fatalf("output = %q, want success message", out)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "nested", "out.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "hello\r\nworld" {
+		t.Fatalf("content = %q, want CRLF-preserving content", string(got))
+	}
+}
+
+func TestWriteFileTool_RequiresOverwriteForExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "existing.txt")
+	requireWriteFile(t, path, "old")
+	tool := NewWriteFileTool(dir, true)
+
+	_, err := tool.Execute(context.Background(), `{"path":"existing.txt","content":"new"}`)
+	if err == nil {
+		t.Fatal("expected overwrite error")
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "old" {
+		t.Fatalf("content = %q, want original content", string(got))
+	}
+
+	_, err = tool.Execute(context.Background(), `{"path":"existing.txt","content":"new","overwrite":true}`)
+	if err != nil {
+		t.Fatalf("Execute overwrite: %v", err)
+	}
+	got, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile after overwrite: %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("content = %q, want overwritten content", string(got))
+	}
+}
+
+func TestListDirTool_ListsEntries(t *testing.T) {
+	dir := t.TempDir()
+	requireWriteFile(t, filepath.Join(dir, "file.txt"), "content")
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	tool := NewListDirTool(dir, true)
+	out, err := tool.Execute(context.Background(), `{}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if !strings.Contains(out, "FILE: file.txt") {
+		t.Fatalf("output = %q, want file entry", out)
+	}
+	if !strings.Contains(out, "DIR:  subdir") {
+		t.Fatalf("output = %q, want directory entry", out)
+	}
+}
+
+func TestToolsExposeExpectedMetadata(t *testing.T) {
+	read := NewReadFileTool("", false, 64)
+	write := NewWriteFileTool("", false)
+	list := NewListDirTool("", false)
+
+	if read.Name() != "read_file" || write.Name() != "write_file" || list.Name() != "list_dir" {
+		t.Fatalf("unexpected names: %q %q %q", read.Name(), write.Name(), list.Name())
+	}
+	if !read.Parameters()["path"].Required {
+		t.Fatal("read_file path should be required")
+	}
+	if !write.Parameters()["path"].Required || !write.Parameters()["content"].Required {
+		t.Fatal("write_file path and content should be required")
+	}
+	if list.Parameters()["path"].Required {
+		t.Fatal("list_dir path should be optional")
+	}
+}
+
+func requireWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
This PR introduces three new filesystem tools for the sushiclaw agent, enabling safe file reading, writing, and directory listing within the configured workspace:

- **`read_file`**: Read file contents with optional pagination via offset and length. Respects a max read size (default 64KB).
- **`write_file`**: Write content to a file, with automatic parent directory creation. Requires `overwrite=true` to replace existing files.
- **`list_dir`**: List files and directories in a given path.

All tools respect the `restrict_to_workspace` setting. When restricted, they use `os.Root` to prevent path traversal and symlink escapes outside the workspace.

### Additional changes
- Extracted tool construction into `pkg/tools/builder.go` with `NewChatTools()` and `NewGatewayTools()` helpers.
- Updated `pkg/config/config.go` to support `read_file`, `write_file`, and `list_dir` enablement flags.
- Updated `config.example.json` with the new tool configs.
- Refactored `internal/gateway/gateway.go` and `internal/chat/repl.go` to use the new builder.
- Removed unused `scripts/publish-version.sh`.

## Test plan
- `make test` passes (all 22 packages).
- `make lint` passes (0 issues).
- Added unit tests in `pkg/tools/fs/filesystem_test.go` covering:
  - Reading file content
  - Pagination with offset/length
  - Blocking workspace escape (`../`)
  - Blocking symlink escape
  - Writing new files and creating parent directories
  - Overwrite protection
  - Directory listing
  - Tool metadata validation
- Added unit tests in `pkg/tools/builder_test.go` covering:
  - Chat tool registration for enabled tools
  - Gateway tool registration with and without exec allowlist