### PR TITLE
feat(tools): add secure input handles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ go.work.sum
 
 # Config with secrets (use config.example.json as template)
 ~/.picoclaw/config.json
+.env
+.codex
 
 # Editor
 .idea/

--- a/config.example.json
+++ b/config.example.json
@@ -89,6 +89,9 @@
     },
     "list_dir": {
       "enabled": true
+    },
+    "secure_input": {
+      "enabled": false
     }
   },
   "mcp": {

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.mau.fi/whatsmeow v0.0.0-20260219150138-7ae702b1eed4
 	golang.org/x/net v0.53.0
+	golang.org/x/term v0.42.0
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.48.2
 )
@@ -97,7 +98,6 @@ require (
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/genai v1.30.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/internal/chat/repl.go
+++ b/internal/chat/repl.go
@@ -101,6 +101,7 @@ func (r *Runner) handleCommand(ctx context.Context, line string) (bool, error) {
 		_, _ = fmt.Fprintln(r.out, "Goodbye!")
 		return true, ErrQuit
 	case "/clear":
+		sushitools.ClearSecureInputs("cli")
 		// In-memory memory is per-agent-instance, so "clear" just means
 		// we can't easily clear it without access to the memory interface.
 		// For now, tell the user.

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -68,7 +68,8 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
 	dm := NewDebugManager(messageBus)
 	rt := &commands.Runtime{
-		ListDefinitions: reg.Definitions,
+		ListDefinitions:   reg.Definitions,
+		ClearSecureInputs: sushitools.ClearSecureInputs,
 	}
 
 	allowedSenders := sushitools.ParseAllowedSenders()

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -54,11 +54,12 @@ type Request struct {
 
 // Runtime provides runtime dependencies to command handlers.
 type Runtime struct {
-	GetModelInfo    func() (name, provider string)
-	ListDefinitions func() []Definition
-	ListModels      func() []string
-	ClearHistory    func() error
-	ToggleDebug     func(ctx context.Context, channel, chatID string) string
+	GetModelInfo      func() (name, provider string)
+	ListDefinitions   func() []Definition
+	ListModels        func() []string
+	ClearHistory      func() error
+	ClearSecureInputs func(chatID string)
+	ToggleDebug       func(ctx context.Context, channel, chatID string) string
 }
 
 // Registry stores command definitions indexed by name and alias.
@@ -313,6 +314,9 @@ func clearHandler(_ context.Context, req Request, rt *Runtime) error {
 		if err := rt.ClearHistory(); err != nil {
 			return req.Reply("Failed to clear history: " + err.Error())
 		}
+	}
+	if rt != nil && rt.ClearSecureInputs != nil {
+		rt.ClearSecureInputs(req.ChatID)
 	}
 	return req.Reply("History cleared.")
 }

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -88,19 +88,23 @@ func TestExecuteStart(t *testing.T) {
 
 func TestExecuteClearCallsCallback(t *testing.T) {
 	cleared := false
+	clearedSecureChat := ""
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
 	rt := &commands.Runtime{
-		ClearHistory: func() error { cleared = true; return nil },
+		ClearHistory:      func() error { cleared = true; return nil },
+		ClearSecureInputs: func(chatID string) { clearedSecureChat = chatID },
 	}
 	exec := commands.NewExecutor(reg, rt)
 
 	var replied string
 	result := exec.Execute(context.Background(), commands.Request{
-		Text:  "/clear",
-		Reply: func(s string) error { replied = s; return nil },
+		ChatID: "chat-1",
+		Text:   "/clear",
+		Reply:  func(s string) error { replied = s; return nil },
 	})
 	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
 	assert.True(t, cleared)
+	assert.Equal(t, "chat-1", clearedSecureChat)
 	assert.Contains(t, replied, "cleared")
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,6 +88,7 @@ type ToolsConfig struct {
 	ReadFile     ToolConfig      `json:"read_file"`
 	WriteFile    ToolConfig      `json:"write_file"`
 	ListDir      ToolConfig      `json:"list_dir"`
+	SecureInput  ToolConfig      `json:"secure_input"`
 }
 
 func (t ToolsConfig) IsToolEnabled(name string) bool {
@@ -100,6 +101,8 @@ func (t ToolsConfig) IsToolEnabled(name string) bool {
 		return t.WriteFile.Enabled
 	case "list_dir":
 		return t.ListDir.Enabled
+	case "secure_input":
+		return t.SecureInput.Enabled
 	}
 	return false
 }

--- a/pkg/config/config_extra_test.go
+++ b/pkg/config/config_extra_test.go
@@ -140,15 +140,17 @@ func TestLoadConfig_ValidFile(t *testing.T) {
 
 func TestToolsConfig_IsToolEnabled(t *testing.T) {
 	cfg := config.ToolsConfig{
-		Exec:      config.ExecToolConfig{Enabled: true},
-		ReadFile:  config.ToolConfig{Enabled: true},
-		WriteFile: config.ToolConfig{Enabled: true},
-		ListDir:   config.ToolConfig{Enabled: true},
+		Exec:        config.ExecToolConfig{Enabled: true},
+		ReadFile:    config.ToolConfig{Enabled: true},
+		WriteFile:   config.ToolConfig{Enabled: true},
+		ListDir:     config.ToolConfig{Enabled: true},
+		SecureInput: config.ToolConfig{Enabled: true},
 	}
 	assert.True(t, cfg.IsToolEnabled("exec"))
 	assert.True(t, cfg.IsToolEnabled("read_file"))
 	assert.True(t, cfg.IsToolEnabled("write_file"))
 	assert.True(t, cfg.IsToolEnabled("list_dir"))
+	assert.True(t, cfg.IsToolEnabled("secure_input"))
 	assert.False(t, cfg.IsToolEnabled("other"))
 }
 

--- a/pkg/tools/builder.go
+++ b/pkg/tools/builder.go
@@ -5,7 +5,10 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/tools/exec"
 	fstools "github.com/sushi30/sushiclaw/pkg/tools/fs"
+	"github.com/sushi30/sushiclaw/pkg/tools/secureinput"
 )
+
+var defaultSecureInputStore = secureinput.NewStore()
 
 // NewChatTools returns tools available to the local terminal chat.
 func NewChatTools(cfg *config.Config) []interfaces.Tool {
@@ -13,7 +16,7 @@ func NewChatTools(cfg *config.Config) []interfaces.Tool {
 	if cfg.Tools.IsToolEnabled("exec") {
 		out = append(out, exec.NewExecTool(workspacePath(cfg), restrictToWorkspace(cfg), true))
 	}
-	return out
+	return withSecureInput(cfg, out)
 }
 
 // NewGatewayTools returns tools available to remote gateway sessions.
@@ -26,7 +29,17 @@ func NewGatewayTools(cfg *config.Config, execAllowedSenders []string) ([]interfa
 		}
 		out = append(out, trustedExec)
 	}
-	return out, nil
+	return withSecureInput(cfg, out), nil
+}
+
+// ClearSecureInputs clears captured secure values for one chat/session.
+func ClearSecureInputs(chatID string) {
+	defaultSecureInputStore.ClearSession(chatID)
+}
+
+// ClearAllSecureInputs clears all captured secure values.
+func ClearAllSecureInputs() {
+	defaultSecureInputStore.ClearAll()
 }
 
 func newFileTools(cfg *config.Config) []interfaces.Tool {
@@ -44,6 +57,14 @@ func newFileTools(cfg *config.Config) []interfaces.Tool {
 		out = append(out, fstools.NewListDirTool(workspace, restrict))
 	}
 	return out
+}
+
+func withSecureInput(cfg *config.Config, out []interfaces.Tool) []interfaces.Tool {
+	if cfg == nil || !cfg.Tools.IsToolEnabled("secure_input") {
+		return out
+	}
+	out = secureinput.WrapAll(out, defaultSecureInputStore)
+	return append([]interfaces.Tool{secureinput.NewTool(defaultSecureInputStore, nil)}, out...)
 }
 
 func workspacePath(cfg *config.Config) string {

--- a/pkg/tools/builder_test.go
+++ b/pkg/tools/builder_test.go
@@ -22,6 +22,18 @@ func TestNewChatTools_RegistersEnabledTools(t *testing.T) {
 	}
 }
 
+func TestNewChatTools_RegistersSecureInputWhenEnabled(t *testing.T) {
+	cfg := newToolsConfig(t)
+	cfg.Tools.SecureInput.Enabled = true
+	cfg.Tools.ReadFile.Enabled = true
+
+	got := toolNames(tools.NewChatTools(cfg))
+	want := []string{"secure_input", "read_file"}
+	if !equalStrings(got, want) {
+		t.Fatalf("tool names = %v, want %v", got, want)
+	}
+}
+
 func TestNewGatewayTools_RegistersFileToolsWithoutExecAllowlist(t *testing.T) {
 	cfg := newToolsConfig(t)
 	cfg.Tools.Exec.Enabled = true
@@ -35,6 +47,23 @@ func TestNewGatewayTools_RegistersFileToolsWithoutExecAllowlist(t *testing.T) {
 
 	got := toolNames(built)
 	want := []string{"read_file", "list_dir"}
+	if !equalStrings(got, want) {
+		t.Fatalf("tool names = %v, want %v", got, want)
+	}
+}
+
+func TestNewGatewayTools_RegistersSecureInputWhenEnabled(t *testing.T) {
+	cfg := newToolsConfig(t)
+	cfg.Tools.SecureInput.Enabled = true
+	cfg.Tools.ListDir.Enabled = true
+
+	built, err := tools.NewGatewayTools(cfg, nil)
+	if err != nil {
+		t.Fatalf("NewGatewayTools: %v", err)
+	}
+
+	got := toolNames(built)
+	want := []string{"secure_input", "list_dir"}
 	if !equalStrings(got, want) {
 		t.Fatalf("tool names = %v, want %v", got, want)
 	}

--- a/pkg/tools/secureinput/secureinput.go
+++ b/pkg/tools/secureinput/secureinput.go
@@ -1,0 +1,330 @@
+package secureinput
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/sushi30/sushiclaw/pkg/tools/exec"
+	"golang.org/x/term"
+)
+
+const scheme = "secure-input://"
+
+var errUnavailable = errors.New("secure input unavailable")
+
+// Store keeps sensitive values in memory, scoped to the chat/session ID.
+type Store struct {
+	mu     sync.RWMutex
+	values map[string]map[string]string
+}
+
+func NewStore() *Store {
+	return &Store{values: make(map[string]map[string]string)}
+}
+
+func (s *Store) Store(ctx context.Context, value string) (string, error) {
+	if s == nil {
+		return "", errUnavailable
+	}
+	session := sessionFromContext(ctx)
+	if session == "" {
+		return "", errUnavailable
+	}
+	token, err := randomToken()
+	if err != nil {
+		return "", errUnavailable
+	}
+	handle := scheme + session + "/" + token
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.values[session] == nil {
+		s.values[session] = make(map[string]string)
+	}
+	s.values[session][handle] = value
+	return handle, nil
+}
+
+func (s *Store) Resolve(ctx context.Context, handle string) (string, error) {
+	if s == nil || !IsHandle(handle) {
+		return "", errUnavailable
+	}
+	session := sessionFromContext(ctx)
+	if session == "" || !strings.HasPrefix(handle, scheme+session+"/") {
+		return "", errUnavailable
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if value, ok := s.values[session][handle]; ok {
+		return value, nil
+	}
+	return "", errUnavailable
+}
+
+func (s *Store) ClearSession(session string) {
+	if s == nil || session == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.values, session)
+}
+
+func (s *Store) ClearAll() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.values = make(map[string]map[string]string)
+}
+
+func IsHandle(value string) bool {
+	return strings.HasPrefix(value, scheme)
+}
+
+type PromptFunc func(prompt string) (string, error)
+
+type Tool struct {
+	store  *Store
+	prompt PromptFunc
+}
+
+func NewTool(store *Store, prompt PromptFunc) *Tool {
+	return &Tool{store: store, prompt: prompt}
+}
+
+func (t *Tool) Name() string { return "secure_input" }
+
+func (t *Tool) Description() string {
+	return "Request sensitive input from the local terminal and return an opaque in-memory handle."
+}
+
+func (t *Tool) Parameters() map[string]interfaces.ParameterSpec {
+	return map[string]interfaces.ParameterSpec{
+		"prompt": {
+			Type:        "string",
+			Description: "Optional prompt shown only on the local terminal",
+			Required:    false,
+		},
+		"name": {
+			Type:        "string",
+			Description: "Optional human-readable label for the captured value",
+			Required:    false,
+		},
+	}
+}
+
+func (t *Tool) Run(ctx context.Context, input string) (string, error) {
+	return t.Execute(ctx, input)
+}
+
+func (t *Tool) Execute(ctx context.Context, args string) (string, error) {
+	var req struct {
+		Prompt string `json:"prompt"`
+		Name   string `json:"name"`
+	}
+	if strings.TrimSpace(args) != "" {
+		_ = json.Unmarshal([]byte(args), &req)
+	}
+
+	prompt := strings.TrimSpace(req.Prompt)
+	if prompt == "" {
+		prompt = "Secure input"
+	}
+	read := t.prompt
+	if read == nil {
+		read = TerminalPrompt(os.Stdin, os.Stderr)
+	}
+	value, err := read(prompt)
+	if err != nil || value == "" {
+		return "", errUnavailable
+	}
+
+	handle, err := t.store.Store(ctx, value)
+	if err != nil {
+		return "", errUnavailable
+	}
+
+	resp := map[string]string{
+		"status": "captured",
+		"handle": handle,
+	}
+	if req.Name != "" {
+		resp["name"] = req.Name
+	}
+	out, err := json.Marshal(resp)
+	if err != nil {
+		return "", errUnavailable
+	}
+	return string(out), nil
+}
+
+func TerminalPrompt(in *os.File, out io.Writer) PromptFunc {
+	return func(prompt string) (string, error) {
+		if in == nil || !term.IsTerminal(int(in.Fd())) {
+			return "", errUnavailable
+		}
+		if out != nil {
+			_, _ = fmt.Fprintf(out, "%s: ", prompt)
+		}
+		bytes, err := term.ReadPassword(int(in.Fd()))
+		if out != nil {
+			_, _ = fmt.Fprintln(out)
+		}
+		if err != nil {
+			return "", errUnavailable
+		}
+		return strings.TrimRight(string(bytes), "\r\n"), nil
+	}
+}
+
+func ReaderPrompt(in io.Reader, out io.Writer) PromptFunc {
+	return func(prompt string) (string, error) {
+		if in == nil {
+			return "", errUnavailable
+		}
+		if out != nil {
+			_, _ = fmt.Fprintf(out, "%s: ", prompt)
+		}
+		line, err := bufio.NewReader(in).ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return "", errUnavailable
+		}
+		return strings.TrimRight(line, "\r\n"), nil
+	}
+}
+
+type ResolvingTool struct {
+	tool  interfaces.Tool
+	store *Store
+}
+
+func Wrap(tool interfaces.Tool, store *Store) interfaces.Tool {
+	if tool == nil || tool.Name() == "secure_input" {
+		return tool
+	}
+	return &ResolvingTool{tool: tool, store: store}
+}
+
+func WrapAll(tools []interfaces.Tool, store *Store) []interfaces.Tool {
+	out := make([]interfaces.Tool, len(tools))
+	for i, tool := range tools {
+		out[i] = Wrap(tool, store)
+	}
+	return out
+}
+
+func (t *ResolvingTool) Name() string { return t.tool.Name() }
+
+func (t *ResolvingTool) Description() string { return t.tool.Description() }
+
+func (t *ResolvingTool) Parameters() map[string]interfaces.ParameterSpec {
+	return t.tool.Parameters()
+}
+
+func (t *ResolvingTool) Run(ctx context.Context, input string) (string, error) {
+	return t.Execute(ctx, input)
+}
+
+func (t *ResolvingTool) Execute(ctx context.Context, args string) (string, error) {
+	resolvedArgs, secrets, err := t.resolveArgs(ctx, args)
+	if err != nil {
+		return "", errUnavailable
+	}
+	out, runErr := t.tool.Execute(ctx, resolvedArgs)
+	out = redact(out, secrets)
+	if runErr != nil {
+		return out, errors.New(redact(runErr.Error(), secrets))
+	}
+	return out, nil
+}
+
+func (t *ResolvingTool) resolveArgs(ctx context.Context, args string) (string, []string, error) {
+	if IsHandle(args) {
+		value, err := t.store.Resolve(ctx, args)
+		return value, []string{value}, err
+	}
+
+	var v any
+	if err := json.Unmarshal([]byte(args), &v); err != nil {
+		return args, nil, nil
+	}
+	secrets := make([]string, 0)
+	resolved, err := t.resolveValue(ctx, v, &secrets)
+	if err != nil {
+		return "", nil, err
+	}
+	out, err := json.Marshal(resolved)
+	if err != nil {
+		return "", nil, errUnavailable
+	}
+	return string(out), secrets, nil
+}
+
+func (t *ResolvingTool) resolveValue(ctx context.Context, value any, secrets *[]string) (any, error) {
+	switch v := value.(type) {
+	case string:
+		if !IsHandle(v) {
+			return v, nil
+		}
+		secret, err := t.store.Resolve(ctx, v)
+		if err != nil {
+			return nil, err
+		}
+		*secrets = append(*secrets, secret)
+		return secret, nil
+	case []any:
+		for i := range v {
+			resolved, err := t.resolveValue(ctx, v[i], secrets)
+			if err != nil {
+				return nil, err
+			}
+			v[i] = resolved
+		}
+		return v, nil
+	case map[string]any:
+		for key := range v {
+			resolved, err := t.resolveValue(ctx, v[key], secrets)
+			if err != nil {
+				return nil, err
+			}
+			v[key] = resolved
+		}
+		return v, nil
+	default:
+		return v, nil
+	}
+}
+
+func redact(value string, secrets []string) string {
+	for _, secret := range secrets {
+		if secret != "" {
+			value = strings.ReplaceAll(value, secret, "[REDACTED]")
+		}
+	}
+	return value
+}
+
+func sessionFromContext(ctx context.Context) string {
+	return exec.ChatIDFromContext(ctx)
+}
+
+func randomToken() (string, error) {
+	var b [24]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b[:]), nil
+}

--- a/pkg/tools/secureinput/secureinput_test.go
+++ b/pkg/tools/secureinput/secureinput_test.go
@@ -1,0 +1,150 @@
+package secureinput
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/sushi30/sushiclaw/pkg/tools/exec"
+)
+
+type recordingTool struct {
+	args string
+	out  string
+	err  error
+}
+
+func (t *recordingTool) Name() string { return "record" }
+
+func (t *recordingTool) Description() string { return "" }
+
+func (t *recordingTool) Parameters() map[string]interfaces.ParameterSpec { return nil }
+
+func (t *recordingTool) Run(ctx context.Context, input string) (string, error) {
+	return t.Execute(ctx, input)
+}
+
+func (t *recordingTool) Execute(_ context.Context, args string) (string, error) {
+	t.args = args
+	return t.out, t.err
+}
+
+func TestToolCapturesHandleWithoutSecret(t *testing.T) {
+	store := NewStore()
+	tool := NewTool(store, func(string) (string, error) { return "super-secret", nil })
+	ctx := exec.WithChatID(context.Background(), "chat-1")
+
+	out, err := tool.Execute(ctx, `{"prompt":"API key","name":"api_key"}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(out, "super-secret") {
+		t.Fatalf("result leaked secret: %s", out)
+	}
+	if !strings.Contains(out, `"status":"captured"`) || !strings.Contains(out, `"handle":"secure-input://chat-1/`) {
+		t.Fatalf("result missing captured handle: %s", out)
+	}
+	if !strings.Contains(out, `"name":"api_key"`) {
+		t.Fatalf("result missing name: %s", out)
+	}
+}
+
+func TestToolUnavailableReturnsGenericError(t *testing.T) {
+	tool := NewTool(NewStore(), func(string) (string, error) {
+		return "should-not-leak", errors.New("contains should-not-leak")
+	})
+	_, err := tool.Execute(exec.WithChatID(context.Background(), "chat-1"), `{}`)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); got != "secure input unavailable" {
+		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestHandlesAreSessionScoped(t *testing.T) {
+	store := NewStore()
+	ctx1 := exec.WithChatID(context.Background(), "chat-1")
+	ctx2 := exec.WithChatID(context.Background(), "chat-2")
+
+	handle, err := store.Store(ctx1, "secret")
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if _, err := store.Resolve(ctx2, handle); err == nil {
+		t.Fatal("expected foreign handle to fail")
+	}
+	value, err := store.Resolve(ctx1, handle)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if value != "secret" {
+		t.Fatalf("value = %q", value)
+	}
+}
+
+func TestWrapperResolvesJSONArgumentsAndRedactsOutput(t *testing.T) {
+	store := NewStore()
+	ctx := exec.WithChatID(context.Background(), "chat-1")
+	handle, err := store.Store(ctx, "super-secret")
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	inner := &recordingTool{out: "tool saw super-secret"}
+	wrapped := Wrap(inner, store)
+	out, err := wrapped.Execute(ctx, `{"token":"`+handle+`","nested":["ok","`+handle+`"]}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(inner.args, "super-secret") {
+		t.Fatalf("inner args were not resolved: %s", inner.args)
+	}
+	if strings.Contains(out, "super-secret") || out != "tool saw [REDACTED]" {
+		t.Fatalf("output not redacted: %s", out)
+	}
+}
+
+func TestWrapperRedactsErrors(t *testing.T) {
+	store := NewStore()
+	ctx := exec.WithChatID(context.Background(), "chat-1")
+	handle, err := store.Store(ctx, "super-secret")
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	inner := &recordingTool{err: errors.New("bad super-secret")}
+	wrapped := Wrap(inner, store)
+	_, err = wrapped.Execute(ctx, `{"token":"`+handle+`"}`)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got := err.Error(); got != "bad [REDACTED]" {
+		t.Fatalf("error = %q", got)
+	}
+}
+
+func TestWrapperInvalidForeignHandleFailsGenerically(t *testing.T) {
+	store := NewStore()
+	ctx1 := exec.WithChatID(context.Background(), "chat-1")
+	ctx2 := exec.WithChatID(context.Background(), "chat-2")
+	handle, err := store.Store(ctx1, "super-secret")
+	if err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	inner := &recordingTool{}
+	wrapped := Wrap(inner, store)
+	_, err = wrapped.Execute(ctx2, `{"token":"`+handle+`"}`)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if inner.args != "" {
+		t.Fatalf("inner tool should not run, args = %s", inner.args)
+	}
+	if got := err.Error(); got != "secure input unavailable" {
+		t.Fatalf("error = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add an opt-in secure_input tool that captures local TTY input and returns opaque in-memory handles
- wrap other tools to resolve secure-input handles just before execution and redact resolved values from outputs/errors
- clear secure-input handles on /clear and ignore local .env/.codex files

## Test plan
- make test
- make lint

## Known gaps
None found.