### PR TITLE
feat: add operational debug progress updates

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -62,7 +62,8 @@
   "gateway": {
     "host": "0.0.0.0",
     "port": 18800,
-    "log_level": "info"
+    "log_level": "info",
+    "debug_heartbeat_seconds": 30
   },
   "tools": {
     "web_search": {

--- a/internal/agent/progress.go
+++ b/internal/agent/progress.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"context"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+)
+
+const DefaultDebugHeartbeatInterval = 30 * time.Second
+
+type ProgressKind string
+
+const (
+	ProgressTurnStarted      ProgressKind = "turn_started"
+	ProgressFirstActivity    ProgressKind = "first_activity"
+	ProgressToolCallStarted  ProgressKind = "tool_call_started"
+	ProgressToolCallFinished ProgressKind = "tool_call_finished"
+	ProgressFallback         ProgressKind = "fallback"
+	ProgressHeartbeat        ProgressKind = "heartbeat"
+	ProgressCompleted        ProgressKind = "completed"
+	ProgressFailed           ProgressKind = "failed"
+)
+
+type ProgressEvent struct {
+	Channel string
+	ChatID  string
+	Kind    ProgressKind
+
+	ToolName string
+	Error    error
+	Elapsed  time.Duration
+}
+
+type ProgressSummary struct {
+	Channel string
+	ChatID  string
+	Success bool
+
+	ToolCalls int
+	Usage     *interfaces.TokenUsage
+	Duration  time.Duration
+	Error     error
+}
+
+type ProgressSink interface {
+	HeartbeatInterval() time.Duration
+	Progress(ctx context.Context, event ProgressEvent)
+	Summary(ctx context.Context, summary ProgressSummary)
+}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	agentsdk "github.com/Ingenimax/agent-sdk-go/pkg/agent"
 	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
@@ -23,12 +24,27 @@ import (
 
 // SessionManager wraps an agent-sdk-go Agent and processes inbound bus messages.
 type SessionManager struct {
-	agent           *agentsdk.Agent
+	agent           agentRunner
 	bus             *bus.MessageBus
 	mem             *InMemoryMemory
 	cfg             *config.Config
 	tools           []interfaces.Tool
 	activatedSkills map[string]bool
+	progress        ProgressSink
+}
+
+type agentRunner interface {
+	Run(ctx context.Context, input string) (string, error)
+	RunDetailed(ctx context.Context, input string) (*interfaces.AgentResponse, error)
+	RunStream(ctx context.Context, input string) (<-chan interfaces.AgentStreamEvent, error)
+}
+
+type SessionOption func(*SessionManager)
+
+func WithProgressSink(sink ProgressSink) SessionOption {
+	return func(sm *SessionManager) {
+		sm.progress = sink
+	}
 }
 
 // BuildAgent creates an agent-sdk-go Agent from config and tools.
@@ -124,21 +140,27 @@ func toAgentSDKMCPConfig(cfg config.MCPConfig) *agentsdk.MCPConfiguration {
 }
 
 // NewSessionManager creates a session manager from config.
-func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus, tools []interfaces.Tool) (*SessionManager, error) {
+func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus, tools []interfaces.Tool, opts ...SessionOption) (*SessionManager, error) {
 	mem := NewInMemoryMemory()
 	a, err := buildAgentWithMemory(cfg, tools, mem)
 	if err != nil {
 		return nil, err
 	}
 
-	return &SessionManager{
+	sm := &SessionManager{
 		agent:           a,
 		bus:             messageBus,
 		mem:             mem,
 		cfg:             cfg,
 		tools:           tools,
 		activatedSkills: make(map[string]bool),
-	}, nil
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(sm)
+		}
+	}
+	return sm, nil
 }
 
 // ClearHistory resets the agent's conversation memory.
@@ -268,13 +290,26 @@ func (sm *SessionManager) handleInbound(ctx context.Context, msg bus.InboundMess
 		"preview": truncate(input, 50),
 	})
 
-	response, err := sm.agent.Run(actx, input)
+	start := time.Now()
+	sm.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressTurnStarted})
+
+	response, usage, toolCalls, err := sm.runStreamingTurn(actx, ctx, msg.Channel, chatID, input, start)
 	if err != nil {
 		logger.ErrorCF("agent", "Agent run failed", map[string]any{"error": err.Error()})
 		_ = sm.bus.PublishOutbound(ctx, bus.OutboundMessage{
 			Channel: msg.Channel,
 			ChatID:  chatID,
 			Content: fmt.Sprintf("Error: %v", err),
+		})
+		sm.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressFailed, Error: err, Elapsed: time.Since(start)})
+		sm.emitSummary(ctx, ProgressSummary{
+			Channel:   msg.Channel,
+			ChatID:    chatID,
+			Success:   false,
+			ToolCalls: toolCalls,
+			Usage:     usage,
+			Duration:  time.Since(start),
+			Error:     err,
 		})
 		return
 	}
@@ -286,6 +321,240 @@ func (sm *SessionManager) handleInbound(ctx context.Context, msg bus.InboundMess
 			Content: response,
 		})
 	}
+	sm.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressCompleted, Elapsed: time.Since(start)})
+	sm.emitSummary(ctx, ProgressSummary{
+		Channel:   msg.Channel,
+		ChatID:    chatID,
+		Success:   true,
+		ToolCalls: toolCalls,
+		Usage:     usage,
+		Duration:  time.Since(start),
+	})
+}
+
+func (sm *SessionManager) runStreamingTurn(
+	actx context.Context,
+	outCtx context.Context,
+	channel string,
+	chatID string,
+	input string,
+	start time.Time,
+) (string, *interfaces.TokenUsage, int, error) {
+	events, err := sm.agent.RunStream(actx, input)
+	if err != nil {
+		sm.emitProgress(outCtx, ProgressEvent{Channel: channel, ChatID: chatID, Kind: ProgressFallback, Error: err, Elapsed: time.Since(start)})
+		return sm.runDetailedTurn(actx, input)
+	}
+	if events == nil {
+		err := errors.New("agent stream returned nil event channel")
+		sm.emitProgress(outCtx, ProgressEvent{Channel: channel, ChatID: chatID, Kind: ProgressFallback, Error: err, Elapsed: time.Since(start)})
+		return sm.runDetailedTurn(actx, input)
+	}
+
+	var streamer bus.Streamer
+	var hasStreamer bool
+	if sm.bus != nil {
+		streamer, hasStreamer = sm.bus.GetStreamer(outCtx, channel, chatID)
+	}
+
+	var sb strings.Builder
+	var usage *interfaces.TokenUsage
+	var toolCalls int
+	var streamErr error
+	firstActivity := false
+	lastActivity := time.Now()
+	heartbeatInterval := sm.heartbeatInterval()
+	heartbeat := time.NewTimer(heartbeatInterval)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				if streamErr != nil && hasStreamer {
+					streamer.Cancel(outCtx)
+				}
+				return sb.String(), usage, toolCalls, streamErr
+			}
+			lastActivity = time.Now()
+			resetTimer(heartbeat, heartbeatInterval)
+			if u, ok := tokenUsageFromMetadata(event.Metadata); ok {
+				usage = u
+			}
+			if !firstActivity {
+				firstActivity = true
+				sm.emitProgress(outCtx, ProgressEvent{Channel: channel, ChatID: chatID, Kind: ProgressFirstActivity, Elapsed: time.Since(start)})
+			}
+			switch event.Type {
+			case interfaces.AgentEventContent:
+				if event.Content != "" {
+					sb.WriteString(event.Content)
+					if hasStreamer {
+						_ = streamer.Update(outCtx, sb.String())
+					}
+				}
+			case interfaces.AgentEventToolCall:
+				toolCalls++
+				sm.emitProgress(outCtx, ProgressEvent{
+					Channel:  channel,
+					ChatID:   chatID,
+					Kind:     ProgressToolCallStarted,
+					ToolName: safeToolName(event.ToolCall),
+					Elapsed:  time.Since(start),
+				})
+			case interfaces.AgentEventToolResult:
+				sm.emitProgress(outCtx, ProgressEvent{
+					Channel:  channel,
+					ChatID:   chatID,
+					Kind:     ProgressToolCallFinished,
+					ToolName: safeToolName(event.ToolCall),
+					Elapsed:  time.Since(start),
+				})
+			case interfaces.AgentEventError:
+				if event.Error != nil {
+					streamErr = event.Error
+				} else {
+					streamErr = errors.New("agent stream error")
+				}
+			case interfaces.AgentEventComplete:
+				// Completion is finalized when the event channel closes; SDKs may
+				// still send a trailing error after a complete event.
+			}
+			if streamErr != nil {
+				if hasStreamer {
+					streamer.Cancel(outCtx)
+				}
+				return sb.String(), usage, toolCalls, streamErr
+			}
+		case <-heartbeat.C:
+			sm.emitProgress(outCtx, ProgressEvent{
+				Channel: channel,
+				ChatID:  chatID,
+				Kind:    ProgressHeartbeat,
+				Elapsed: time.Since(lastActivity),
+			})
+			resetTimer(heartbeat, heartbeatInterval)
+		case <-outCtx.Done():
+			if hasStreamer {
+				streamer.Cancel(outCtx)
+			}
+			return sb.String(), usage, toolCalls, outCtx.Err()
+		}
+	}
+}
+
+func (sm *SessionManager) runDetailedTurn(ctx context.Context, input string) (string, *interfaces.TokenUsage, int, error) {
+	response, err := sm.agent.RunDetailed(ctx, input)
+	if err != nil {
+		return "", nil, 0, err
+	}
+	toolCalls := response.ExecutionSummary.ToolCalls
+	return response.Content, meaningfulUsage(response.Usage, response.ExecutionSummary.LLMCalls), toolCalls, nil
+}
+
+func (sm *SessionManager) heartbeatInterval() time.Duration {
+	if sm.progress == nil || sm.progress.HeartbeatInterval() <= 0 {
+		return DefaultDebugHeartbeatInterval
+	}
+	return sm.progress.HeartbeatInterval()
+}
+
+func (sm *SessionManager) emitProgress(ctx context.Context, event ProgressEvent) {
+	if sm.progress != nil {
+		sm.progress.Progress(ctx, event)
+	}
+}
+
+func (sm *SessionManager) emitSummary(ctx context.Context, summary ProgressSummary) {
+	if sm.progress != nil {
+		sm.progress.Summary(ctx, summary)
+	}
+}
+
+func resetTimer(timer *time.Timer, d time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(d)
+}
+
+func safeToolName(toolCall *interfaces.ToolCallEvent) string {
+	if toolCall == nil || strings.TrimSpace(toolCall.Name) == "" {
+		return "unknown"
+	}
+	return toolCall.Name
+}
+
+func meaningfulUsage(usage *interfaces.TokenUsage, llmCalls int) *interfaces.TokenUsage {
+	if usage == nil {
+		return nil
+	}
+	if llmCalls == 0 &&
+		usage.InputTokens == 0 &&
+		usage.OutputTokens == 0 &&
+		usage.TotalTokens == 0 &&
+		usage.ReasoningTokens == 0 &&
+		usage.CacheCreationInputTokens == 0 &&
+		usage.CacheReadInputTokens == 0 {
+		return nil
+	}
+	return usage
+}
+
+func tokenUsageFromMetadata(metadata map[string]interface{}) (*interfaces.TokenUsage, bool) {
+	if len(metadata) == 0 {
+		return nil, false
+	}
+	source := metadata
+	if nested, ok := metadata["usage"]; ok {
+		if nestedMap, ok := nested.(map[string]interface{}); ok {
+			source = nestedMap
+		} else if usage, ok := nested.(*interfaces.TokenUsage); ok && usage != nil {
+			return usage, true
+		} else {
+			return nil, false
+		}
+	}
+
+	input, hasInput := firstInt(source, "input_tokens", "prompt_tokens")
+	output, hasOutput := firstInt(source, "output_tokens", "completion_tokens")
+	total, hasTotal := firstInt(source, "total_tokens")
+	if !hasInput && !hasOutput && !hasTotal {
+		return nil, false
+	}
+	if !hasTotal {
+		total = input + output
+	}
+	return &interfaces.TokenUsage{
+		InputTokens:  input,
+		OutputTokens: output,
+		TotalTokens:  total,
+	}, true
+}
+
+func firstInt(m map[string]interface{}, keys ...string) (int, bool) {
+	for _, key := range keys {
+		v, ok := m[key]
+		if !ok {
+			continue
+		}
+		switch n := v.(type) {
+		case int:
+			return n, true
+		case int32:
+			return int(n), true
+		case int64:
+			return int(n), true
+		case float32:
+			return int(n), true
+		case float64:
+			return int(n), true
+		}
+	}
+	return 0, false
 }
 
 func createLLM(cfg *config.Config) (interfaces.LLM, error) {

--- a/internal/agent/session_debug_test.go
+++ b/internal/agent/session_debug_test.go
@@ -1,0 +1,266 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sushi30/sushiclaw/pkg/bus"
+)
+
+type mockRunner struct {
+	stream      <-chan interfaces.AgentStreamEvent
+	streamErr   error
+	detailed    *interfaces.AgentResponse
+	detailedErr error
+}
+
+func (m *mockRunner) Run(context.Context, string) (string, error) {
+	return "", errors.New("Run should not be called")
+}
+
+func (m *mockRunner) RunStream(context.Context, string) (<-chan interfaces.AgentStreamEvent, error) {
+	return m.stream, m.streamErr
+}
+
+func (m *mockRunner) RunDetailed(context.Context, string) (*interfaces.AgentResponse, error) {
+	return m.detailed, m.detailedErr
+}
+
+type collectingProgress struct {
+	heartbeat time.Duration
+	mu        sync.Mutex
+	events    []ProgressEvent
+	summaries []ProgressSummary
+}
+
+func (c *collectingProgress) HeartbeatInterval() time.Duration {
+	if c.heartbeat > 0 {
+		return c.heartbeat
+	}
+	return time.Hour
+}
+
+func (c *collectingProgress) Progress(_ context.Context, event ProgressEvent) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, event)
+}
+
+func (c *collectingProgress) Summary(_ context.Context, summary ProgressSummary) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.summaries = append(c.summaries, summary)
+}
+
+func TestSessionManagerDebugStartCompletionAndSummary(t *testing.T) {
+	events := streamEvents(
+		interfaces.AgentStreamEvent{Type: interfaces.AgentEventContent, Content: "hello"},
+		interfaces.AgentStreamEvent{Type: interfaces.AgentEventComplete},
+	)
+	extBus := bus.NewMessageBus()
+	progress := &collectingProgress{}
+	sm := &SessionManager{agent: &mockRunner{stream: events}, bus: extBus, progress: progress}
+
+	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "hi"))
+
+	msg := requireOutboundMessage(t, extBus)
+	assert.Equal(t, "hello", msg.Content)
+	assertEventKinds(t, progress.events, ProgressTurnStarted, ProgressFirstActivity, ProgressCompleted)
+	require.Len(t, progress.summaries, 1)
+	assert.True(t, progress.summaries[0].Success)
+	assert.Equal(t, 0, progress.summaries[0].ToolCalls)
+	assert.Nil(t, progress.summaries[0].Usage)
+	assert.GreaterOrEqual(t, progress.summaries[0].Duration, time.Duration(0))
+}
+
+func TestSessionManagerDebugToolEventsUseOnlyNames(t *testing.T) {
+	events := streamEvents(
+		interfaces.AgentStreamEvent{
+			Type: interfaces.AgentEventToolCall,
+			ToolCall: &interfaces.ToolCallEvent{
+				Name:      "exec",
+				Arguments: `{"cmd":"secret"}`,
+			},
+		},
+		interfaces.AgentStreamEvent{
+			Type: interfaces.AgentEventToolResult,
+			ToolCall: &interfaces.ToolCallEvent{
+				Name:   "exec",
+				Result: "secret result",
+			},
+		},
+		interfaces.AgentStreamEvent{Type: interfaces.AgentEventContent, Content: "done"},
+	)
+	extBus := bus.NewMessageBus()
+	progress := &collectingProgress{}
+	sm := &SessionManager{agent: &mockRunner{stream: events}, bus: extBus, progress: progress}
+
+	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "run"))
+
+	requireOutboundMessage(t, extBus)
+	require.Len(t, progress.summaries, 1)
+	assert.Equal(t, 1, progress.summaries[0].ToolCalls)
+
+	var toolEvents []ProgressEvent
+	for _, event := range progress.events {
+		if event.Kind == ProgressToolCallStarted || event.Kind == ProgressToolCallFinished {
+			toolEvents = append(toolEvents, event)
+		}
+	}
+	require.Len(t, toolEvents, 2)
+	for _, event := range toolEvents {
+		assert.Equal(t, "exec", event.ToolName)
+		assert.NotContains(t, event.ToolName, "secret")
+	}
+}
+
+func TestSessionManagerDebugTokenSummaryFromStreamMetadata(t *testing.T) {
+	events := streamEvents(
+		interfaces.AgentStreamEvent{Type: interfaces.AgentEventContent, Content: "ok"},
+		interfaces.AgentStreamEvent{
+			Type: interfaces.AgentEventContent,
+			Metadata: map[string]interface{}{
+				"usage": map[string]interface{}{
+					"prompt_tokens":     4,
+					"completion_tokens": 6,
+					"total_tokens":      10,
+				},
+			},
+		},
+	)
+	progress := &collectingProgress{}
+	sm := &SessionManager{agent: &mockRunner{stream: events}, bus: bus.NewMessageBus(), progress: progress}
+
+	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "tokens"))
+
+	require.Len(t, progress.summaries, 1)
+	require.NotNil(t, progress.summaries[0].Usage)
+	assert.Equal(t, 4, progress.summaries[0].Usage.InputTokens)
+	assert.Equal(t, 6, progress.summaries[0].Usage.OutputTokens)
+	assert.Equal(t, 10, progress.summaries[0].Usage.TotalTokens)
+}
+
+func TestSessionManagerDebugHeartbeatAfterSilence(t *testing.T) {
+	ch := make(chan interfaces.AgentStreamEvent, 2)
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		ch <- interfaces.AgentStreamEvent{Type: interfaces.AgentEventContent, Content: "late"}
+		close(ch)
+	}()
+	progress := &collectingProgress{heartbeat: 10 * time.Millisecond}
+	sm := &SessionManager{agent: &mockRunner{stream: ch}, bus: bus.NewMessageBus(), progress: progress}
+
+	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "slow"))
+
+	assertHasEvent(t, progress.events, ProgressHeartbeat)
+}
+
+func TestSessionManagerStreamErrorPublishesOneUserErrorAndFailureSummary(t *testing.T) {
+	streamErr := errors.New("stream failed")
+	events := streamEvents(
+		interfaces.AgentStreamEvent{Type: interfaces.AgentEventContent, Content: "partial"},
+		interfaces.AgentStreamEvent{Type: interfaces.AgentEventError, Error: streamErr},
+	)
+	extBus := bus.NewMessageBus()
+	progress := &collectingProgress{}
+	sm := &SessionManager{agent: &mockRunner{stream: events}, bus: extBus, progress: progress}
+
+	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "bad"))
+
+	msg := requireOutboundMessage(t, extBus)
+	assert.Equal(t, "Error: stream failed", msg.Content)
+	assertNoOutboundMessage(t, extBus)
+	require.Len(t, progress.summaries, 1)
+	assert.False(t, progress.summaries[0].Success)
+	assert.ErrorIs(t, progress.summaries[0].Error, streamErr)
+	assertHasEvent(t, progress.events, ProgressFailed)
+}
+
+func TestSessionManagerStreamingStartupFallbackUsesDetailedUsage(t *testing.T) {
+	startErr := errors.New("no streaming")
+	progress := &collectingProgress{}
+	extBus := bus.NewMessageBus()
+	sm := &SessionManager{
+		agent: &mockRunner{
+			streamErr: startErr,
+			detailed: &interfaces.AgentResponse{
+				Content: "fallback",
+				Usage:   &interfaces.TokenUsage{InputTokens: 7, OutputTokens: 8, TotalTokens: 15},
+				ExecutionSummary: interfaces.ExecutionSummary{
+					LLMCalls:  1,
+					ToolCalls: 2,
+				},
+			},
+		},
+		bus:      extBus,
+		progress: progress,
+	}
+
+	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "fallback"))
+
+	assert.Equal(t, "fallback", requireOutboundMessage(t, extBus).Content)
+	assertHasEvent(t, progress.events, ProgressFallback)
+	require.Len(t, progress.summaries, 1)
+	assert.True(t, progress.summaries[0].Success)
+	assert.Equal(t, 2, progress.summaries[0].ToolCalls)
+	require.NotNil(t, progress.summaries[0].Usage)
+	assert.Equal(t, 15, progress.summaries[0].Usage.TotalTokens)
+}
+
+func streamEvents(events ...interfaces.AgentStreamEvent) <-chan interfaces.AgentStreamEvent {
+	ch := make(chan interfaces.AgentStreamEvent, len(events))
+	for _, event := range events {
+		ch <- event
+	}
+	close(ch)
+	return ch
+}
+
+func inbound(channel, chatID, content string) bus.InboundMessage {
+	return bus.InboundMessage{Channel: channel, ChatID: chatID, Content: content}
+}
+
+func requireOutboundMessage(t *testing.T, extBus *bus.MessageBus) bus.OutboundMessage {
+	t.Helper()
+	select {
+	case msg := <-extBus.OutboundChan():
+		return msg
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected outbound message")
+		return bus.OutboundMessage{}
+	}
+}
+
+func assertNoOutboundMessage(t *testing.T, extBus *bus.MessageBus) {
+	t.Helper()
+	select {
+	case msg := <-extBus.OutboundChan():
+		t.Fatalf("unexpected outbound message: %#v", msg)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func assertEventKinds(t *testing.T, events []ProgressEvent, want ...ProgressKind) {
+	t.Helper()
+	require.GreaterOrEqual(t, len(events), len(want))
+	for i, kind := range want {
+		assert.Equal(t, kind, events[i].Kind)
+	}
+}
+
+func assertHasEvent(t *testing.T, events []ProgressEvent, kind ProgressKind) {
+	t.Helper()
+	for _, event := range events {
+		if event.Kind == kind {
+			return
+		}
+	}
+	t.Fatalf("expected event kind %s in %#v", kind, events)
+}

--- a/internal/commandfilter/commandfilter_test.go
+++ b/internal/commandfilter/commandfilter_test.go
@@ -54,6 +54,8 @@ func TestFilter_KnownCommandsWithArgs(t *testing.T) {
 		"/switch model gpt-4o",
 		"/check channel telegram",
 		"/use python",
+		"/debug on",
+		"/debug off",
 		"/clear",
 	}
 	for _, cmd := range cases {

--- a/internal/gateway/debug.go
+++ b/internal/gateway/debug.go
@@ -2,49 +2,197 @@ package gateway
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
+	"time"
 
+	"github.com/sushi30/sushiclaw/internal/agent"
 	"github.com/sushi30/sushiclaw/pkg/bus"
 	"github.com/sushi30/sushiclaw/pkg/logger"
 )
 
-// DebugManager toggles per-chat debug event forwarding.
-// Currently stubbed: agent-sdk-go integration does not yet expose event streaming.
+// DebugManager owns per-chat operational debug progress.
 type DebugManager struct {
-	mu      sync.Mutex
-	active  bool
-	cancel  context.CancelFunc
-	bus     *bus.MessageBus
-	channel string
-	chatID  string
+	mu        sync.RWMutex
+	active    map[string]bool
+	bus       *bus.MessageBus
+	heartbeat time.Duration
 }
 
 // NewDebugManager creates a new DebugManager.
-func NewDebugManager(messageBus *bus.MessageBus) *DebugManager {
-	return &DebugManager{bus: messageBus}
+func NewDebugManager(messageBus *bus.MessageBus, heartbeat ...time.Duration) *DebugManager {
+	interval := agent.DefaultDebugHeartbeatInterval
+	if len(heartbeat) > 0 && heartbeat[0] > 0 {
+		interval = heartbeat[0]
+	}
+	return &DebugManager{
+		active:    make(map[string]bool),
+		bus:       messageBus,
+		heartbeat: interval,
+	}
+}
+
+func (d *DebugManager) HeartbeatInterval() time.Duration {
+	if d == nil || d.heartbeat <= 0 {
+		return agent.DefaultDebugHeartbeatInterval
+	}
+	return d.heartbeat
+}
+
+// Set updates debug mode for one channel/chat pair and returns a user-facing status.
+func (d *DebugManager) Set(ctx context.Context, channel, chatID, mode string) string {
+	if d == nil {
+		return "Debug toggle unavailable."
+	}
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	switch mode {
+	case "", "toggle":
+		if d.isActive(channel, chatID) {
+			return d.disable(channel, chatID)
+		}
+		return d.enable(channel, chatID)
+	case "on":
+		if d.isActive(channel, chatID) {
+			return "Debug mode already enabled."
+		}
+		return d.enable(channel, chatID)
+	case "off":
+		if !d.isActive(channel, chatID) {
+			return "Debug mode already disabled."
+		}
+		return d.disable(channel, chatID)
+	default:
+		return "Usage: /debug [on|off]"
+	}
 }
 
 // Toggle flips debug mode and returns a status string to send back to the user.
 func (d *DebugManager) Toggle(ctx context.Context, channel, chatID string) string {
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	return d.Set(ctx, channel, chatID, "toggle")
+}
 
-	if d.active {
-		if d.cancel != nil {
-			d.cancel()
-		}
-		d.cancel = nil
-		d.active = false
-		d.channel = ""
-		d.chatID = ""
-		logger.InfoCF("debug", "Debug mode disabled", map[string]any{"chat_id": chatID})
-		return "Debug mode disabled."
+func (d *DebugManager) Progress(ctx context.Context, event agent.ProgressEvent) {
+	if d == nil || !d.isActive(event.Channel, event.ChatID) {
+		return
 	}
+	d.publish(ctx, event.Channel, event.ChatID, debugProgressText(event))
+}
 
-	d.channel = channel
-	d.chatID = chatID
-	d.active = true
+func (d *DebugManager) Summary(ctx context.Context, summary agent.ProgressSummary) {
+	if d == nil || !d.isActive(summary.Channel, summary.ChatID) {
+		return
+	}
+	d.publish(ctx, summary.Channel, summary.ChatID, debugSummaryText(summary))
+}
 
-	logger.InfoCF("debug", "Debug mode enabled", map[string]any{"chat_id": chatID})
-	return "Debug mode enabled. (Event forwarding not yet implemented with agent-sdk-go.)"
+func (d *DebugManager) enable(channel, chatID string) string {
+	d.mu.Lock()
+	d.active[stateKey(channel, chatID)] = true
+	d.mu.Unlock()
+	logger.InfoCF("debug", "Debug mode enabled", map[string]any{"channel": channel, "chat_id": chatID})
+	return "Debug mode enabled."
+}
+
+func (d *DebugManager) disable(channel, chatID string) string {
+	d.mu.Lock()
+	delete(d.active, stateKey(channel, chatID))
+	d.mu.Unlock()
+	logger.InfoCF("debug", "Debug mode disabled", map[string]any{"channel": channel, "chat_id": chatID})
+	return "Debug mode disabled."
+}
+
+func (d *DebugManager) isActive(channel, chatID string) bool {
+	if d == nil {
+		return false
+	}
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.active[stateKey(channel, chatID)]
+}
+
+func (d *DebugManager) publish(ctx context.Context, channel, chatID, content string) {
+	if d.bus == nil || strings.TrimSpace(content) == "" {
+		return
+	}
+	if err := d.bus.PublishOutbound(ctx, bus.OutboundMessage{
+		Channel: channel,
+		ChatID:  chatID,
+		Content: content,
+	}); err != nil {
+		logger.WarnCF("debug", "Failed to publish debug message", map[string]any{
+			"channel": channel,
+			"chat_id": chatID,
+			"error":   err.Error(),
+		})
+	}
+}
+
+func stateKey(channel, chatID string) string {
+	return strings.TrimSpace(channel) + "\x00" + strings.TrimSpace(chatID)
+}
+
+func debugProgressText(event agent.ProgressEvent) string {
+	switch event.Kind {
+	case agent.ProgressTurnStarted:
+		return "[debug] Turn started."
+	case agent.ProgressFirstActivity:
+		return "[debug] Model activity started."
+	case agent.ProgressToolCallStarted:
+		return fmt.Sprintf("[debug] Tool call started: %s", event.ToolName)
+	case agent.ProgressToolCallFinished:
+		return fmt.Sprintf("[debug] Tool call completed: %s", event.ToolName)
+	case agent.ProgressFallback:
+		if event.Error != nil {
+			return fmt.Sprintf("[debug] Streaming unavailable, falling back to detailed run: %v", event.Error)
+		}
+		return "[debug] Streaming unavailable, falling back to detailed run."
+	case agent.ProgressHeartbeat:
+		return fmt.Sprintf("[debug] Still working. No agent events for %s.", formatDuration(event.Elapsed))
+	case agent.ProgressCompleted:
+		return "[debug] Turn completed."
+	case agent.ProgressFailed:
+		if event.Error != nil {
+			return fmt.Sprintf("[debug] Turn failed: %v", event.Error)
+		}
+		return "[debug] Turn failed."
+	default:
+		return ""
+	}
+}
+
+func debugSummaryText(summary agent.ProgressSummary) string {
+	var sb strings.Builder
+	if summary.Success {
+		sb.WriteString("[debug] Summary")
+	} else {
+		sb.WriteString("[debug] Failure summary")
+	}
+	if summary.Error != nil {
+		sb.WriteString("\nError: ")
+		sb.WriteString(summary.Error.Error())
+	}
+	fmt.Fprintf(&sb, "\nTool calls: %d", summary.ToolCalls)
+	if summary.Usage != nil {
+		fmt.Fprintf(&sb, "\nTokens: total=%d input=%d output=%d",
+			summary.Usage.TotalTokens,
+			summary.Usage.InputTokens,
+			summary.Usage.OutputTokens,
+		)
+	} else {
+		sb.WriteString("\nTokens: unavailable")
+	}
+	sb.WriteString("\nTask time: ")
+	sb.WriteString(formatDuration(summary.Duration))
+	return sb.String()
+}
+
+func formatDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	if d < time.Second {
+		return d.Round(time.Millisecond).String()
+	}
+	return d.Round(time.Second).String()
 }

--- a/internal/gateway/debug_test.go
+++ b/internal/gateway/debug_test.go
@@ -3,42 +3,133 @@ package gateway
 import (
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sushi30/sushiclaw/internal/agent"
 	"github.com/sushi30/sushiclaw/pkg/bus"
 )
 
-// TestDebugManager_ToggleOnOff verifies that the first Toggle enables debug
-// mode and the second disables it, with distinct reply strings each time.
-func TestDebugManager_ToggleOnOff(t *testing.T) {
+func TestDebugManagerToggleOnOff(t *testing.T) {
+	mgr := NewDebugManager(bus.NewMessageBus())
+	ctx := t.Context()
+
+	reply1 := mgr.Set(ctx, "telegram", "chat1", "toggle")
+	assert.True(t, mgr.isActive("telegram", "chat1"))
+	assert.Contains(t, reply1, "enabled")
+
+	reply2 := mgr.Set(ctx, "telegram", "chat1", "toggle")
+	assert.False(t, mgr.isActive("telegram", "chat1"))
+	assert.Contains(t, reply2, "disabled")
+}
+
+func TestDebugManagerOnOffIdempotent(t *testing.T) {
+	mgr := NewDebugManager(bus.NewMessageBus())
+	ctx := t.Context()
+
+	assert.Equal(t, "Debug mode enabled.", mgr.Set(ctx, "telegram", "chat1", "on"))
+	assert.Equal(t, "Debug mode already enabled.", mgr.Set(ctx, "telegram", "chat1", "on"))
+	assert.Equal(t, "Debug mode disabled.", mgr.Set(ctx, "telegram", "chat1", "off"))
+	assert.Equal(t, "Debug mode already disabled.", mgr.Set(ctx, "telegram", "chat1", "off"))
+}
+
+func TestDebugManagerHeartbeatDefaultAndOverride(t *testing.T) {
+	defaultMgr := NewDebugManager(bus.NewMessageBus(), -1)
+	assert.Equal(t, agent.DefaultDebugHeartbeatInterval, defaultMgr.HeartbeatInterval())
+
+	overrideMgr := NewDebugManager(bus.NewMessageBus(), 5*time.Second)
+	assert.Equal(t, 5*time.Second, overrideMgr.HeartbeatInterval())
+}
+
+func TestDebugManagerPerChatIsolation(t *testing.T) {
+	mgr := NewDebugManager(bus.NewMessageBus())
+	ctx := t.Context()
+
+	mgr.Set(ctx, "telegram", "chat1", "on")
+
+	assert.True(t, mgr.isActive("telegram", "chat1"))
+	assert.False(t, mgr.isActive("telegram", "chat2"))
+	assert.False(t, mgr.isActive("email", "chat1"))
+}
+
+func TestDebugManagerInactiveSuppressesOutbound(t *testing.T) {
 	extBus := bus.NewMessageBus()
 	mgr := NewDebugManager(extBus)
 
+	mgr.Progress(t.Context(), agent.ProgressEvent{
+		Channel: "telegram",
+		ChatID:  "chat1",
+		Kind:    agent.ProgressTurnStarted,
+	})
+
+	assertNoOutbound(t, extBus)
+}
+
+func TestDebugManagerPublishesProgressOnlyToEnabledChat(t *testing.T) {
+	extBus := bus.NewMessageBus()
+	mgr := NewDebugManager(extBus)
 	ctx := t.Context()
+	mgr.Set(ctx, "telegram", "chat1", "on")
 
-	reply1 := mgr.Toggle(ctx, "telegram", "chat1")
-	if !mgr.active {
-		t.Fatal("expected active=true after first Toggle")
-	}
-	if !strings.Contains(reply1, "enabled") {
-		t.Fatalf("first Toggle reply should contain 'enabled', got %q", reply1)
-	}
+	mgr.Progress(ctx, agent.ProgressEvent{
+		Channel:  "telegram",
+		ChatID:   "chat2",
+		Kind:     agent.ProgressToolCallStarted,
+		ToolName: "exec",
+	})
+	assertNoOutbound(t, extBus)
 
-	reply2 := mgr.Toggle(ctx, "telegram", "chat1")
-	if mgr.active {
-		t.Fatal("expected active=false after second Toggle")
-	}
-	if !strings.Contains(reply2, "disabled") {
-		t.Fatalf("second Toggle reply should contain 'disabled', got %q", reply2)
+	mgr.Progress(ctx, agent.ProgressEvent{
+		Channel:  "telegram",
+		ChatID:   "chat1",
+		Kind:     agent.ProgressToolCallStarted,
+		ToolName: "exec",
+	})
+	msg := requireOutbound(t, extBus)
+	assert.Equal(t, "telegram", msg.Channel)
+	assert.Equal(t, "chat1", msg.ChatID)
+	assert.Contains(t, msg.Content, "exec")
+}
+
+func TestDebugManagerSummaryFormatsUsage(t *testing.T) {
+	extBus := bus.NewMessageBus()
+	mgr := NewDebugManager(extBus)
+	ctx := t.Context()
+	mgr.Set(ctx, "telegram", "chat1", "on")
+
+	mgr.Summary(ctx, agent.ProgressSummary{
+		Channel:   "telegram",
+		ChatID:    "chat1",
+		Success:   true,
+		ToolCalls: 2,
+		Usage:     &interfaces.TokenUsage{InputTokens: 3, OutputTokens: 5, TotalTokens: 8},
+		Duration:  1200 * time.Millisecond,
+	})
+
+	msg := requireOutbound(t, extBus)
+	assert.Contains(t, msg.Content, "Tool calls: 2")
+	assert.Contains(t, msg.Content, "Tokens: total=8 input=3 output=5")
+	assert.True(t, strings.Contains(msg.Content, "Task time: 1s") || strings.Contains(msg.Content, "Task time: 1.2s"))
+}
+
+func requireOutbound(t *testing.T, extBus *bus.MessageBus) bus.OutboundMessage {
+	t.Helper()
+	select {
+	case msg := <-extBus.OutboundChan():
+		return msg
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected outbound message")
+		return bus.OutboundMessage{}
 	}
 }
 
-// TestDebugManager_NoEventsWhenInactive verifies that when debug mode has not
-// been toggled on, the manager is inactive.
-func TestDebugManager_NoEventsWhenInactive(t *testing.T) {
-	extBus := bus.NewMessageBus()
-	mgr := NewDebugManager(extBus)
-
-	if mgr.active {
-		t.Fatal("expected active=false by default")
+func assertNoOutbound(t *testing.T, extBus *bus.MessageBus) {
+	t.Helper()
+	select {
+	case msg := <-extBus.OutboundChan():
+		t.Fatalf("unexpected outbound message: %#v", msg)
+	case <-time.After(20 * time.Millisecond):
 	}
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -67,7 +67,8 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	cmdFilter := commandfilter.NewCommandFilter()
 
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
-	dm := NewDebugManager(messageBus)
+	heartbeat := time.Duration(cfg.Gateway.DebugHeartbeatSeconds) * time.Second
+	dm := NewDebugManager(messageBus, heartbeat)
 	rt := &commands.Runtime{
 		ListDefinitions: reg.Definitions,
 	}
@@ -95,7 +96,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 		}
 	}
 
-	sessionMgr, err := agent.NewSessionManager(cfg, messageBus, tools)
+	sessionMgr, err := agent.NewSessionManager(cfg, messageBus, tools, agent.WithProgressSink(dm))
 	if err != nil {
 		if allowEmptyStartup {
 			logger.WarnC("gateway", fmt.Sprintf("Failed to create agent session: %v", err))
@@ -144,7 +145,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rt.ToggleDebug = dm.Toggle
+	rt.SetDebug = dm.Set
 	if sessionMgr != nil {
 		rt.ClearHistory = sessionMgr.ClearHistory
 		rt.GetModelInfo = sessionMgr.GetModelInfo

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -66,7 +66,7 @@ type Runtime struct {
 	ListModels      func() []string
 	ListSkills      func() []SkillInfo
 	ClearHistory    func() error
-	ToggleDebug     func(ctx context.Context, channel, chatID string) string
+	SetDebug        func(ctx context.Context, channel, chatID, mode string) string
 	ActivateSkill   func(skillName string) error
 }
 
@@ -256,7 +256,7 @@ func BuiltinDefinitions() []Definition {
 		{Name: "start", Description: "Start the bot", Handler: startHandler},
 		{Name: "help", Description: "Show this help message", Handler: helpHandler},
 		{Name: "clear", Description: "Clear conversation history", Handler: clearHandler},
-		{Name: "debug", Description: "Toggle debug event forwarding", Handler: debugHandler},
+		{Name: "debug", Description: "Toggle debug event forwarding", Handler: debugHandler, Usage: "/debug [on|off]"},
 		{Name: "model", Description: "Show or switch model", Handler: modelHandler},
 		{Name: "show", Description: "Show current configuration"},
 		{Name: "list", Description: "List available options", SubCommands: []SubCommand{
@@ -359,10 +359,21 @@ func modelHandler(_ context.Context, req Request, rt *Runtime) error {
 }
 
 func debugHandler(ctx context.Context, req Request, rt *Runtime) error {
-	if rt == nil || rt.ToggleDebug == nil {
+	if rt == nil || rt.SetDebug == nil {
 		return req.Reply("Debug toggle unavailable.")
 	}
-	reply := rt.ToggleDebug(ctx, req.Channel, req.ChatID)
+	mode := nthToken(req.Text, 1)
+	if mode == "" {
+		mode = "toggle"
+	}
+	mode = normalize(mode)
+	if mode != "toggle" && mode != "on" && mode != "off" {
+		return req.Reply("Usage: /debug [on|off]")
+	}
+	if nthToken(req.Text, 2) != "" {
+		return req.Reply("Usage: /debug [on|off]")
+	}
+	reply := rt.SetDebug(ctx, req.Channel, req.ChatID, mode)
 	return req.Reply(reply)
 }
 

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -135,10 +135,10 @@ func TestExecuteModelNoRuntime(t *testing.T) {
 }
 
 func TestExecuteDebug(t *testing.T) {
-	toggled := false
+	mode := ""
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
 	rt := &commands.Runtime{
-		ToggleDebug: func(_ context.Context, _, _ string) string { toggled = true; return "Debug toggled." },
+		SetDebug: func(_ context.Context, _, _, m string) string { mode = m; return "Debug toggled." },
 	}
 	exec := commands.NewExecutor(reg, rt)
 
@@ -148,8 +148,50 @@ func TestExecuteDebug(t *testing.T) {
 		Reply: func(s string) error { replied = s; return nil },
 	})
 	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
-	assert.True(t, toggled)
+	assert.Equal(t, "toggle", mode)
 	assert.Equal(t, "Debug toggled.", replied)
+}
+
+func TestExecuteDebugOnOff(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	var modes []string
+	rt := &commands.Runtime{
+		SetDebug: func(_ context.Context, _, _, mode string) string {
+			modes = append(modes, mode)
+			return "ok"
+		},
+	}
+	exec := commands.NewExecutor(reg, rt)
+
+	for _, text := range []string{"/debug on", "/debug off"} {
+		result := exec.Execute(context.Background(), commands.Request{
+			Text:  text,
+			Reply: func(string) error { return nil },
+		})
+		assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	}
+
+	assert.Equal(t, []string{"on", "off"}, modes)
+}
+
+func TestExecuteDebugInvalidArgs(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{
+		SetDebug: func(context.Context, string, string, string) string {
+			t.Fatal("SetDebug should not be called for invalid args")
+			return ""
+		},
+	})
+
+	for _, text := range []string{"/debug maybe", "/debug on extra"} {
+		var replied string
+		result := exec.Execute(context.Background(), commands.Request{
+			Text:  text,
+			Reply: func(s string) error { replied = s; return nil },
+		})
+		assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+		assert.Equal(t, "Usage: /debug [on|off]", replied)
+	}
 }
 
 func TestExecuteDebugNoRuntime(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -77,9 +77,10 @@ func (m *ModelConfig) APIKeyString() string {
 }
 
 type GatewayConfig struct {
-	Host     string `json:"host"`
-	Port     int    `json:"port"`
-	LogLevel string `json:"log_level"`
+	Host                  string `json:"host"`
+	Port                  int    `json:"port"`
+	LogLevel              string `json:"log_level"`
+	DebugHeartbeatSeconds int    `json:"debug_heartbeat_seconds,omitempty"`
 }
 
 type ToolsConfig struct {


### PR DESCRIPTION
## Summary
- add explicit /debug on and /debug off controls while preserving /debug toggle behavior
- wire per-chat debug progress into agent turns with heartbeat updates and final summaries
- prefer streaming agent events with detailed-run fallback for usage and execution summaries

## Test plan
- make test
- make lint