### PR TITLE
feat(commands): add /list skills command

### DIFF
--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sushi30/sushiclaw/pkg/commands"
 	"github.com/sushi30/sushiclaw/pkg/logger"
 )
 
@@ -162,32 +163,45 @@ func (b *ContextBuilder) captureBaseline() (map[string]time.Time, map[string]boo
 
 // skillsSummary walks skills/ and builds a markdown summary block.
 func (b *ContextBuilder) skillsSummary(skillsDir string) string {
-	entries, err := os.ReadDir(skillsDir)
-	if err != nil {
+	skills := listSkillsInDir(skillsDir)
+	if len(skills) == 0 {
 		return ""
 	}
 
-	var lines []string
+	lines := make([]string, 0, len(skills))
+	for _, skill := range skills {
+		lines = append(lines, "- **"+skill.Name+"**: "+skill.Description)
+	}
+
+	return "## Skills\n\n" + strings.Join(lines, "\n")
+}
+
+func listSkillsInDir(skillsDir string) []commands.SkillInfo {
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return nil
+	}
+
+	skills := make([]commands.SkillInfo, 0, len(entries))
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
 		}
 		skillFile := filepath.Join(skillsDir, e.Name(), "SKILL.md")
-		content, ok := b.readFileIfExists(skillFile)
-		if !ok {
+		content, err := os.ReadFile(skillFile)
+		if err != nil {
 			continue
 		}
-		desc := firstDescriptionLine(content)
+		desc := skillDescription(string(content))
 		if desc == "" {
 			desc = e.Name()
 		}
-		lines = append(lines, "- **"+e.Name()+"**: "+desc)
+		skills = append(skills, commands.SkillInfo{
+			Name:        e.Name(),
+			Description: desc,
+		})
 	}
-
-	if len(lines) == 0 {
-		return ""
-	}
-	return "## Skills\n\n" + strings.Join(lines, "\n")
+	return skills
 }
 
 // readFileIfExists returns the file content and whether the file existed.
@@ -215,6 +229,33 @@ func parseMarkdownBody(content string) string {
 	}
 	body := strings.TrimSpace(rest[idx+4:])
 	return body
+}
+
+func skillDescription(content string) string {
+	if desc := frontmatterDescription(content); desc != "" {
+		return desc
+	}
+	return firstDescriptionLine(content)
+}
+
+func frontmatterDescription(content string) string {
+	content = strings.TrimSpace(content)
+	if !strings.HasPrefix(content, "---") {
+		return ""
+	}
+	rest := content[3:]
+	idx := strings.Index(rest, "\n---")
+	if idx == -1 {
+		return ""
+	}
+	for _, line := range strings.Split(rest[:idx], "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if !ok || strings.TrimSpace(key) != "description" {
+			continue
+		}
+		return strings.Trim(strings.TrimSpace(value), `"'`)
+	}
+	return ""
 }
 
 // firstDescriptionLine returns the first non-blank, non-frontmatter line from

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -191,6 +191,15 @@ func (sm *SessionManager) ListModels() []string {
 	return names
 }
 
+// ListSkills returns all skills available in the configured workspace.
+func (sm *SessionManager) ListSkills() []commands.SkillInfo {
+	ws := sm.cfg.WorkspacePath()
+	if ws == "" {
+		return nil
+	}
+	return listSkillsInDir(filepath.Join(ws, "skills"))
+}
+
 // GetModelInfo returns the configured model name and its provider.
 func (sm *SessionManager) GetModelInfo() (name, provider string) {
 	name = sm.cfg.Agents.Defaults.ModelName

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -367,3 +367,59 @@ func TestSessionManager_ActivateSkill_NotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
+
+func TestSessionManager_ListSkills(t *testing.T) {
+	ws := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(ws, "skills", "python"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(ws, "skills", "review"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(ws, "skills", "missing-file"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(ws, "skills", "ignored.txt"), []byte("not a skill"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(ws, "skills", "python", "SKILL.md"), []byte("---\nname: python\ndescription: Python coding help\n---\n\n# Python\n\nBody fallback."), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(ws, "skills", "review", "SKILL.md"), []byte("# Review\n\n- Review code carefully."), 0644))
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{ModelName: "test-model"},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+	}
+	cfg.Agents.Defaults.Workspace = ws
+
+	sm, err := agent.NewSessionManager(cfg, nil, nil)
+	require.NoError(t, err)
+
+	skills := sm.ListSkills()
+	require.Len(t, skills, 2)
+	assert.Equal(t, "python", skills[0].Name)
+	assert.Equal(t, "Python coding help", skills[0].Description)
+	assert.Equal(t, "review", skills[1].Name)
+	assert.Equal(t, "Review code carefully.", skills[1].Description)
+}
+
+func TestSessionManager_ListSkillsMissingDirectory(t *testing.T) {
+	ws := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{ModelName: "test-model"},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+	}
+	cfg.Agents.Defaults.Workspace = ws
+
+	sm, err := agent.NewSessionManager(cfg, nil, nil)
+	require.NoError(t, err)
+
+	assert.Empty(t, sm.ListSkills())
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -149,6 +149,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 		rt.ClearHistory = sessionMgr.ClearHistory
 		rt.GetModelInfo = sessionMgr.GetModelInfo
 		rt.ListModels = sessionMgr.ListModels
+		rt.ListSkills = sessionMgr.ListSkills
 		rt.ActivateSkill = sessionMgr.ActivateSkill
 	}
 	executor := commands.NewExecutor(reg, rt)

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -53,11 +53,18 @@ type Request struct {
 	Reply    func(text string) error
 }
 
+// SkillInfo describes a skill available in the configured workspace.
+type SkillInfo struct {
+	Name        string
+	Description string
+}
+
 // Runtime provides runtime dependencies to command handlers.
 type Runtime struct {
 	GetModelInfo    func() (name, provider string)
 	ListDefinitions func() []Definition
 	ListModels      func() []string
+	ListSkills      func() []SkillInfo
 	ClearHistory    func() error
 	ToggleDebug     func(ctx context.Context, channel, chatID string) string
 	ActivateSkill   func(skillName string) error
@@ -254,6 +261,7 @@ func BuiltinDefinitions() []Definition {
 		{Name: "show", Description: "Show current configuration"},
 		{Name: "list", Description: "List available options", SubCommands: []SubCommand{
 			{Name: "models", Description: "List configured models", Handler: listModelsHandler},
+			{Name: "skills", Description: "List available skills", Handler: listSkillsHandler},
 		}},
 		{Name: "use", Description: "Use a specific skill", Handler: useHandler, Usage: "/use <skill-name>"},
 		{Name: "btw", Description: "Add a note to conversation context"},
@@ -306,6 +314,26 @@ func listModelsHandler(_ context.Context, req Request, rt *Runtime) error {
 	sb.WriteString("Configured models:\n")
 	for _, m := range models {
 		sb.WriteString("• " + m + "\n")
+	}
+	return req.Reply(strings.TrimRight(sb.String(), "\n"))
+}
+
+func listSkillsHandler(_ context.Context, req Request, rt *Runtime) error {
+	if rt == nil || rt.ListSkills == nil {
+		return req.Reply("Skill list unavailable.")
+	}
+	skills := rt.ListSkills()
+	if len(skills) == 0 {
+		return req.Reply("No skills available.")
+	}
+	var sb strings.Builder
+	sb.WriteString("Available skills:\n")
+	for _, s := range skills {
+		sb.WriteString("• " + s.Name)
+		if s.Description != "" {
+			sb.WriteString(" — " + s.Description)
+		}
+		sb.WriteByte('\n')
 	}
 	return req.Reply(strings.TrimRight(sb.String(), "\n"))
 }

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -174,6 +174,85 @@ func TestExecutePassthroughNoHandler(t *testing.T) {
 	assert.Equal(t, commands.OutcomePassthrough, result.Outcome)
 }
 
+func TestExecuteListSkills(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{
+		ListSkills: func() []commands.SkillInfo {
+			return []commands.SkillInfo{
+				{Name: "python", Description: "Python coding help"},
+				{Name: "review"},
+			}
+		},
+	}
+	exec := commands.NewExecutor(reg, rt)
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/list skills",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Contains(t, replied, "Available skills:")
+	assert.Contains(t, replied, "• python — Python coding help")
+	assert.Contains(t, replied, "• review")
+}
+
+func TestExecuteListSkillsNoRuntime(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{})
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/list skills",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Equal(t, "Skill list unavailable.", replied)
+}
+
+func TestExecuteListSkillsEmpty(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{
+		ListSkills: func() []commands.SkillInfo { return nil },
+	}
+	exec := commands.NewExecutor(reg, rt)
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/list skills",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Equal(t, "No skills available.", replied)
+}
+
+func TestExecuteListUsageIncludesSkills(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{})
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/list",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Contains(t, replied, "/list [models|skills]")
+}
+
+func TestExecuteListUnknownOptionIncludesSkills(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{})
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/list widgets",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Contains(t, replied, "Unknown option: widgets")
+	assert.Contains(t, replied, "/list [models|skills]")
+}
+
 func TestExecuteUseSuccess(t *testing.T) {
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
 	rt := &commands.Runtime{

--- a/pkg/tools/websearch/websearch.go
+++ b/pkg/tools/websearch/websearch.go
@@ -85,8 +85,10 @@ func buildProvider(cfg config.WebSearchToolConfig) (Provider, error) {
 	}
 }
 
-func (t *WebSearchTool) Name() string        { return "web_search" }
-func (t *WebSearchTool) Description() string { return fmt.Sprintf("Search the web for current information, news, facts, and links using %s. Returns a list of results with titles, URLs, and descriptions.", t.provider.Name()) }
+func (t *WebSearchTool) Name() string { return "web_search" }
+func (t *WebSearchTool) Description() string {
+	return fmt.Sprintf("Search the web for current information, news, facts, and links using %s. Returns a list of results with titles, URLs, and descriptions.", t.provider.Name())
+}
 
 func (t *WebSearchTool) Parameters() map[string]interfaces.ParameterSpec {
 	return map[string]interfaces.ParameterSpec{

--- a/pkg/tools/websearch/websearch_test.go
+++ b/pkg/tools/websearch/websearch_test.go
@@ -137,7 +137,7 @@ func (m *mockProvider) Search(_ context.Context, query string, maxResults int) (
 }
 
 func TestBraveProvider_Search(t *testing.T) {
-	 srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "GET", r.Method)
 		assert.Equal(t, "test-key", r.Header.Get("X-Subscription-Token"))
 		assert.Equal(t, "test", r.URL.Query().Get("q"))


### PR DESCRIPTION
## Summary

Adds a `/list skills` command that displays all available skills from the configured workspace directory. Skills are discovered by scanning `workspace/skills/*/SKILL.md` files and extracting their names and descriptions (from YAML frontmatter if present, otherwise the first body line).

Changes:
- `pkg/commands/commands.go`: new `SkillInfo` type, `listSkillsHandler`, and `/list skills` subcommand
- `internal/agent/context.go`: refactored skill scanning into reusable `listSkillsInDir()` with frontmatter parsing
- `internal/agent/session.go`: `ListSkills()` method on `SessionManager`
- `internal/gateway/gateway.go`: wire `ListSkills` into command runtime
- Tests for all new behavior

## Test plan

- `make test` — all tests pass
- `make lint` — no issues
- `make fmt && make vet` — clean
- New unit tests:
  - `TestSessionManager_ListSkills` — verifies skill discovery with frontmatter and fallback descriptions
  - `TestSessionManager_ListSkillsMissingDirectory` — handles missing skills directory
  - `TestExecuteListSkills` — command handler output formatting
  - `TestExecuteListSkillsNoRuntime` / `TestExecuteListSkillsEmpty` — edge cases
  - `TestExecuteListUsageIncludesSkills` / `TestExecuteListUnknownOptionIncludesSkills` — help text updates

Closes #104