### PR TITLE
fix(tools): harden exec command parsing

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -67,6 +67,13 @@ func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem *InMe
 		"prompt_length": len(systemPrompt),
 		"tools":         toolNames,
 	})
+	for _, t := range tools {
+		logger.DebugCF("agent", "Registering tool", map[string]any{
+			"name":        t.Name(),
+			"description": t.Description(),
+			"parameters":  t.Parameters(),
+		})
+	}
 
 	opts := []agentsdk.Option{
 		agentsdk.WithName("sushiclaw"),

--- a/pkg/tools/exec/exec_tool.go
+++ b/pkg/tools/exec/exec_tool.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -61,14 +62,7 @@ func (e *ExecTool) Run(ctx context.Context, input string) (string, error) {
 
 // Execute executes the tool with the given arguments JSON string.
 func (e *ExecTool) Execute(ctx context.Context, args string) (string, error) {
-	// Simple parsing: if args looks like a JSON object with "command", extract it.
-	cmdStr := strings.Trim(args, `{} `)
-	if strings.HasPrefix(cmdStr, `"command":`) {
-		parts := strings.SplitN(cmdStr, `"command":`, 2)
-		if len(parts) == 2 {
-			cmdStr = strings.Trim(parts[1], ` "{},`)
-		}
-	}
+	cmdStr := parseCommand(args)
 	if cmdStr == "" {
 		return "", fmt.Errorf("no command provided")
 	}
@@ -101,6 +95,27 @@ func (e *ExecTool) Execute(ctx context.Context, args string) (string, error) {
 		return string(out), fmt.Errorf("exec error: %w", err)
 	}
 	return string(out), nil
+}
+
+func parseCommand(args string) string {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return ""
+	}
+
+	var payload struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal([]byte(args), &payload); err == nil && payload.Command != "" {
+		return strings.TrimSpace(payload.Command)
+	}
+
+	var raw string
+	if err := json.Unmarshal([]byte(args), &raw); err == nil {
+		return strings.TrimSpace(raw)
+	}
+
+	return args
 }
 
 func isLocalChat(chatID string) bool {

--- a/pkg/tools/exec/exec_tool_test.go
+++ b/pkg/tools/exec/exec_tool_test.go
@@ -75,6 +75,32 @@ func TestExecTool_Execute_RawCommand(t *testing.T) {
 	}
 }
 
+func TestExecTool_Execute_JSONCommandPreservesQuoting(t *testing.T) {
+	tool := NewExecTool("", false, true)
+	ctx := WithChatID(context.Background(), "cli")
+
+	out, err := tool.Execute(ctx, `{"command":"printf '%s\n' \"hello world\""}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "hello world\n" {
+		t.Errorf("output = %q, want %q", out, "hello world\n")
+	}
+}
+
+func TestExecTool_Execute_JSONStringCommand(t *testing.T) {
+	tool := NewExecTool("", false, true)
+	ctx := WithChatID(context.Background(), "cli")
+
+	out, err := tool.Execute(ctx, `"echo string-command"`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "string-command") {
+		t.Errorf("output = %q, want to contain 'string-command'", out)
+	}
+}
+
 func TestExecTool_Execute_Empty(t *testing.T) {
 	tool := NewExecTool("", false, true)
 	_, err := tool.Execute(context.Background(), "")


### PR DESCRIPTION
## Summary
- Log registered agent tools at debug level so exec registration can be inspected without adding model prompt context.
- Parse exec tool arguments as JSON before falling back to raw commands, preserving quotes and escaped characters.
- Add coverage for JSON object and JSON string command inputs.

## Test plan
- make test
- make lint