### PR TITLE
Quiet telego debug logging

### DIFF
--- a/pkg/channels/telegram/telegram.go
+++ b/pkg/channels/telegram/telegram.go
@@ -82,7 +82,7 @@ func NewTelegramChannel(bc *config.Channel, telegramCfg *config.TelegramSettings
 	if baseURL := strings.TrimRight(strings.TrimSpace(telegramCfg.BaseURL), "/"); baseURL != "" {
 		opts = append(opts, telego.WithAPIServer(baseURL))
 	}
-	opts = append(opts, telego.WithLogger(logger.NewLogger("telego")))
+	opts = append(opts, telego.WithLogger(logger.NewQuietLogger("telego")))
 
 	bot, err := telego.NewBot(telegramCfg.Token.String(), opts...)
 	if err != nil {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -169,3 +169,30 @@ func (l *Logger) Warnf(format string, args ...any) {
 func (l *Logger) Errorf(format string, args ...any) {
 	log(ERROR, l.component, fmt.Sprintf(format, args...), nil)
 }
+
+// QuietLogger is like Logger, but drops debug/info output.
+// Use it for chatty dependencies that should only surface warnings and errors.
+type QuietLogger struct {
+	component string
+}
+
+// NewQuietLogger creates a named logger that suppresses debug/info messages.
+func NewQuietLogger(component string) *QuietLogger {
+	return &QuietLogger{component: component}
+}
+
+// Debugf suppresses debug messages.
+func (l *QuietLogger) Debugf(format string, args ...any) {}
+
+// Infof suppresses info messages.
+func (l *QuietLogger) Infof(format string, args ...any) {}
+
+// Warnf logs a warn message.
+func (l *QuietLogger) Warnf(format string, args ...any) {
+	log(WARN, l.component, fmt.Sprintf(format, args...), nil)
+}
+
+// Errorf logs an error message.
+func (l *QuietLogger) Errorf(format string, args ...any) {
+	log(ERROR, l.component, fmt.Sprintf(format, args...), nil)
+}


### PR DESCRIPTION
Suppress telego debug/info logging so Telegram typing actions no longer spam the logs.

Verification: go test ./pkg/logger ./pkg/channels/telegram