### PR TITLE
feat(email): add inbound and outbound attachment handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,7 +170,7 @@ Copy `config.example.json` to get started.
 Any config field that uses `SecureString` supports `env://VAR_NAME` references:
 
 ```json
-{ "api_key": "env://ANTHROPIC_API_KEY" }
+{ "api_key": "env://OPENAI_API_KEY" }
 ```
 
 Resolution happens during `json.Unmarshal` in `pkg/config.SecureString.UnmarshalJSON`. If the
@@ -303,7 +303,7 @@ See `RELEASE_NOTES.md` for the email config migration guide if upgrading from an
 docker build -t sushiclaw .
 docker run -d \
   -v ~/.picoclaw:/home/sushiclaw/.picoclaw \
-  -e ANTHROPIC_API_KEY=sk-... \
+  -e OPENAI_API_KEY=sk-... \
   sushiclaw gateway
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ For Telegram image handling, enable the vision tool with a vision-capable model:
   "tools": {
     "vision": {
       "enabled": true,
-      "model": "openrouter/z-ai/glm-5v-turbo",
-      "api_key": "env://OPENROUTER_API_KEY"
+      "model_name": "openrouter-glm-5v"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ docker pull ghcr.io/sushi30/sushiclaw:latest
 
 docker run -d \
   -v ~/.picoclaw:/home/sushiclaw/.picoclaw \
-  -e ANTHROPIC_API_KEY=sk-... \
+  -e OPENAI_API_KEY=sk-... \
   ghcr.io/sushi30/sushiclaw:latest gateway
 ```
 
@@ -86,10 +86,10 @@ Copy `config.example.json` to `~/.picoclaw/config.json`. Key sections:
   "agents": {
     "defaults": {
       "workspace": "~/.picoclaw/workspace",
-      "model_name": "claude-sonnet"
+      "model_name": "gpt-4o-mini"
     }
   },
-  "model_list": [{ "model_name": "claude-sonnet", "api_key": "env://ANTHROPIC_API_KEY" }],
+  "model_list": [{ "model_name": "gpt-4o-mini", "api_key": "env://OPENAI_API_KEY" }],
   "channels": { ... },
   "email_channel": { ... },
   "tools": { ... }
@@ -107,10 +107,24 @@ Override config path with `$SUSHICLAW_CONFIG`.
 API keys in `config.json` can reference environment variables:
 
 ```json
-{ "api_key": "env://ANTHROPIC_API_KEY" }
+{ "api_key": "env://OPENAI_API_KEY" }
 ```
 
 Resolved at load time by `pkg/config.SecureString` during JSON unmarshal.
+
+For Telegram image handling, enable the vision tool with a vision-capable model:
+
+```json
+{
+  "tools": {
+    "vision": {
+      "enabled": true,
+      "model": "openrouter/z-ai/glm-5v-turbo",
+      "api_key": "env://OPENROUTER_API_KEY"
+    }
+  }
+}
+```
 
 ---
 

--- a/config.example.json
+++ b/config.example.json
@@ -4,7 +4,7 @@
     "defaults": {
       "workspace": "~/.picoclaw/workspace",
       "restrict_to_workspace": true,
-      "model_name": "claude-sonnet",
+      "model_name": "gpt-4o-mini",
       "max_tokens": 8192,
       "context_window": 131072,
       "temperature": 0.7,
@@ -15,10 +15,10 @@
   },
   "model_list": [
     {
-      "model_name": "claude-sonnet",
-      "model": "anthropic/claude-sonnet-4-6",
-      "api_key": "env://ANTHROPIC_API_KEY",
-      "api_base": "https://api.anthropic.com/v1"
+      "model_name": "gpt-4o-mini",
+      "model": "gpt-4o-mini",
+      "api_key": "env://OPENAI_API_KEY",
+      "api_base": "https://api.openai.com/v1"
     }
   ],
   "channels": {
@@ -34,7 +34,7 @@
     },
     "telegram": {
       "enabled": false,
-      "token": "YOUR_TELEGRAM_BOT_TOKEN",
+      "token": "env://TELEGRAM_BOT_TOKEN",
       "allow_from": [],
       "group_trigger": {
         "mention_only": true
@@ -94,6 +94,13 @@
       "enabled": true,
       "allow_command": true,
       "exec_timeout_minutes": 5
+    },
+    "vision": {
+      "enabled": true,
+      "model": "gpt-4o-mini",
+      "api_key": "env://OPENAI_API_KEY",
+      "api_base": "https://api.openai.com/v1",
+      "prompt": "Describe this image in detail."
     },
     "media_cleanup": {
       "enabled": true,

--- a/config.example.json
+++ b/config.example.json
@@ -97,9 +97,7 @@
     },
     "vision": {
       "enabled": true,
-      "model": "gpt-4o-mini",
-      "api_key": "env://OPENAI_API_KEY",
-      "api_base": "https://api.openai.com/v1",
+      "model_name": "gpt-4o-mini",
       "prompt": "Describe this image in detail."
     },
     "media_cleanup": {

--- a/examples/config/telegram-openrouter.json
+++ b/examples/config/telegram-openrouter.json
@@ -50,8 +50,7 @@
     },
     "vision": {
       "enabled": true,
-      "model": "openrouter/z-ai/glm-5v-turbo",
-      "api_key": "env://OPENROUTER_API_KEY",
+      "model_name": "openrouter-glm-5v",
       "prompt": "Describe this image in detail."
     },
     "media_cleanup": {

--- a/examples/config/telegram-openrouter.json
+++ b/examples/config/telegram-openrouter.json
@@ -1,0 +1,72 @@
+{
+  "version": 2,
+  "agents": {
+    "defaults": {
+      "workspace": "~/.picoclaw/workspace",
+      "restrict_to_workspace": true,
+      "model_name": "openrouter-glm-5v",
+      "max_tokens": 8192,
+      "context_window": 131072,
+      "temperature": 0.7,
+      "max_tool_iterations": 20,
+      "summarize_message_threshold": 20,
+      "summarize_token_percent": 75
+    }
+  },
+  "model_list": [
+    {
+      "model_name": "openrouter-glm-5v",
+      "model": "openrouter/z-ai/glm-5v-turbo",
+      "api_key": "env://OPENROUTER_API_KEY"
+    }
+  ],
+  "channels": {
+    "telegram": {
+      "enabled": true,
+      "token": "env://TELEGRAM_BOT_TOKEN",
+      "allow_from": ["telegram:YOUR_TELEGRAM_USER_ID"],
+      "group_trigger": {
+        "mention_only": true
+      },
+      "streaming": {
+        "enabled": true
+      }
+    }
+  },
+  "email_channel": {
+    "enabled": false
+  },
+  "gateway": {
+    "host": "0.0.0.0",
+    "port": 18800,
+    "log_level": "info"
+  },
+  "tools": {
+    "exec": {
+      "enabled": true
+    },
+    "web_search": {
+      "enabled": false
+    },
+    "vision": {
+      "enabled": true,
+      "model": "openrouter/z-ai/glm-5v-turbo",
+      "api_key": "env://OPENROUTER_API_KEY",
+      "prompt": "Describe this image in detail."
+    },
+    "media_cleanup": {
+      "enabled": true,
+      "max_age": 30,
+      "interval": 5
+    },
+    "read_file": {
+      "enabled": true
+    },
+    "write_file": {
+      "enabled": true
+    },
+    "list_dir": {
+      "enabled": true
+    }
+  }
+}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/llm/openrouter"
 	"github.com/sushi30/sushiclaw/pkg/logger"
+	"github.com/sushi30/sushiclaw/pkg/media"
 	"github.com/sushi30/sushiclaw/pkg/tools/exec"
 	"github.com/sushi30/sushiclaw/pkg/tools/toolctx"
 )
@@ -32,6 +33,7 @@ type SessionManager struct {
 	tools           []interfaces.Tool
 	activatedSkills map[string]bool
 	progress        ProgressSink
+	mediaStore      media.MediaStore
 }
 
 type agentRunner interface {
@@ -141,7 +143,7 @@ func toAgentSDKMCPConfig(cfg config.MCPConfig) *agentsdk.MCPConfiguration {
 }
 
 // NewSessionManager creates a session manager from config.
-func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus, tools []interfaces.Tool, opts ...SessionOption) (*SessionManager, error) {
+func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus, tools []interfaces.Tool, store media.MediaStore, opts ...SessionOption) (*SessionManager, error) {
 	mem := NewInMemoryMemory()
 	a, err := buildAgentWithMemory(cfg, tools, mem)
 	if err != nil {
@@ -155,6 +157,7 @@ func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus, tools []i
 		cfg:             cfg,
 		tools:           tools,
 		activatedSkills: make(map[string]bool),
+		mediaStore:      store,
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -283,8 +286,23 @@ func (sm *SessionManager) handleInbound(ctx context.Context, msg bus.InboundMess
 	actx = toolctx.WithSenderID(actx, msg.SenderID)
 
 	input := msg.Content
-	if input == "" && len(msg.Media) > 0 {
-		input = fmt.Sprintf("[media attachments: %v]", msg.Media)
+	if len(msg.Media) > 0 {
+		paths := make([]string, 0, len(msg.Media))
+		for _, ref := range msg.Media {
+			if sm.mediaStore != nil && strings.HasPrefix(ref, "media://") {
+				if p, err := sm.mediaStore.Resolve(ref); err == nil {
+					paths = append(paths, p)
+					continue
+				}
+			}
+			paths = append(paths, ref)
+		}
+		mediaDesc := fmt.Sprintf("[attached files: %v]", paths)
+		if input == "" {
+			input = mediaDesc
+		} else {
+			input = input + "\n\n" + mediaDesc
+		}
 	}
 
 	logger.DebugCF("agent", "Processing message", map[string]any{

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -242,7 +242,7 @@ func TestNewSessionManager_ToolsRegistered(t *testing.T) {
 	}
 
 	tool := &mockTool{name: "test-tool"}
-	sm, err := agent.NewSessionManager(cfg, nil, []interfaces.Tool{tool})
+	sm, err := agent.NewSessionManager(cfg, nil, []interfaces.Tool{tool}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"test-tool"}, sm.ToolNames())
 }
@@ -299,7 +299,7 @@ func TestSessionManager_ActivateSkill(t *testing.T) {
 	}
 	cfg.Agents.Defaults.Workspace = ws
 
-	sm, err := agent.NewSessionManager(cfg, nil, nil)
+	sm, err := agent.NewSessionManager(cfg, nil, nil, nil)
 	require.NoError(t, err)
 
 	// First activation should succeed.
@@ -334,7 +334,7 @@ func TestSessionManager_ActivateSkill_AlreadyLoaded(t *testing.T) {
 	}
 	cfg.Agents.Defaults.Workspace = ws
 
-	sm, err := agent.NewSessionManager(cfg, nil, nil)
+	sm, err := agent.NewSessionManager(cfg, nil, nil, nil)
 	require.NoError(t, err)
 
 	require.NoError(t, sm.ActivateSkill("python"))
@@ -360,7 +360,7 @@ func TestSessionManager_ActivateSkill_NotFound(t *testing.T) {
 	}
 	cfg.Agents.Defaults.Workspace = ws
 
-	sm, err := agent.NewSessionManager(cfg, nil, nil)
+	sm, err := agent.NewSessionManager(cfg, nil, nil, nil)
 	require.NoError(t, err)
 
 	err = sm.ActivateSkill("nonexistent")
@@ -391,7 +391,7 @@ func TestSessionManager_ListSkills(t *testing.T) {
 	}
 	cfg.Agents.Defaults.Workspace = ws
 
-	sm, err := agent.NewSessionManager(cfg, nil, nil)
+	sm, err := agent.NewSessionManager(cfg, nil, nil, nil)
 	require.NoError(t, err)
 
 	skills := sm.ListSkills()
@@ -418,7 +418,7 @@ func TestSessionManager_ListSkillsMissingDirectory(t *testing.T) {
 	}
 	cfg.Agents.Defaults.Workspace = ws
 
-	sm, err := agent.NewSessionManager(cfg, nil, nil)
+	sm, err := agent.NewSessionManager(cfg, nil, nil, nil)
 	require.NoError(t, err)
 
 	assert.Empty(t, sm.ListSkills())

--- a/internal/gateway/config_test.go
+++ b/internal/gateway/config_test.go
@@ -36,14 +36,14 @@ func TestLoadExampleConfig(t *testing.T) {
 		t.Fatalf("LoadConfig: %v", err)
 	}
 
-	if cfg.Agents.Defaults.ModelName != "claude-sonnet" {
-		t.Errorf("model_name = %q, want %q", cfg.Agents.Defaults.ModelName, "claude-sonnet")
+	if cfg.Agents.Defaults.ModelName != "gpt-4o-mini" {
+		t.Errorf("model_name = %q, want %q", cfg.Agents.Defaults.ModelName, "gpt-4o-mini")
 	}
 	if len(cfg.ModelList) == 0 {
 		t.Fatal("model_list is empty")
 	}
-	if cfg.ModelList[0].ModelName != "claude-sonnet" {
-		t.Errorf("model_list[0].model_name = %q, want %q", cfg.ModelList[0].ModelName, "claude-sonnet")
+	if cfg.ModelList[0].ModelName != "gpt-4o-mini" {
+		t.Errorf("model_list[0].model_name = %q, want %q", cfg.ModelList[0].ModelName, "gpt-4o-mini")
 	}
 	if cfg.Gateway.Port != 18800 {
 		t.Errorf("gateway.port = %d, want 18800", cfg.Gateway.Port)

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -74,8 +74,16 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 		ListDefinitions: reg.Definitions,
 	}
 
+	mediaStore := media.NewFileMediaStoreWithCleanup(media.MediaCleanerConfig{
+		Enabled:  cfg.Tools.MediaCleanup.Enabled,
+		MaxAge:   time.Duration(cfg.Tools.MediaCleanup.MaxAge) * time.Minute,
+		Interval: time.Duration(cfg.Tools.MediaCleanup.Interval) * time.Minute,
+	})
+	mediaStore.Start()
+	defer mediaStore.Stop()
+
 	allowedSenders := sushitools.ParseAllowedSenders()
-	tools, err := sushitools.NewGatewayTools(cfg, allowedSenders)
+	tools, err := sushitools.NewGatewayTools(cfg, allowedSenders, mediaStore)
 	if err != nil {
 		logger.WarnCF("gateway", "Failed to init trusted exec tool",
 			map[string]any{"error": err.Error()})
@@ -118,7 +126,12 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 		logger.InfoC("gateway", "Cron tool registered")
 	}
 
-	sessionMgr, err := agent.NewSessionManager(cfg, messageBus, tools, agent.WithProgressSink(dm))
+	if cfg.Tools.IsToolEnabled("vision") {
+		logger.InfoCF("gateway", "Vision tool registered",
+			map[string]any{"model": cfg.Tools.Vision.Model})
+	}
+
+	sessionMgr, err := agent.NewSessionManager(cfg, messageBus, tools, mediaStore, agent.WithProgressSink(dm))
 	if err != nil {
 		if allowEmptyStartup {
 			logger.WarnC("gateway", fmt.Sprintf("Failed to create agent session: %v", err))
@@ -126,14 +139,6 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 			return fmt.Errorf("error creating agent session: %w", err)
 		}
 	}
-
-	mediaStore := media.NewFileMediaStoreWithCleanup(media.MediaCleanerConfig{
-		Enabled:  cfg.Tools.MediaCleanup.Enabled,
-		MaxAge:   time.Duration(cfg.Tools.MediaCleanup.MaxAge) * time.Minute,
-		Interval: time.Duration(cfg.Tools.MediaCleanup.Interval) * time.Minute,
-	})
-	mediaStore.Start()
-	defer mediaStore.Stop()
 
 	cm, err := channels.NewManager(cfg, messageBus, mediaStore)
 	if err != nil {

--- a/pkg/channels/email/email.go
+++ b/pkg/channels/email/email.go
@@ -9,13 +9,9 @@ import (
 	"fmt"
 	"io"
 	"net/smtp"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/google/uuid"
 
 	imap "github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapclient"
@@ -26,7 +22,6 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/channels"
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/logger"
-	"github.com/sushi30/sushiclaw/pkg/media"
 )
 
 // EmailConfig holds configuration for the email channel.
@@ -266,34 +261,9 @@ func (c *EmailChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaMessa
 		return nil, nil
 	}
 
-	store := c.GetMediaStore()
-	if store == nil {
-		return nil, fmt.Errorf("no media store available: %w", channels.ErrSendFailed)
-	}
-
-	var attachments []attachmentInfo
-	for _, part := range msg.Parts {
-		localPath, err := store.Resolve(part.Ref)
-		if err != nil {
-			return nil, fmt.Errorf("resolve media ref %q: %w: %w", part.Ref, err, channels.ErrSendFailed)
-		}
-		data, err := os.ReadFile(localPath)
-		if err != nil {
-			return nil, fmt.Errorf("read attachment %q: %w: %w", localPath, err, channels.ErrSendFailed)
-		}
-		ct := part.ContentType
-		if ct == "" {
-			ct = "application/octet-stream"
-		}
-		filename := part.Filename
-		if filename == "" {
-			filename = filepath.Base(localPath)
-		}
-		attachments = append(attachments, attachmentInfo{
-			filename:    filename,
-			contentType: ct,
-			data:        data,
-		})
+	attachments, err := newEmailMediaHandler(c.GetMediaStore()).outboundAttachments(msg.Parts)
+	if err != nil {
+		return nil, err
 	}
 
 	// Use the first non-empty caption as the email body.
@@ -663,41 +633,7 @@ func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope
 		metadata["reply_to_message_id"] = rawID
 	}
 
-	var mediaPaths []string
-	if store := c.GetMediaStore(); store != nil && len(attachments) > 0 {
-		if err := os.MkdirAll(media.TempDir(), 0o700); err != nil {
-			logger.WarnCF("email", "Failed to create media temp dir", map[string]any{
-				"err": err.Error(),
-				"dir": media.TempDir(),
-			})
-		} else {
-			scope := channels.BuildMediaScope("email", fromAddr, envelope.MessageID)
-			for _, att := range attachments {
-				localPath := filepath.Join(media.TempDir(), uuid.New().String()[:8]+"_"+att.filename)
-				if err := os.WriteFile(localPath, att.data, 0o600); err != nil {
-					logger.WarnCF("email", "Failed to write attachment", map[string]any{
-						"err":      err.Error(),
-						"filename": att.filename,
-					})
-					continue
-				}
-				ref, storeErr := store.Store(localPath, media.MediaMeta{
-					Filename:      att.filename,
-					ContentType:   att.contentType,
-					Source:        "email",
-					CleanupPolicy: media.CleanupPolicyDeleteOnCleanup,
-				}, scope)
-				if storeErr != nil {
-					logger.WarnCF("email", "Failed to store attachment", map[string]any{
-						"err":      storeErr.Error(),
-						"filename": att.filename,
-					})
-					continue
-				}
-			mediaPaths = append(mediaPaths, ref)
-			}
-		}
-	}
+	mediaPaths := newEmailMediaHandler(c.GetMediaStore()).storeInboundAttachments(fromAddr, envelope.MessageID, attachments)
 
 	sender := bus.SenderInfo{
 		Platform:    "email",
@@ -810,88 +746,6 @@ func extractBodyParts(r io.Reader) (text, references string) {
 	}
 
 	return "", references
-}
-
-// attachmentInfo holds a parsed email attachment before storage.
-type attachmentInfo struct {
-	filename    string
-	contentType string
-	data        []byte
-}
-
-// extractAttachments walks the MIME message and returns all attachment parts.
-func extractAttachments(r io.Reader) []attachmentInfo {
-	raw, err := io.ReadAll(r)
-	if err != nil {
-		return nil
-	}
-
-	mr, err := gomail.CreateReader(bytes.NewReader(raw))
-	if err != nil {
-		return nil
-	}
-
-	var attachments []attachmentInfo
-
-	for {
-		p, err := mr.NextPart()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			break
-		}
-		attachHeader, ok := p.Header.(*gomail.AttachmentHeader)
-		if !ok {
-			continue
-		}
-		filename, _ := attachHeader.Filename()
-		if filename == "" {
-			ct, _, _ := attachHeader.ContentType()
-			filename = fallbackFilename(ct)
-		}
-		data, _ := io.ReadAll(p.Body)
-		if len(data) == 0 {
-			continue
-		}
-		ct, _, _ := attachHeader.ContentType()
-		if ct == "" {
-			ct = "application/octet-stream"
-		}
-		attachments = append(attachments, attachmentInfo{
-			filename:    filename,
-			contentType: ct,
-			data:        data,
-		})
-	}
-
-	return attachments
-}
-
-// fallbackFilename generates a filename from a MIME type when none is provided.
-func fallbackFilename(ct string) string {
-	ext := "bin"
-	switch ct {
-	case "text/plain":
-		ext = "txt"
-	case "text/html":
-		ext = "html"
-	case "image/jpeg", "image/jpg":
-		ext = "jpg"
-	case "image/png":
-		ext = "png"
-	case "image/gif":
-		ext = "gif"
-	case "image/webp":
-		ext = "webp"
-	case "application/pdf":
-		ext = "pdf"
-	case "application/zip":
-		ext = "zip"
-	case "application/json":
-		ext = "json"
-	}
-	return fmt.Sprintf("attachment.%s", ext)
 }
 
 func isCalendarRSVP(envelope *imap.Envelope, raw []byte) bool {

--- a/pkg/channels/email/email.go
+++ b/pkg/channels/email/email.go
@@ -9,9 +9,13 @@ import (
 	"fmt"
 	"io"
 	"net/smtp"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 
 	imap "github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapclient"
@@ -22,6 +26,7 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/channels"
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/logger"
+	"github.com/sushi30/sushiclaw/pkg/media"
 )
 
 // EmailConfig holds configuration for the email channel.
@@ -247,6 +252,211 @@ func (c *EmailChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]str
 	return nil, nil
 }
 
+// SendMedia implements the channels.MediaSender interface for sending attachments.
+func (c *EmailChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaMessage) ([]string, error) {
+	if !c.IsRunning() {
+		return nil, channels.ErrNotRunning
+	}
+
+	to := msg.ChatID
+	if to == "" {
+		return nil, fmt.Errorf("chat ID (recipient address) is empty: %w", channels.ErrSendFailed)
+	}
+	if len(msg.Parts) == 0 {
+		return nil, nil
+	}
+
+	store := c.GetMediaStore()
+	if store == nil {
+		return nil, fmt.Errorf("no media store available: %w", channels.ErrSendFailed)
+	}
+
+	var attachments []attachmentInfo
+	for _, part := range msg.Parts {
+		localPath, err := store.Resolve(part.Ref)
+		if err != nil {
+			return nil, fmt.Errorf("resolve media ref %q: %w: %w", part.Ref, err, channels.ErrSendFailed)
+		}
+		data, err := os.ReadFile(localPath)
+		if err != nil {
+			return nil, fmt.Errorf("read attachment %q: %w: %w", localPath, err, channels.ErrSendFailed)
+		}
+		ct := part.ContentType
+		if ct == "" {
+			ct = "application/octet-stream"
+		}
+		filename := part.Filename
+		if filename == "" {
+			filename = filepath.Base(localPath)
+		}
+		attachments = append(attachments, attachmentInfo{
+			filename:    filename,
+			contentType: ct,
+			data:        data,
+		})
+	}
+
+	// Use the first non-empty caption as the email body.
+	var body string
+	for _, part := range msg.Parts {
+		if part.Caption != "" {
+			body = part.Caption
+			break
+		}
+	}
+	return nil, c.sendMultipartEmail(ctx, to, body, msg.Context.ReplyToMessageID, attachments)
+}
+
+// sendMultipartEmail builds and sends a multipart MIME message with HTML body and attachments.
+func (c *EmailChannel) sendMultipartEmail(ctx context.Context, to, content, replyToID string, attachments []attachmentInfo) error {
+	subject := c.config.DefaultSubject
+	if subject == "" {
+		subject = "Message"
+	}
+
+	outboundMsgID := generateMessageID(extractDomain(c.config.SMTPFrom.String()))
+	outboundMsgIDRaw := strings.Trim(outboundMsgID, "<>")
+
+	if replyToID == "" {
+		if v, ok := c.lastMsgByChatID.Load(to); ok {
+			replyToID = v.(string)
+		}
+	}
+
+	var ancestorRefs []string
+	if replyToID != "" {
+		c.tmMu.RLock()
+		node, hasNode := c.tm.AllMessages[replyToID]
+		if hasNode {
+			ancestorRefs = c.tm.ReferencesChain(replyToID)
+			if !node.IsGhost && node.Subject != "" {
+				subject = "Re: " + node.Subject
+			}
+		}
+		c.tmMu.RUnlock()
+	}
+
+	if replyToID == "" && len(outboundMsgIDRaw) >= 8 {
+		subject = fmt.Sprintf("%s [%s]", subject, outboundMsgIDRaw[:8])
+	}
+
+	var h gomail.Header
+	h.SetAddressList("From", []*gomail.Address{{Address: c.config.SMTPFrom.String()}})
+	h.SetAddressList("To", []*gomail.Address{{Address: to}})
+	h.SetSubject(subject)
+	h.SetDate(time.Now())
+	h.SetMessageID(outboundMsgIDRaw)
+
+	if replyToID != "" {
+		h.SetMsgIDList("In-Reply-To", []string{replyToID})
+		allRefs := append(ancestorRefs, replyToID)
+		h.SetMsgIDList("References", allRefs)
+	}
+
+	var bodyBuf bytes.Buffer
+	w, err := gomail.CreateWriter(&bodyBuf, h)
+	if err != nil {
+		return fmt.Errorf("create mime writer: %w: %w", err, channels.ErrSendFailed)
+	}
+
+	// Write HTML body part
+	if strings.TrimSpace(content) != "" {
+		var inlineH gomail.InlineHeader
+		inlineH.SetContentType("text/html", map[string]string{"charset": "utf-8"})
+		inlineW, err := w.CreateSingleInline(inlineH)
+		if err != nil {
+			_ = w.Close()
+			return fmt.Errorf("create inline writer: %w: %w", err, channels.ErrSendFailed)
+		}
+		if _, err := inlineW.Write([]byte(markdownToHTML(content))); err != nil {
+			_ = inlineW.Close()
+			_ = w.Close()
+			return fmt.Errorf("write html body: %w: %w", err, channels.ErrSendFailed)
+		}
+		if err := inlineW.Close(); err != nil {
+			_ = w.Close()
+			return fmt.Errorf("close inline writer: %w: %w", err, channels.ErrSendFailed)
+		}
+	}
+
+	// Write attachment parts
+	for _, att := range attachments {
+		var attH gomail.AttachmentHeader
+		attH.SetFilename(att.filename)
+		attH.SetContentType(att.contentType, map[string]string{})
+		attW, err := w.CreateAttachment(attH)
+		if err != nil {
+			_ = w.Close()
+			return fmt.Errorf("create attachment writer: %w: %w", err, channels.ErrSendFailed)
+		}
+		if _, err := attW.Write(att.data); err != nil {
+			_ = attW.Close()
+			_ = w.Close()
+			return fmt.Errorf("write attachment: %w: %w", err, channels.ErrSendFailed)
+		}
+		if err := attW.Close(); err != nil {
+			_ = w.Close()
+			return fmt.Errorf("close attachment writer: %w: %w", err, channels.ErrSendFailed)
+		}
+	}
+
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("close mime writer: %w: %w", err, channels.ErrSendFailed)
+	}
+
+	smtpPort := c.config.SMTPPort
+	if smtpPort == 0 {
+		smtpPort = 587
+	}
+
+	addr := fmt.Sprintf("%s:%d", c.config.SMTPHost, smtpPort)
+	smtpUser := c.config.SMTPUser.String()
+	if smtpUser == "" {
+		smtpUser = c.config.SMTPFrom.String()
+	}
+
+	var auth smtp.Auth
+	if c.config.SMTPPassword.String() != "" {
+		auth = smtp.PlainAuth("", smtpUser, c.config.SMTPPassword.String(), c.config.SMTPHost)
+	}
+
+	if smtpPort == 465 {
+		tlsCfg := &tls.Config{ServerName: c.config.SMTPHost}
+		conn, err := tls.Dial("tcp", addr, tlsCfg)
+		if err != nil {
+			return fmt.Errorf("smtp tls dial: %w", channels.ErrTemporary)
+		}
+		client, err := smtp.NewClient(conn, c.config.SMTPHost)
+		if err != nil {
+			return fmt.Errorf("smtp new client: %w", channels.ErrTemporary)
+		}
+		defer func() { _ = client.Close() }()
+		if err := sendViaSMTPClient(client, auth, c.config.SMTPFrom.String(), to, bodyBuf.Bytes()); err != nil {
+			return err
+		}
+	} else {
+		if err := smtp.SendMail(addr, auth, c.config.SMTPFrom.String(), []string{to}, bodyBuf.Bytes()); err != nil {
+			return fmt.Errorf("smtp send: %w: %w", err, channels.ErrTemporary)
+		}
+	}
+
+	var outboundRefsStr string
+	if replyToID != "" {
+		parts := make([]string, 0, len(ancestorRefs)+1)
+		for _, r := range ancestorRefs {
+			parts = append(parts, "<"+r+">")
+		}
+		parts = append(parts, "<"+replyToID+">")
+		outboundRefsStr = strings.Join(parts, " ")
+	}
+	c.tmMu.Lock()
+	c.tm.ProcessHeaders(outboundMsgIDRaw, subject, replyToID, outboundRefsStr)
+	c.tmMu.Unlock()
+
+	logger.DebugCF("email", "Media message sent", map[string]any{"to": to, "attachments": len(attachments)})
+	return nil
+}
+
 func sendViaSMTPClient(client *smtp.Client, auth smtp.Auth, from, to string, body []byte) error {
 	if auth != nil {
 		if err := client.Auth(auth); err != nil {
@@ -331,7 +541,9 @@ func (c *EmailChannel) pollIMAP() {
 		return
 	}
 
-	if len(searchData.AllSeqNums()) == 0 {
+	unseenCount := len(searchData.AllSeqNums())
+	logger.DebugCF("email", "IMAP poll complete", map[string]any{"unseen": unseenCount})
+	if unseenCount == 0 {
 		return
 	}
 
@@ -374,10 +586,13 @@ func (c *EmailChannel) pollIMAP() {
 		}
 
 		if envelope == nil || bodyBytes == nil {
+			logger.DebugCF("email", "Skipping IMAP message: missing envelope or body", map[string]any{"seq": seqNum, "has_envelope": envelope != nil, "has_body": len(bodyBytes) > 0})
 			continue
 		}
+		logger.DebugCF("email", "Processing IMAP message", map[string]any{"seq": seqNum, "from": extractFrom(envelope), "subject": envelope.Subject, "size": len(bodyBytes)})
 		processed, _ := c.processEmail(c.ctx, envelope, bytes.NewReader(bodyBytes))
 		if !processed {
+			logger.DebugCF("email", "IMAP message skipped by processEmail", map[string]any{"seq": seqNum, "from": extractFrom(envelope), "subject": envelope.Subject})
 			continue
 		}
 
@@ -401,11 +616,13 @@ func (c *EmailChannel) pollIMAP() {
 func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope, bodyLiteral io.Reader) (bool, string) {
 	fromAddr := extractFrom(envelope)
 	if fromAddr == "" {
+		logger.DebugCF("email", "processEmail skipped: empty sender", map[string]any{"subject": envelope.Subject})
 		return false, ""
 	}
 
 	raw, err := io.ReadAll(bodyLiteral)
 	if err != nil {
+		logger.DebugCF("email", "processEmail skipped: read error", map[string]any{"err": err.Error()})
 		return false, ""
 	}
 
@@ -415,13 +632,18 @@ func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope
 	}
 
 	plainText, references := extractBodyParts(bytes.NewReader(raw))
-	if strings.TrimSpace(plainText) == "" {
+	attachments := extractAttachments(bytes.NewReader(raw))
+
+	// Allow emails with only attachments (no text body) to be processed.
+	if strings.TrimSpace(plainText) == "" && len(attachments) == 0 {
+		logger.DebugCF("email", "processEmail skipped: empty body and no attachments", map[string]any{"from": fromAddr, "subject": envelope.Subject})
 		return false, ""
 	}
 
 	logger.InfoCF("email", "Email received", map[string]any{
-		"from":    fromAddr,
-		"subject": envelope.Subject,
+		"from":        fromAddr,
+		"subject":     envelope.Subject,
+		"attachments": len(attachments),
 	})
 
 	metadata := map[string]string{}
@@ -441,6 +663,42 @@ func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope
 		metadata["reply_to_message_id"] = rawID
 	}
 
+	var mediaPaths []string
+	if store := c.GetMediaStore(); store != nil && len(attachments) > 0 {
+		if err := os.MkdirAll(media.TempDir(), 0o700); err != nil {
+			logger.WarnCF("email", "Failed to create media temp dir", map[string]any{
+				"err": err.Error(),
+				"dir": media.TempDir(),
+			})
+		} else {
+			scope := channels.BuildMediaScope("email", fromAddr, envelope.MessageID)
+			for _, att := range attachments {
+				localPath := filepath.Join(media.TempDir(), uuid.New().String()[:8]+"_"+att.filename)
+				if err := os.WriteFile(localPath, att.data, 0o600); err != nil {
+					logger.WarnCF("email", "Failed to write attachment", map[string]any{
+						"err":      err.Error(),
+						"filename": att.filename,
+					})
+					continue
+				}
+				ref, storeErr := store.Store(localPath, media.MediaMeta{
+					Filename:      att.filename,
+					ContentType:   att.contentType,
+					Source:        "email",
+					CleanupPolicy: media.CleanupPolicyDeleteOnCleanup,
+				}, scope)
+				if storeErr != nil {
+					logger.WarnCF("email", "Failed to store attachment", map[string]any{
+						"err":      storeErr.Error(),
+						"filename": att.filename,
+					})
+					continue
+				}
+			mediaPaths = append(mediaPaths, ref)
+			}
+		}
+	}
+
 	sender := bus.SenderInfo{
 		Platform:    "email",
 		PlatformID:  fromAddr,
@@ -451,7 +709,7 @@ func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope
 	c.HandleMessageWithContext(ctx,
 		fromAddr,
 		plainText,
-		nil,
+		mediaPaths,
 		bus.InboundContext{
 			ChatType:  "direct",
 			ChatID:    fromAddr,
@@ -552,6 +810,88 @@ func extractBodyParts(r io.Reader) (text, references string) {
 	}
 
 	return "", references
+}
+
+// attachmentInfo holds a parsed email attachment before storage.
+type attachmentInfo struct {
+	filename    string
+	contentType string
+	data        []byte
+}
+
+// extractAttachments walks the MIME message and returns all attachment parts.
+func extractAttachments(r io.Reader) []attachmentInfo {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil
+	}
+
+	mr, err := gomail.CreateReader(bytes.NewReader(raw))
+	if err != nil {
+		return nil
+	}
+
+	var attachments []attachmentInfo
+
+	for {
+		p, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			break
+		}
+		attachHeader, ok := p.Header.(*gomail.AttachmentHeader)
+		if !ok {
+			continue
+		}
+		filename, _ := attachHeader.Filename()
+		if filename == "" {
+			ct, _, _ := attachHeader.ContentType()
+			filename = fallbackFilename(ct)
+		}
+		data, _ := io.ReadAll(p.Body)
+		if len(data) == 0 {
+			continue
+		}
+		ct, _, _ := attachHeader.ContentType()
+		if ct == "" {
+			ct = "application/octet-stream"
+		}
+		attachments = append(attachments, attachmentInfo{
+			filename:    filename,
+			contentType: ct,
+			data:        data,
+		})
+	}
+
+	return attachments
+}
+
+// fallbackFilename generates a filename from a MIME type when none is provided.
+func fallbackFilename(ct string) string {
+	ext := "bin"
+	switch ct {
+	case "text/plain":
+		ext = "txt"
+	case "text/html":
+		ext = "html"
+	case "image/jpeg", "image/jpg":
+		ext = "jpg"
+	case "image/png":
+		ext = "png"
+	case "image/gif":
+		ext = "gif"
+	case "image/webp":
+		ext = "webp"
+	case "application/pdf":
+		ext = "pdf"
+	case "application/zip":
+		ext = "zip"
+	case "application/json":
+		ext = "json"
+	}
+	return fmt.Sprintf("attachment.%s", ext)
 }
 
 func isCalendarRSVP(envelope *imap.Envelope, raw []byte) bool {

--- a/pkg/channels/email/email_media.go
+++ b/pkg/channels/email/email_media.go
@@ -1,0 +1,184 @@
+package email
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+
+	gomail "github.com/emersion/go-message/mail"
+
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/channels"
+	"github.com/sushi30/sushiclaw/pkg/logger"
+	"github.com/sushi30/sushiclaw/pkg/media"
+)
+
+type emailMediaHandler struct {
+	store media.MediaStore
+}
+
+func newEmailMediaHandler(store media.MediaStore) emailMediaHandler {
+	return emailMediaHandler{store: store}
+}
+
+func (h emailMediaHandler) outboundAttachments(parts []bus.MediaPart) ([]attachmentInfo, error) {
+	if h.store == nil {
+		return nil, fmt.Errorf("no media store available: %w", channels.ErrSendFailed)
+	}
+
+	attachments := make([]attachmentInfo, 0, len(parts))
+	for _, part := range parts {
+		localPath, err := h.store.Resolve(part.Ref)
+		if err != nil {
+			return nil, fmt.Errorf("resolve media ref %q: %w: %w", part.Ref, err, channels.ErrSendFailed)
+		}
+		data, err := os.ReadFile(localPath)
+		if err != nil {
+			return nil, fmt.Errorf("read attachment %q: %w: %w", localPath, err, channels.ErrSendFailed)
+		}
+		ct := part.ContentType
+		if ct == "" {
+			ct = "application/octet-stream"
+		}
+		filename := part.Filename
+		if filename == "" {
+			filename = filepath.Base(localPath)
+		}
+		attachments = append(attachments, attachmentInfo{
+			filename:    filename,
+			contentType: ct,
+			data:        data,
+		})
+	}
+
+	return attachments, nil
+}
+
+func (h emailMediaHandler) storeInboundAttachments(fromAddr, messageID string, attachments []attachmentInfo) []string {
+	if h.store == nil || len(attachments) == 0 {
+		return nil
+	}
+
+	if err := os.MkdirAll(media.TempDir(), 0o700); err != nil {
+		logger.WarnCF("email", "Failed to create media temp dir", map[string]any{
+			"err": err.Error(),
+			"dir": media.TempDir(),
+		})
+		return nil
+	}
+
+	scope := channels.BuildMediaScope("email", fromAddr, messageID)
+	mediaPaths := make([]string, 0, len(attachments))
+	for _, att := range attachments {
+		localPath := filepath.Join(media.TempDir(), uuid.New().String()[:8]+"_"+att.filename)
+		if err := os.WriteFile(localPath, att.data, 0o600); err != nil {
+			logger.WarnCF("email", "Failed to write attachment", map[string]any{
+				"err":      err.Error(),
+				"filename": att.filename,
+			})
+			continue
+		}
+		ref, storeErr := h.store.Store(localPath, media.MediaMeta{
+			Filename:      att.filename,
+			ContentType:   att.contentType,
+			Source:        "email",
+			CleanupPolicy: media.CleanupPolicyDeleteOnCleanup,
+		}, scope)
+		if storeErr != nil {
+			logger.WarnCF("email", "Failed to store attachment", map[string]any{
+				"err":      storeErr.Error(),
+				"filename": att.filename,
+			})
+			continue
+		}
+		mediaPaths = append(mediaPaths, ref)
+	}
+
+	return mediaPaths
+}
+
+// attachmentInfo holds a parsed email attachment before storage.
+type attachmentInfo struct {
+	filename    string
+	contentType string
+	data        []byte
+}
+
+// extractAttachments walks the MIME message and returns all attachment parts.
+func extractAttachments(r io.Reader) []attachmentInfo {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil
+	}
+
+	mr, err := gomail.CreateReader(bytes.NewReader(raw))
+	if err != nil {
+		return nil
+	}
+
+	var attachments []attachmentInfo
+
+	for {
+		p, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			break
+		}
+		attachHeader, ok := p.Header.(*gomail.AttachmentHeader)
+		if !ok {
+			continue
+		}
+		filename, _ := attachHeader.Filename()
+		if filename == "" {
+			ct, _, _ := attachHeader.ContentType()
+			filename = fallbackFilename(ct)
+		}
+		data, _ := io.ReadAll(p.Body)
+		if len(data) == 0 {
+			continue
+		}
+		ct, _, _ := attachHeader.ContentType()
+		if ct == "" {
+			ct = "application/octet-stream"
+		}
+		attachments = append(attachments, attachmentInfo{
+			filename:    filename,
+			contentType: ct,
+			data:        data,
+		})
+	}
+
+	return attachments
+}
+
+// fallbackFilename generates a filename from a MIME type when none is provided.
+func fallbackFilename(ct string) string {
+	ext := "bin"
+	switch ct {
+	case "text/plain":
+		ext = "txt"
+	case "text/html":
+		ext = "html"
+	case "image/jpeg", "image/jpg":
+		ext = "jpg"
+	case "image/png":
+		ext = "png"
+	case "image/gif":
+		ext = "gif"
+	case "image/webp":
+		ext = "webp"
+	case "application/pdf":
+		ext = "pdf"
+	case "application/zip":
+		ext = "zip"
+	case "application/json":
+		ext = "json"
+	}
+	return fmt.Sprintf("attachment.%s", ext)
+}

--- a/pkg/channels/email/email_test.go
+++ b/pkg/channels/email/email_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/bus"
 	"github.com/sushi30/sushiclaw/pkg/channels"
 	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/media"
 )
 
 func TestGenerateMessageID(t *testing.T) {
@@ -710,6 +712,254 @@ func extractSubjectFromSMTPBody(t *testing.T, body string) string {
 	}
 	t.Fatalf("no Subject header found in SMTP body:\n%s", body)
 	return ""
+}
+
+func TestExtractAttachments(t *testing.T) {
+	mimeWithAttachments := strings.Join([]string{
+		"MIME-Version: 1.0",
+		`Content-Type: multipart/mixed; boundary="boundary"`,
+		"",
+		"--boundary",
+		"Content-Type: text/plain; charset=utf-8",
+		"",
+		"Hello with attachment",
+		"--boundary",
+		"Content-Type: application/octet-stream",
+		`Content-Disposition: attachment; filename="test.txt"`,
+		"",
+		"attachment data",
+		"--boundary",
+		"Content-Type: image/png",
+		`Content-Disposition: attachment; filename="image.png"`,
+		"",
+		"pngdata",
+		"--boundary--",
+	}, "\r\n")
+
+	attachments := extractAttachments(strings.NewReader(mimeWithAttachments))
+	if len(attachments) != 2 {
+		t.Fatalf("expected 2 attachments, got %d", len(attachments))
+	}
+	if attachments[0].filename != "test.txt" {
+		t.Errorf("attachment[0].filename = %q, want %q", attachments[0].filename, "test.txt")
+	}
+	if string(attachments[0].data) != "attachment data" {
+		t.Errorf("attachment[0].data = %q, want %q", attachments[0].data, "attachment data")
+	}
+	if attachments[1].filename != "image.png" {
+		t.Errorf("attachment[1].filename = %q, want %q", attachments[1].filename, "image.png")
+	}
+	if string(attachments[1].data) != "pngdata" {
+		t.Errorf("attachment[1].data = %q, want %q", attachments[1].data, "pngdata")
+	}
+}
+
+func TestExtractAttachments_NoAttachments(t *testing.T) {
+	plainMIME := "MIME-Version: 1.0\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nHello"
+	attachments := extractAttachments(strings.NewReader(plainMIME))
+	if len(attachments) != 0 {
+		t.Errorf("expected 0 attachments, got %d", len(attachments))
+	}
+}
+
+func TestProcessEmail_WithAttachments(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	store := media.NewFileMediaStore()
+	ch := &EmailChannel{
+		BaseChannel: channels.NewBaseChannel("email", EmailConfig{}, messageBus, nil),
+		tm:          NewThreadManager(),
+	}
+	ch.SetMediaStore(store)
+
+	mimeWithAttachment := strings.Join([]string{
+		"MIME-Version: 1.0",
+		`Content-Type: multipart/mixed; boundary="boundary"`,
+		"",
+		"--boundary",
+		"Content-Type: text/plain; charset=utf-8",
+		"",
+		"See attached",
+		"--boundary",
+		"Content-Type: text/plain",
+		`Content-Disposition: attachment; filename="notes.txt"`,
+		"",
+		"note content",
+		"--boundary--",
+	}, "\r\n")
+
+	envelope := &imap.Envelope{
+		From:      []imap.Address{{Mailbox: "test", Host: "example.com", Name: "Test Sender"}},
+		Subject:   "With attachment",
+		MessageID: "mid-attachment",
+	}
+
+	processed, got := ch.processEmail(context.Background(), envelope, strings.NewReader(mimeWithAttachment))
+	if !processed {
+		t.Fatal("processEmail() reported skipped message")
+	}
+	if got != "See attached" {
+		t.Fatalf("processEmail() = %q, want %q", got, "See attached")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for inbound message")
+	case inbound, ok := <-messageBus.InboundChan():
+		if !ok {
+			t.Fatal("expected inbound message")
+		}
+		if inbound.Channel != "email" {
+			t.Fatalf("channel=%q", inbound.Channel)
+		}
+		if inbound.Content != "See attached" {
+			t.Fatalf("content=%q", inbound.Content)
+		}
+		if len(inbound.Media) != 1 {
+			t.Fatalf("expected 1 media ref, got %d", len(inbound.Media))
+		}
+		if !strings.HasPrefix(inbound.Media[0], "media://") {
+			t.Errorf("media ref = %q, want media:// prefix", inbound.Media[0])
+		}
+	}
+}
+
+func TestProcessEmail_MediaOnly(t *testing.T) {
+	messageBus := bus.NewMessageBus()
+	store := media.NewFileMediaStore()
+	ch := &EmailChannel{
+		BaseChannel: channels.NewBaseChannel("email", EmailConfig{}, messageBus, nil),
+		tm:          NewThreadManager(),
+	}
+	ch.SetMediaStore(store)
+
+	mimeOnlyAttachment := strings.Join([]string{
+		"MIME-Version: 1.0",
+		`Content-Type: multipart/mixed; boundary="boundary"`,
+		"",
+		"--boundary",
+		"Content-Type: application/pdf",
+		`Content-Disposition: attachment; filename="doc.pdf"`,
+		"",
+		"pdfdata",
+		"--boundary--",
+	}, "\r\n")
+
+	envelope := &imap.Envelope{
+		From:      []imap.Address{{Mailbox: "test", Host: "example.com"}},
+		Subject:   "PDF only",
+		MessageID: "mid-pdf",
+	}
+
+	processed, got := ch.processEmail(context.Background(), envelope, strings.NewReader(mimeOnlyAttachment))
+	if !processed {
+		t.Fatal("processEmail() reported skipped message")
+	}
+	if got != "" {
+		t.Fatalf("processEmail() text = %q, want empty", got)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for inbound message")
+	case inbound, ok := <-messageBus.InboundChan():
+		if !ok {
+			t.Fatal("expected inbound message")
+		}
+		if inbound.Content != "" {
+			t.Fatalf("content=%q, want empty", inbound.Content)
+		}
+		if len(inbound.Media) != 1 {
+			t.Fatalf("expected 1 media ref, got %d", len(inbound.Media))
+		}
+	}
+}
+
+func TestSendMedia_WithAttachment(t *testing.T) {
+	smtpHost, smtpPort, received := startSMTPCapture(t)
+	smtpPortInt, _ := strconv.Atoi(smtpPort)
+
+	cfg := EmailConfig{
+		SMTPHost:       smtpHost,
+		SMTPPort:       smtpPortInt,
+		SMTPFrom:       *config.NewSecureString("bot@test.com"),
+		DefaultSubject: "Message",
+		IMAPHost:       "127.0.0.1",
+		IMAPPort:       10143,
+		IMAPUser:       *config.NewSecureString("u"),
+		IMAPPassword:   *config.NewSecureString("p"),
+	}
+
+	ch, err := NewEmailChannel(cfg, bus.NewMessageBus())
+	if err != nil {
+		t.Fatalf("NewEmailChannel: %v", err)
+	}
+	ch.SetRunning(true)
+
+	// Seed the thread manager so the reply gets a Re: subject.
+	ch.tm.ProcessHeaders("orig-attach@test.com", "Original Subject", "", "")
+
+	// Create a temp file and store it.
+	store := media.NewFileMediaStore()
+	ch.SetMediaStore(store)
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "report.txt")
+	if err := os.WriteFile(tmpFile, []byte("report content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ref, err := store.Store(tmpFile, media.MediaMeta{
+		Filename:    "report.txt",
+		ContentType: "text/plain",
+		Source:      "test",
+	}, "test:scope")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ch.SendMedia(context.Background(), bus.OutboundMediaMessage{
+		ChatID: "user@example.com",
+		Parts: []bus.MediaPart{
+			{
+				Type:        "file",
+				Ref:         ref,
+				Filename:    "report.txt",
+				ContentType: "text/plain",
+				Caption:     "Please find the report attached.",
+			},
+		},
+		Context: bus.InboundContext{ReplyToMessageID: "orig-attach@test.com"},
+	})
+	if err != nil {
+		t.Fatalf("SendMedia: %v", err)
+	}
+
+	select {
+	case body := <-received:
+		if !strings.Contains(body, "Subject: Re: Original Subject") {
+			t.Errorf("missing Re: subject in:\n%s", body)
+		}
+		if !strings.Contains(body, "Content-Disposition: attachment") {
+			t.Errorf("missing attachment disposition in:\n%s", body)
+		}
+		if !strings.Contains(body, "filename=report.txt") {
+			t.Errorf("missing attachment filename in:\n%s", body)
+		}
+		// Content is base64-encoded by gomail
+		if !strings.Contains(body, "cmVwb3J0IGNvbnRlbnQ=") {
+			t.Errorf("missing base64 attachment content in:\n%s", body)
+		}
+		if !strings.Contains(body, "Please find the report attached.") {
+			t.Errorf("missing caption/body in:\n%s", body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout: SMTP capture received nothing")
+	}
 }
 
 func TestProcessEmail_SkipsEmptyOrSenderlessMessages(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -170,11 +170,12 @@ type BaiduSearchConfig struct {
 }
 
 type VisionToolConfig struct {
-	Enabled bool          `json:"enabled"`
-	Model   string        `json:"model"`
-	APIKey  *SecureString `json:"api_key,omitzero"`
-	APIBase string        `json:"api_base,omitempty"`
-	Prompt  string        `json:"prompt,omitempty"`
+	Enabled   bool          `json:"enabled"`
+	ModelName string        `json:"model_name,omitempty"`
+	Model     string        `json:"model"`
+	APIKey    *SecureString `json:"api_key,omitzero"`
+	APIBase   string        `json:"api_base,omitempty"`
+	Prompt    string        `json:"prompt,omitempty"`
 }
 
 // APIKeyString returns the resolved API key.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,6 +91,7 @@ type ToolsConfig struct {
 	WriteFile    ToolConfig          `json:"write_file"`
 	ListDir      ToolConfig          `json:"list_dir"`
 	WebSearch    WebSearchToolConfig `json:"web_search"`
+	Vision       VisionToolConfig    `json:"vision"`
 }
 
 func (t ToolsConfig) IsToolEnabled(name string) bool {
@@ -107,6 +108,8 @@ func (t ToolsConfig) IsToolEnabled(name string) bool {
 		return t.ListDir.Enabled
 	case "web_search":
 		return t.WebSearch.Enabled
+	case "vision":
+		return t.Vision.Enabled
 	}
 	return false
 }
@@ -164,6 +167,22 @@ type TavilySearchConfig struct {
 type BaiduSearchConfig struct {
 	Enabled bool          `json:"enabled"`
 	APIKey  *SecureString `json:"api_key,omitzero"`
+}
+
+type VisionToolConfig struct {
+	Enabled bool          `json:"enabled"`
+	Model   string        `json:"model"`
+	APIKey  *SecureString `json:"api_key,omitzero"`
+	APIBase string        `json:"api_base,omitempty"`
+	Prompt  string        `json:"prompt,omitempty"`
+}
+
+// APIKeyString returns the resolved API key.
+func (v VisionToolConfig) APIKeyString() string {
+	if v.APIKey != nil {
+		return v.APIKey.String()
+	}
+	return ""
 }
 
 // EmailChanCfg is the top-level email_channel config in config.json.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,9 +14,9 @@ func TestParseExampleConfig(t *testing.T) {
 	cfg, err := config.LoadConfig("../../config.example.json")
 	require.NoError(t, err)
 
-	assert.Equal(t, "claude-sonnet", cfg.Agents.Defaults.ModelName)
+	assert.Equal(t, "gpt-4o-mini", cfg.Agents.Defaults.ModelName)
 	assert.NotEmpty(t, cfg.ModelList)
-	assert.Equal(t, "claude-sonnet", cfg.ModelList[0].ModelName)
+	assert.Equal(t, "gpt-4o-mini", cfg.ModelList[0].ModelName)
 	assert.Equal(t, 18800, cfg.Gateway.Port)
 	assert.NotNil(t, cfg.Channels["telegram"])
 }
@@ -31,7 +31,7 @@ func TestChannelDecode(t *testing.T) {
 
 	var tgSettings config.TelegramSettings
 	require.NoError(t, tgCh.Decode(&tgSettings))
-	// Token value is "YOUR_TELEGRAM_BOT_TOKEN" in example
+	// Token value is an env:// reference in example config.
 	assert.NotEmpty(t, tgSettings.Token.String())
 }
 

--- a/pkg/tools/builder.go
+++ b/pkg/tools/builder.go
@@ -3,8 +3,10 @@ package tools
 import (
 	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
 	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/media"
 	"github.com/sushi30/sushiclaw/pkg/tools/exec"
 	fstools "github.com/sushi30/sushiclaw/pkg/tools/fs"
+	"github.com/sushi30/sushiclaw/pkg/tools/vision"
 	"github.com/sushi30/sushiclaw/pkg/tools/websearch"
 )
 
@@ -19,11 +21,16 @@ func NewChatTools(cfg *config.Config) []interfaces.Tool {
 			out = append(out, tool)
 		}
 	}
+	if cfg.Tools.IsToolEnabled("vision") {
+		if tool, err := vision.NewTool(cfg.Tools.Vision, defaultModel(cfg), nil); err == nil {
+			out = append(out, tool)
+		}
+	}
 	return out
 }
 
 // NewGatewayTools returns tools available to remote gateway sessions.
-func NewGatewayTools(cfg *config.Config, execAllowedSenders []string) ([]interfaces.Tool, error) {
+func NewGatewayTools(cfg *config.Config, execAllowedSenders []string, store media.MediaStore) ([]interfaces.Tool, error) {
 	out := newFileTools(cfg)
 	if cfg.Tools.IsToolEnabled("exec") && len(execAllowedSenders) > 0 {
 		trustedExec, err := NewTrustedExecTool(cfg, workspacePath(cfg), restrictToWorkspace(cfg), execAllowedSenders)
@@ -31,6 +38,11 @@ func NewGatewayTools(cfg *config.Config, execAllowedSenders []string) ([]interfa
 			return out, err
 		}
 		out = append(out, trustedExec)
+	}
+	if cfg.Tools.IsToolEnabled("vision") {
+		if tool, err := vision.NewTool(cfg.Tools.Vision, defaultModel(cfg), store); err == nil {
+			out = append(out, tool)
+		}
 	}
 	return out, nil
 }
@@ -61,4 +73,17 @@ func workspacePath(cfg *config.Config) string {
 
 func restrictToWorkspace(cfg *config.Config) bool {
 	return cfg != nil && cfg.Agents.Defaults.RestrictToWorkspace
+}
+
+func defaultModel(cfg *config.Config) *config.ModelConfig {
+	if cfg == nil {
+		return nil
+	}
+	name := cfg.Agents.Defaults.ModelName
+	for i := range cfg.ModelList {
+		if cfg.ModelList[i].ModelName == name {
+			return &cfg.ModelList[i]
+		}
+	}
+	return nil
 }

--- a/pkg/tools/builder.go
+++ b/pkg/tools/builder.go
@@ -22,7 +22,7 @@ func NewChatTools(cfg *config.Config) []interfaces.Tool {
 		}
 	}
 	if cfg.Tools.IsToolEnabled("vision") {
-		if tool, err := vision.NewTool(cfg.Tools.Vision, defaultModel(cfg), nil); err == nil {
+		if tool, err := vision.NewTool(cfg.Tools.Vision, visionModel(cfg), nil); err == nil {
 			out = append(out, tool)
 		}
 	}
@@ -40,7 +40,7 @@ func NewGatewayTools(cfg *config.Config, execAllowedSenders []string, store medi
 		out = append(out, trustedExec)
 	}
 	if cfg.Tools.IsToolEnabled("vision") {
-		if tool, err := vision.NewTool(cfg.Tools.Vision, defaultModel(cfg), store); err == nil {
+		if tool, err := vision.NewTool(cfg.Tools.Vision, visionModel(cfg), store); err == nil {
 			out = append(out, tool)
 		}
 	}
@@ -80,6 +80,22 @@ func defaultModel(cfg *config.Config) *config.ModelConfig {
 		return nil
 	}
 	name := cfg.Agents.Defaults.ModelName
+	for i := range cfg.ModelList {
+		if cfg.ModelList[i].ModelName == name {
+			return &cfg.ModelList[i]
+		}
+	}
+	return nil
+}
+
+func visionModel(cfg *config.Config) *config.ModelConfig {
+	if cfg == nil {
+		return nil
+	}
+	name := cfg.Tools.Vision.ModelName
+	if name == "" {
+		return defaultModel(cfg)
+	}
 	for i := range cfg.ModelList {
 		if cfg.ModelList[i].ModelName == name {
 			return &cfg.ModelList[i]

--- a/pkg/tools/builder_test.go
+++ b/pkg/tools/builder_test.go
@@ -56,6 +56,32 @@ func TestNewGatewayTools_RegistersTrustedExecWithAllowlist(t *testing.T) {
 	}
 }
 
+func TestNewGatewayTools_RegistersVisionFromModelListReference(t *testing.T) {
+	cfg := newToolsConfig(t)
+	cfg.Agents.Defaults.ModelName = "text-model"
+	cfg.ModelList = []config.ModelConfig{
+		{ModelName: "text-model", Model: "openrouter/z-ai/glm-4.5"},
+		{
+			ModelName: "vision-model",
+			Model:     "openrouter/z-ai/glm-5v-turbo",
+			APIKey:    config.NewSecureString("test-key"),
+		},
+	}
+	cfg.Tools.Vision.Enabled = true
+	cfg.Tools.Vision.ModelName = "vision-model"
+
+	built, err := tools.NewGatewayTools(cfg, nil, nil)
+	if err != nil {
+		t.Fatalf("NewGatewayTools: %v", err)
+	}
+
+	got := toolNames(built)
+	want := []string{"vision"}
+	if !equalStrings(got, want) {
+		t.Fatalf("tool names = %v, want %v", got, want)
+	}
+}
+
 func newToolsConfig(t *testing.T) *config.Config {
 	t.Helper()
 	return &config.Config{

--- a/pkg/tools/builder_test.go
+++ b/pkg/tools/builder_test.go
@@ -28,7 +28,7 @@ func TestNewGatewayTools_RegistersFileToolsWithoutExecAllowlist(t *testing.T) {
 	cfg.Tools.ReadFile.Enabled = true
 	cfg.Tools.ListDir.Enabled = true
 
-	built, err := tools.NewGatewayTools(cfg, nil)
+	built, err := tools.NewGatewayTools(cfg, nil, nil)
 	if err != nil {
 		t.Fatalf("NewGatewayTools: %v", err)
 	}
@@ -44,7 +44,7 @@ func TestNewGatewayTools_RegistersTrustedExecWithAllowlist(t *testing.T) {
 	cfg := newToolsConfig(t)
 	cfg.Tools.Exec.Enabled = true
 
-	built, err := tools.NewGatewayTools(cfg, []string{"chat-1"})
+	built, err := tools.NewGatewayTools(cfg, []string{"chat-1"}, nil)
 	if err != nil {
 		t.Fatalf("NewGatewayTools: %v", err)
 	}

--- a/pkg/tools/vision/vision.go
+++ b/pkg/tools/vision/vision.go
@@ -182,7 +182,7 @@ func (t *VisionTool) describeImage(ctx context.Context, prompt, dataURI string) 
 	if err != nil {
 		return "", fmt.Errorf("vision API request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {

--- a/pkg/tools/vision/vision.go
+++ b/pkg/tools/vision/vision.go
@@ -1,0 +1,206 @@
+package vision
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/media"
+)
+
+const defaultPrompt = "Describe this image in detail."
+const defaultMaxTokens = 1024
+
+// VisionTool calls a vision-capable LLM to describe an image.
+type VisionTool struct {
+	model       string
+	apiKey      string
+	apiBase     string
+	defaultPrompt string
+	client      *http.Client
+	mediaStore  media.MediaStore
+}
+
+// Args is the expected JSON shape from the agent.
+type Args struct {
+	ImagePath string `json:"image_path"`
+	Prompt    string `json:"prompt"`
+}
+
+// NewTool creates a VisionTool from config.
+func NewTool(cfg config.VisionToolConfig, defaultModelCfg *config.ModelConfig, store media.MediaStore) (*VisionTool, error) {
+	apiKey := cfg.APIKeyString()
+	if apiKey == "" && defaultModelCfg != nil {
+		apiKey = defaultModelCfg.APIKeyString()
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("vision tool requires api_key (set VISION_API_KEY env var or config, or ensure a default model has an api_key)")
+	}
+
+	model := cfg.Model
+	if model == "" && defaultModelCfg != nil {
+		model = defaultModelCfg.Model
+		if model == "" {
+			model = defaultModelCfg.ModelName
+		}
+	}
+	if model == "" {
+		return nil, fmt.Errorf("vision tool requires model (set vision.model in config, or ensure a default model is configured)")
+	}
+
+	// Strip openrouter/ prefix if present — the API endpoint expects the raw model ID.
+	model = strings.TrimPrefix(model, "openrouter/")
+
+	apiBase := cfg.APIBase
+	if apiBase == "" && defaultModelCfg != nil {
+		apiBase = defaultModelCfg.APIBase
+	}
+	if apiBase == "" {
+		apiBase = "https://openrouter.ai/api/v1"
+	}
+
+	prompt := cfg.Prompt
+	if prompt == "" {
+		prompt = defaultPrompt
+	}
+
+	return &VisionTool{
+		model:         model,
+		apiKey:        apiKey,
+		apiBase:       strings.TrimSuffix(apiBase, "/"),
+		defaultPrompt: prompt,
+		client:        &http.Client{Timeout: 60 * time.Second},
+		mediaStore:    store,
+	}, nil
+}
+
+func (t *VisionTool) Name() string        { return "vision" }
+func (t *VisionTool) Description() string { return "Analyze an image using a vision-capable LLM and return a text description." }
+
+func (t *VisionTool) Parameters() map[string]interfaces.ParameterSpec {
+	return map[string]interfaces.ParameterSpec{
+		"image_path": {
+			Type:        "string",
+			Description: "Local file path or media:// reference to the image to analyze",
+			Required:    true,
+		},
+		"prompt": {
+			Type:        "string",
+			Description: "Optional custom prompt for the vision analysis (default: describe the image)",
+			Required:    false,
+		},
+	}
+}
+
+// Run executes the tool with the given input string.
+func (t *VisionTool) Run(ctx context.Context, input string) (string, error) {
+	return t.Execute(ctx, input)
+}
+
+// Execute executes the tool with the given arguments JSON string.
+func (t *VisionTool) Execute(ctx context.Context, args string) (string, error) {
+	var a Args
+	if err := json.Unmarshal([]byte(args), &a); err != nil {
+		// Fallback: treat whole input as image_path.
+		a.ImagePath = strings.TrimSpace(args)
+	}
+	if a.ImagePath == "" {
+		return "", fmt.Errorf("image_path is required")
+	}
+
+	localPath := a.ImagePath
+	if strings.HasPrefix(a.ImagePath, "media://") {
+		if t.mediaStore == nil {
+			return "", fmt.Errorf("cannot resolve media ref: no media store available")
+		}
+		resolved, err := t.mediaStore.Resolve(a.ImagePath)
+		if err != nil {
+			return "", fmt.Errorf("resolve media ref %q: %w", a.ImagePath, err)
+		}
+		localPath = resolved
+	}
+
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		return "", fmt.Errorf("read image %q: %w", localPath, err)
+	}
+
+	contentType := mime.TypeByExtension(filepath.Ext(localPath))
+	if contentType == "" {
+		contentType = "image/jpeg"
+	}
+	b64 := base64.StdEncoding.EncodeToString(data)
+	dataURI := fmt.Sprintf("data:%s;base64,%s", contentType, b64)
+
+	prompt := a.Prompt
+	if prompt == "" {
+		prompt = t.defaultPrompt
+	}
+
+	return t.describeImage(ctx, prompt, dataURI)
+}
+
+func (t *VisionTool) describeImage(ctx context.Context, prompt, dataURI string) (string, error) {
+	payload := map[string]interface{}{
+		"model": t.model,
+		"messages": []map[string]interface{}{
+			{
+				"role": "user",
+				"content": []map[string]interface{}{
+					{"type": "text", "text": prompt},
+					{"type": "image_url", "image_url": map[string]string{"url": dataURI}},
+				},
+			},
+		},
+		"max_tokens": defaultMaxTokens,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.apiBase+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+t.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("vision API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("vision API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("parse vision API response: %w", err)
+	}
+	if len(result.Choices) == 0 {
+		return "", fmt.Errorf("vision API returned no choices")
+	}
+	return strings.TrimSpace(result.Choices[0].Message.Content), nil
+}

--- a/workspace/AGENT.md
+++ b/workspace/AGENT.md
@@ -35,6 +35,27 @@ be practical, accurate, and efficient.
 - Respect user control, privacy, and safety
 - Aim for fast, efficient help without sacrificing quality
 
+## Dev Server Workflow
+
+When the user asks to start a dev server:
+
+1. Validate that the current shell is running inside tmux:
+   ```bash
+   printenv TMUX
+   tmux display-message -p '#S:#I.#P'
+   ```
+2. If not inside tmux, tell the user that dev server startup is supported only on tmux.
+3. If inside tmux, start a new pane from the repository root and run `air` in it:
+   ```bash
+   tmux split-window -h -c "$(pwd)" 'air; exec zsh -i'
+   ```
+4. Find the pane and read its logs to confirm the process started successfully:
+   ```bash
+   tmux list-panes -F '#{pane_index} #{pane_id} #{pane_current_command} #{pane_current_path} #{pane_active}'
+   tmux capture-pane -t <pane_id> -p -S -200
+   ```
+5. Notify the user that the dev server is ready and they can start messaging it.
+
 ## Goals
 
 - Provide fast and lightweight AI assistance


### PR DESCRIPTION
## Summary
Add inbound and outbound email attachment support to the email channel, matching the patterns already used by WhatsApp and Telegram. Also make the example configs directly usable by documenting API-key based OpenAI/OpenRouter setup and enabling the vision tool needed for image attachments.

## Changes
- **Inbound**: Parse MIME attachment parts, write them to temp files through the email media helper, store via `MediaStore`, and pass `media://` refs to the agent.
- **Outbound**: Implement `channels.MediaSender` (`SendMedia`) to attach files from `media://` refs to SMTP messages as multipart MIME.
- **Threading**: Outbound `SendMedia` reuses the existing reply/thread tracking logic from `Send()`.
- **Vision/config docs**: Add a Telegram OpenRouter example config, switch the default example to OpenAI-compatible API settings, document `tools.vision`, and support `tools.vision.model_name` references into `model_list`.

## Known gaps
- #122 Add tool registration discovery system
- #124 Support Gemini image understanding in vision tool

## Test plan
- `make test`
- `make lint`
- `go test ./pkg/channels/email`
- `go test ./pkg/tools ./pkg/config ./pkg/tools/vision`
- `jq empty config.example.json examples/config/telegram-openrouter.json`
- Verified the dev server logs register both `exec` and `vision` tools after enabling `tools.vision` in the active config.