### PR TITLE
feat: register email as a first-class channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ the owned channel packages (whatsapp_native, telegram) to trigger their `init()`
 | `pkg/channels/` | Channel infrastructure: `BaseChannel` (shared functionality, allow-list, group triggers, typing/reaction/placeholder orchestration), `Manager` (lifecycle and outbound dispatch), registry, and capability interfaces (`StreamingCapable`, `TypingCapable`, etc.). |
 | `pkg/channels/whatsapp_native/` | Owned WhatsApp native channel (requires `whatsapp_native` build tag). |
 | `pkg/channels/telegram/` | Owned Telegram channel. |
-| `pkg/channels/email/` | Owned Email channel (SMTP outbound + IMAP polling inbound). Wired manually in `internal/gateway/` outside the standard channel registry. |
+| `pkg/channels/email/` | Owned Email channel (SMTP outbound + IMAP polling inbound). Registered through the standard channel registry. |
 | `pkg/commands/` | Slash command registry, executor, and built-in command definitions (`/help`, `/clear`, `/list models`, etc.). Supports `!` prefix in addition to `/`. |
 | `pkg/config/` | Config loading, `SecureString` (with `env://` resolution), `FlexibleStringSlice`, and path helpers. |
 | `pkg/identity/` | Sender identity matching for allow-lists. |
@@ -183,8 +183,7 @@ can report this as an error.
 |---------|-------------|
 | `agents.defaults` | Default agent settings: `model_name`, `workspace`, `restrict_to_workspace`, `max_tokens`, `temperature`, `max_tool_iterations` |
 | `model_list` | Array of model configs. Each needs `model_name`, `model` (provider ID), `api_key` (supports `env://`), optional `api_base` |
-| `channels` | Map of channel configs (WhatsApp native, Telegram). Email is **not** here — see `email_channel` |
-| `email_channel` | Top-level email config (SMTP + IMAP). See `pkg/channels/email/` |
+| `channels` | Map of channel configs (WhatsApp native, Telegram, Email). Email config lives under `channels.email`; top-level `email_channel` is no longer supported. |
 | `gateway` | `host`, `port`, `log_level` |
 | `tools` | `exec.enabled`, `media_cleanup.enabled`, `media_cleanup.max_age`, `media_cleanup.interval` |
 
@@ -289,8 +288,8 @@ The agent supports two provider paths (determined in `internal/agent/session.go`
 
 ### Email (`email`)
 
-- Wired manually in `internal/gateway/gateway.go` (not via the channel registry)
-- Config lives under top-level `email_channel` key
+- Registered through the standard channel registry
+- Config lives under `channels.email`; top-level `email_channel` is no longer supported
 - SMTP (outbound) + IMAP polling (inbound)
 - Port 465 → implicit TLS. Port 587 → STARTTLS. Port 993 → implicit TLS (IMAP).
 - Processed messages are marked `\Seen`

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ Copy `config.example.json` to `~/.picoclaw/config.json`. Key sections:
     }
   },
   "model_list": [{ "model_name": "gpt-4o-mini", "api_key": "env://OPENAI_API_KEY" }],
-  "channels": { ... },
-  "email_channel": { ... },
+  "channels": {
+    "email": { "enabled": false, "type": "email", "...": "..." }
+  },
   "tools": { ... }
 }
 ```
@@ -183,26 +184,30 @@ Messages from senders not in `allow_from` receive a rejection reply instead of b
 
 ---
 
-### Email channel
+### Email Channel
 
-SMTP (outbound) + IMAP polling (inbound). Config lives under `email_channel` (not inside `channels`):
+SMTP (outbound) + IMAP polling (inbound). Config lives under `channels.email`.
+The legacy top-level `email_channel` key is no longer supported.
 
 ```json
 {
-  "email_channel": {
-    "enabled": true,
-    "smtp_host": "smtp.example.com",
-    "smtp_port": 587,
-    "smtp_from": "bot@example.com",
-    "smtp_user": "bot@example.com",
-    "smtp_password": "env://SMTP_PASSWORD",
-    "imap_host": "imap.example.com",
-    "imap_port": 993,
-    "imap_user": "bot@example.com",
-    "imap_password": "env://IMAP_PASSWORD",
-    "poll_interval_secs": 30,
-    "allow_from": ["trusted@example.com"],
-    "default_subject": "Re: your message"
+  "channels": {
+    "email": {
+      "enabled": true,
+      "type": "email",
+      "smtp_host": "smtp.example.com",
+      "smtp_port": 587,
+      "smtp_from": "bot@example.com",
+      "smtp_user": "bot@example.com",
+      "smtp_password": "env://SMTP_PASSWORD",
+      "imap_host": "imap.example.com",
+      "imap_port": 993,
+      "imap_user": "bot@example.com",
+      "imap_password": "env://IMAP_PASSWORD",
+      "poll_interval_secs": 30,
+      "allow_from": ["trusted@example.com"],
+      "default_subject": "Re: your message"
+    }
   }
 }
 ```
@@ -211,7 +216,7 @@ SMTP (outbound) + IMAP polling (inbound). Config lives under `email_channel` (no
 - Port 993 → implicit TLS (IMAP).
 - Processed messages are marked `\Seen`.
 
-> **Migrating from an older config?** See [RELEASE_NOTES.md](RELEASE_NOTES.md) for step-by-step instructions if your config uses the old `channels.email` format.
+> **Migrating from an older config?** See [RELEASE_NOTES.md](RELEASE_NOTES.md) for step-by-step instructions if your config uses the old top-level `email_channel` format.
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,54 +1,26 @@
 # Release Notes
 
-## Email channel config migration (fix/email4)
+## Email Channel Config Migration
 
-### What changed
+### What Changed
 
-The email channel is wired manually outside the standard channel registry.
-This means email config must live under the top-level `email_channel` key,
-**not** inside the `channels` map.
+Email is now a first-class channel registered through the standard `channels`
+map. The legacy top-level `email_channel` key is no longer supported.
 
-If your config has `channels.email`, startup will fail with:
+If your config still uses `email_channel`, the gateway will ignore that block
+and no email channel will be started. Move the settings to `channels.email`.
 
-```
-error loading config: channel "email" has unknown type "email"
-```
+### Required Config Migration
 
-### Required config migration
-
-Open `~/.picoclaw/config.json` (or `$SUSHICLAW_CONFIG`) and move the email
-block from `channels` to a top-level `email_channel` key.
+Open `~/.picoclaw/config.json` or `$SUSHICLAW_CONFIG` and move the email block
+from the top-level `email_channel` key into the `channels` map.
 
 **Before:**
 
 ```json
 {
   "channels": {
-    "whatsapp": { ... },
-    "email": {
-      "enabled": true,
-      "smtp_host": "smtp.gmail.com",
-      "smtp_port": 587,
-      "smtp_from": "env://SMTP_USER",
-      "smtp_user": "env://SMTP_USER",
-      "smtp_password": "env://SMTP_PASSWORD",
-      "imap_host": "imap.gmail.com",
-      "imap_port": 993,
-      "imap_user": "env://SMTP_USER",
-      "imap_password": "env://SMTP_PASSWORD",
-      "poll_interval_secs": 10,
-      "allow_from": ["you@example.com"]
-    }
-  }
-}
-```
-
-**After:**
-
-```json
-{
-  "channels": {
-    "whatsapp": { ... }
+    "telegram": { "...": "..." }
   },
   "email_channel": {
     "enabled": true,
@@ -67,11 +39,37 @@ block from `channels` to a top-level `email_channel` key.
 }
 ```
 
-### Reference: full email_channel options
+**After:**
+
+```json
+{
+  "channels": {
+    "telegram": { "...": "..." },
+    "email": {
+      "enabled": true,
+      "type": "email",
+      "smtp_host": "smtp.gmail.com",
+      "smtp_port": 587,
+      "smtp_from": "env://SMTP_USER",
+      "smtp_user": "env://SMTP_USER",
+      "smtp_password": "env://SMTP_PASSWORD",
+      "imap_host": "imap.gmail.com",
+      "imap_port": 993,
+      "imap_user": "env://SMTP_USER",
+      "imap_password": "env://SMTP_PASSWORD",
+      "poll_interval_secs": 10,
+      "allow_from": ["you@example.com"]
+    }
+  }
+}
+```
+
+### Reference: Full `channels.email` Options
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `enabled` | bool | Enable/disable the email channel |
+| `type` | string | Use `email`; required for custom channel keys |
 | `smtp_host` | string | SMTP server hostname |
 | `smtp_port` | int | SMTP port (typically 587 for TLS, 465 for SSL) |
 | `smtp_from` | string | Sender address (supports `env://VAR`) |

--- a/config.example.json
+++ b/config.example.json
@@ -43,21 +43,24 @@
       "streaming": {
         "enabled": true
       }
+    },
+    "email": {
+      "enabled": false,
+      "type": "email",
+      "smtp_host": "smtp.example.com",
+      "smtp_port": 587,
+      "smtp_from": "bot@example.com",
+      "smtp_user": "",
+      "smtp_password": "env://EMAIL_SMTP_PASSWORD",
+      "default_subject": "Message from sushiclaw",
+      "imap_host": "imap.example.com",
+      "imap_port": 993,
+      "imap_user": "bot@example.com",
+      "imap_password": "env://EMAIL_IMAP_PASSWORD",
+      "poll_interval_secs": 30,
+      "allow_from": [],
+      "reasoning_channel_id": ""
     }
-  },
-  "email_channel": {
-    "enabled": false,
-    "smtp_host": "smtp.example.com",
-    "smtp_port": 587,
-    "smtp_from": "bot@example.com",
-    "smtp_user": "",
-    "default_subject": "Message from sushiclaw",
-    "imap_host": "imap.example.com",
-    "imap_port": 993,
-    "imap_user": "bot@example.com",
-    "poll_interval_secs": 30,
-    "allow_from": [],
-    "reasoning_channel_id": ""
   },
   "gateway": {
     "host": "0.0.0.0",

--- a/config_example_sushi30_test.go
+++ b/config_example_sushi30_test.go
@@ -1,13 +1,11 @@
 package main_test
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
-	"github.com/sushi30/sushiclaw/pkg/channels/email"
 	"github.com/sushi30/sushiclaw/pkg/config"
 )
 
@@ -66,15 +64,21 @@ func TestExampleConfigLoadsAsV2(t *testing.T) {
 		t.Error("telegram streaming.enabled should be true in example config")
 	}
 
-	// Email is wired separately via email.InitChannel (not through ChannelsConfig).
-	// Decode email_channel directly into email.EmailConfig so json tag renames break this test.
-	var rawTop struct {
-		EmailChannel email.EmailConfig `json:"email_channel"`
+	emailCh := cfg.Channels["email"]
+	if emailCh == nil {
+		t.Fatal("email channel config missing")
 	}
-	if err := json.Unmarshal(data, &rawTop); err != nil {
-		t.Fatalf("parse email_channel section: %v", err)
+	if emailCh.Type != config.ChannelEmail {
+		t.Errorf("email type = %q, want %q", emailCh.Type, config.ChannelEmail)
 	}
-	if rawTop.EmailChannel.SMTPHost == "" {
-		t.Error("email_channel.smtp_host missing from example config")
+	var emailCfg config.EmailSettings
+	if err := emailCh.Decode(&emailCfg); err != nil {
+		t.Fatalf("decode email settings: %v", err)
+	}
+	if emailCfg.SMTPHost == "" {
+		t.Error("channels.email.smtp_host missing from example config")
+	}
+	if emailCfg.IMAPPassword.String() == "" {
+		t.Error("channels.email.imap_password missing from example config")
 	}
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sushi30/sushiclaw/internal/envresolve"
 	"github.com/sushi30/sushiclaw/pkg/bus"
 	"github.com/sushi30/sushiclaw/pkg/channels"
-	"github.com/sushi30/sushiclaw/pkg/channels/email"
 	"github.com/sushi30/sushiclaw/pkg/commands"
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/cron"
@@ -143,14 +142,6 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	cm, err := channels.NewManager(cfg, messageBus, mediaStore)
 	if err != nil {
 		return fmt.Errorf("error creating channel manager: %w", err)
-	}
-
-	emailCh, err := email.InitChannel(messageBus)
-	if err != nil {
-		return fmt.Errorf("email channel: %w", err)
-	}
-	if emailCh != nil {
-		cm.RegisterChannel("email", emailCh)
 	}
 
 	messageBus.SetStreamDelegate(cm)

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/logger"
 
 	// Register owned channel implementations.
+	_ "github.com/sushi30/sushiclaw/pkg/channels/email"
 	_ "github.com/sushi30/sushiclaw/pkg/channels/telegram"
 	_ "github.com/sushi30/sushiclaw/pkg/channels/whatsapp_native"
 )

--- a/pkg/channels/email/email.go
+++ b/pkg/channels/email/email.go
@@ -24,29 +24,14 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/logger"
 )
 
-// EmailConfig holds configuration for the email channel.
-// Loaded from the "channels.email" section of the picoclaw config JSON.
-type EmailConfig struct {
-	Enabled            bool                       `json:"enabled"`
-	SMTPHost           string                     `json:"smtp_host"`
-	SMTPPort           int                        `json:"smtp_port"`
-	SMTPFrom           config.SecureString        `json:"smtp_from"`
-	SMTPUser           config.SecureString        `json:"smtp_user"`
-	SMTPPassword       config.SecureString        `json:"smtp_password"`
-	DefaultSubject     string                     `json:"default_subject"`
-	IMAPHost           string                     `json:"imap_host"`
-	IMAPPort           int                        `json:"imap_port"`
-	IMAPUser           config.SecureString        `json:"imap_user"`
-	IMAPPassword       config.SecureString        `json:"imap_password"`
-	PollIntervalSecs   int                        `json:"poll_interval_secs"`
-	AllowFrom          config.FlexibleStringSlice `json:"allow_from"`
-	ReasoningChannelID string                     `json:"reasoning_channel_id"`
-}
+// EmailConfig is kept as a compatibility alias for callers that construct
+// email settings directly.
+type EmailConfig = config.EmailSettings
 
 // EmailChannel implements the Channel interface using SMTP (outbound) and IMAP polling (inbound).
 type EmailChannel struct {
 	*channels.BaseChannel
-	config          EmailConfig
+	config          config.EmailSettings
 	ctx             context.Context
 	cancel          context.CancelFunc
 	tm              *ThreadManager
@@ -55,29 +40,48 @@ type EmailChannel struct {
 }
 
 // NewEmailChannel creates a new email channel.
-func NewEmailChannel(cfg EmailConfig, messageBus *bus.MessageBus) (*EmailChannel, error) {
+func NewEmailChannel(bc *config.Channel, cfg *config.EmailSettings, messageBus *bus.MessageBus) (*EmailChannel, error) {
+	if bc == nil {
+		return nil, fmt.Errorf("email channel config is required")
+	}
+	if cfg == nil {
+		return nil, fmt.Errorf("email settings are required")
+	}
 	if cfg.SMTPHost == "" {
 		return nil, fmt.Errorf("email smtp_host is required")
 	}
-	if cfg.SMTPFrom.String() == "" {
-		return nil, fmt.Errorf("email smtp_from is required")
+	if err := requireSecureString("smtp_from", cfg.SMTPFrom); err != nil {
+		return nil, err
 	}
 	if cfg.IMAPHost == "" {
 		return nil, fmt.Errorf("email imap_host is required")
 	}
-	if cfg.IMAPUser.String() == "" {
-		return nil, fmt.Errorf("email imap_user is required")
+	if err := requireSecureString("imap_user", cfg.IMAPUser); err != nil {
+		return nil, err
+	}
+	if err := requireSecureString("imap_password", cfg.IMAPPassword); err != nil {
+		return nil, err
 	}
 
-	base := channels.NewBaseChannel("email", cfg, messageBus, cfg.AllowFrom,
-		channels.WithReasoningChannelID(cfg.ReasoningChannelID),
+	base := channels.NewBaseChannel(bc.Name(), cfg, messageBus, bc.AllowFrom,
+		channels.WithReasoningChannelID(bc.ReasoningChannelID),
 	)
 
 	return &EmailChannel{
 		BaseChannel: base,
-		config:      cfg,
+		config:      *cfg,
 		tm:          NewThreadManager(),
 	}, nil
+}
+
+func requireSecureString(name string, value config.SecureString) error {
+	if value.String() == "" {
+		return fmt.Errorf("email %s is required", name)
+	}
+	if value.IsUnresolvedEnv() {
+		return fmt.Errorf("email %s is required (unresolved: %s)", name, value.String())
+	}
+	return nil
 }
 
 // Start begins IMAP polling.

--- a/pkg/channels/email/email_integration_test.go
+++ b/pkg/channels/email/email_integration_test.go
@@ -174,7 +174,7 @@ func TestEmailInboundPipeline(t *testing.T) {
 		PollIntervalSecs: 1,
 	}
 
-	ch, err := NewEmailChannel(cfg, msgBus)
+	ch, err := newTestEmailChannel(t, cfg, msgBus)
 	if err != nil {
 		t.Fatalf("NewEmailChannel: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestEmailOutboundPipeline(t *testing.T) {
 		IMAPPassword: *config.NewSecureString("p"),
 	}
 
-	ch, err := NewEmailChannel(cfg, msgBus)
+	ch, err := newTestEmailChannel(t, cfg, msgBus)
 	if err != nil {
 		t.Fatalf("NewEmailChannel: %v", err)
 	}
@@ -298,7 +298,7 @@ func TestEmailReplyThreading(t *testing.T) {
 		PollIntervalSecs: 1,
 	}
 
-	ch, err := NewEmailChannel(cfg, msgBus)
+	ch, err := newTestEmailChannel(t, cfg, msgBus)
 	if err != nil {
 		t.Fatalf("NewEmailChannel: %v", err)
 	}
@@ -389,7 +389,7 @@ func TestEmailNewEmail_ThreadReply(t *testing.T) {
 		PollIntervalSecs: 1,
 	}
 
-	ch, err := NewEmailChannel(cfg, msgBus)
+	ch, err := newTestEmailChannel(t, cfg, msgBus)
 	if err != nil {
 		t.Fatalf("NewEmailChannel: %v", err)
 	}
@@ -477,7 +477,7 @@ func TestEmailReplyChain_ThreadContinuation(t *testing.T) {
 		PollIntervalSecs: 1,
 	}
 
-	ch, err := NewEmailChannel(cfg, msgBus)
+	ch, err := newTestEmailChannel(t, cfg, msgBus)
 	if err != nil {
 		t.Fatalf("NewEmailChannel: %v", err)
 	}

--- a/pkg/channels/email/email_test.go
+++ b/pkg/channels/email/email_test.go
@@ -2,7 +2,6 @@ package email
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -17,6 +16,22 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/media"
 )
+
+func testEmailBaseChannel(name string) *config.Channel {
+	ch := &config.Channel{
+		Enabled:            true,
+		Type:               config.ChannelEmail,
+		AllowFrom:          config.FlexibleStringSlice{"*"},
+		ReasoningChannelID: "reasoning-email",
+	}
+	ch.SetName(name)
+	return ch
+}
+
+func newTestEmailChannel(t *testing.T, cfg EmailConfig, msgBus *bus.MessageBus) (*EmailChannel, error) {
+	t.Helper()
+	return NewEmailChannel(testEmailBaseChannel("email"), &cfg, msgBus)
+}
 
 func TestGenerateMessageID(t *testing.T) {
 	got := generateMessageID("example.com")
@@ -39,16 +54,17 @@ func TestNewEmailChannel(t *testing.T) {
 	msgBus := bus.NewMessageBus()
 
 	validCfg := EmailConfig{
-		SMTPHost: "smtp.example.com",
-		SMTPFrom: *config.NewSecureString("bot@example.com"),
-		IMAPHost: "imap.example.com",
-		IMAPUser: *config.NewSecureString("bot@example.com"),
+		SMTPHost:     "smtp.example.com",
+		SMTPFrom:     *config.NewSecureString("bot@example.com"),
+		IMAPHost:     "imap.example.com",
+		IMAPUser:     *config.NewSecureString("bot@example.com"),
+		IMAPPassword: *config.NewSecureString("password"),
 	}
 
 	t.Run("missing smtp_host", func(t *testing.T) {
 		cfg := validCfg
 		cfg.SMTPHost = ""
-		_, err := NewEmailChannel(cfg, msgBus)
+		_, err := newTestEmailChannel(t, cfg, msgBus)
 		if err == nil {
 			t.Error("expected error for missing smtp_host, got nil")
 		}
@@ -57,7 +73,7 @@ func TestNewEmailChannel(t *testing.T) {
 	t.Run("missing smtp_from", func(t *testing.T) {
 		cfg := validCfg
 		cfg.SMTPFrom = config.SecureString{}
-		_, err := NewEmailChannel(cfg, msgBus)
+		_, err := newTestEmailChannel(t, cfg, msgBus)
 		if err == nil {
 			t.Error("expected error for missing smtp_from, got nil")
 		}
@@ -66,7 +82,7 @@ func TestNewEmailChannel(t *testing.T) {
 	t.Run("missing imap_host", func(t *testing.T) {
 		cfg := validCfg
 		cfg.IMAPHost = ""
-		_, err := NewEmailChannel(cfg, msgBus)
+		_, err := newTestEmailChannel(t, cfg, msgBus)
 		if err == nil {
 			t.Error("expected error for missing imap_host, got nil")
 		}
@@ -75,14 +91,32 @@ func TestNewEmailChannel(t *testing.T) {
 	t.Run("missing imap_user", func(t *testing.T) {
 		cfg := validCfg
 		cfg.IMAPUser = config.SecureString{}
-		_, err := NewEmailChannel(cfg, msgBus)
+		_, err := newTestEmailChannel(t, cfg, msgBus)
 		if err == nil {
 			t.Error("expected error for missing imap_user, got nil")
 		}
 	})
 
+	t.Run("missing imap_password", func(t *testing.T) {
+		cfg := validCfg
+		cfg.IMAPPassword = config.SecureString{}
+		_, err := newTestEmailChannel(t, cfg, msgBus)
+		if err == nil {
+			t.Error("expected error for missing imap_password, got nil")
+		}
+	})
+
+	t.Run("unresolved required env var", func(t *testing.T) {
+		cfg := validCfg
+		cfg.IMAPPassword.Set("env://MISSING_IMAP_PASSWORD")
+		_, err := newTestEmailChannel(t, cfg, msgBus)
+		if err == nil {
+			t.Error("expected error for unresolved imap_password, got nil")
+		}
+	})
+
 	t.Run("valid config", func(t *testing.T) {
-		ch, err := NewEmailChannel(validCfg, msgBus)
+		ch, err := newTestEmailChannel(t, validCfg, msgBus)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -91,6 +125,24 @@ func TestNewEmailChannel(t *testing.T) {
 		}
 		if ch.IsRunning() {
 			t.Error("new channel should not be running")
+		}
+	})
+
+	t.Run("uses configured channel name and common fields", func(t *testing.T) {
+		bc := testEmailBaseChannel("work_email")
+		bc.AllowFrom = config.FlexibleStringSlice{"allowed@example.com"}
+		ch, err := NewEmailChannel(bc, &validCfg, msgBus)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if ch.Name() != "work_email" {
+			t.Errorf("Name() = %q, want %q", ch.Name(), "work_email")
+		}
+		if !ch.IsAllowed("allowed@example.com") {
+			t.Error("expected allow_from from common channel config to be used")
+		}
+		if ch.ReasoningChannelID() != "reasoning-email" {
+			t.Errorf("ReasoningChannelID() = %q, want reasoning-email", ch.ReasoningChannelID())
 		}
 	})
 }
@@ -163,113 +215,57 @@ func TestDisplayName(t *testing.T) {
 	}
 }
 
-func TestLoadEmailConfig_ResolvesEnvSecureStrings(t *testing.T) {
-	t.Setenv("EMAIL_SMTP_PASS", "secret-smtp-pass")
-	t.Setenv("EMAIL_IMAP_PASS", "secret-imap-pass")
+func TestEmailFactoryRegistered(t *testing.T) {
+	names := channels.GetRegisteredFactoryNames()
+	for _, name := range names {
+		if name == config.ChannelEmail {
+			return
+		}
+	}
+	t.Fatalf("email factory was not registered; factories=%v", names)
+}
 
-	raw := map[string]any{
-		"channels": map[string]any{
-			"email": map[string]any{
-				"enabled":       true,
-				"smtp_host":     "smtp.example.com",
-				"smtp_from":     "bot@example.com",
-				"smtp_password": "env://EMAIL_SMTP_PASS",
-				"imap_host":     "imap.example.com",
-				"imap_user":     "bot@example.com",
-				"imap_password": "env://EMAIL_IMAP_PASS",
+func TestManagerCreatesEmailChannelFromChannelsConfig(t *testing.T) {
+	mb := bus.NewMessageBus()
+	defer mb.Close()
+
+	cfg := &config.Config{
+		Channels: config.ChannelsConfig{
+			"email": {
+				Enabled:   true,
+				Type:      config.ChannelEmail,
+				AllowFrom: config.FlexibleStringSlice{"allowed@example.com"},
 			},
 		},
 	}
-	data, err := json.Marshal(raw)
+	cfg.Channels["email"].SetName("email")
+
+	settingsJSON := []byte(`{
+		"enabled": true,
+		"type": "email",
+		"smtp_host": "smtp.example.com",
+		"smtp_from": "bot@example.com",
+		"imap_host": "imap.example.com",
+		"imap_user": "bot@example.com",
+		"imap_password": "password",
+		"allow_from": ["allowed@example.com"]
+	}`)
+	if err := cfg.Channels["email"].UnmarshalJSON(settingsJSON); err != nil {
+		t.Fatalf("unmarshal email channel: %v", err)
+	}
+	cfg.Channels["email"].SetName("email")
+
+	m, err := channels.NewManager(cfg, mb, media.NewFileMediaStore())
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("NewManager: %v", err)
 	}
 
-	f, err := os.CreateTemp(t.TempDir(), "config*.json")
-	if err != nil {
-		t.Fatal(err)
+	for _, name := range m.GetEnabledChannels() {
+		if name == "email" {
+			return
+		}
 	}
-	if _, err := f.Write(data); err != nil {
-		t.Fatal(err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	t.Setenv("SUSHICLAW_CONFIG", f.Name())
-
-	cfg, err := loadEmailConfig()
-	if err != nil {
-		t.Fatalf("loadEmailConfig() error: %v", err)
-	}
-
-	if got := cfg.SMTPPassword.String(); got != "secret-smtp-pass" {
-		t.Errorf("SMTPPassword = %q, want %q", got, "secret-smtp-pass")
-	}
-	if got := cfg.IMAPPassword.String(); got != "secret-imap-pass" {
-		t.Errorf("IMAPPassword = %q, want %q", got, "secret-imap-pass")
-	}
-}
-
-func writeConfigFile(t *testing.T, raw map[string]any) string {
-	t.Helper()
-	data, err := json.Marshal(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
-	f, err := os.CreateTemp(t.TempDir(), "config*.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := f.Write(data); err != nil {
-		t.Fatal(err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
-	return f.Name()
-}
-
-func TestInitChannel_Disabled_ReturnsNil(t *testing.T) {
-	raw := map[string]any{
-		"channels": map[string]any{
-			"email": map[string]any{"enabled": false},
-		},
-	}
-	t.Setenv("SUSHICLAW_CONFIG", writeConfigFile(t, raw))
-
-	ch, err := InitChannel(bus.NewMessageBus())
-	if err != nil {
-		t.Fatalf("InitChannel() error = %v, want nil", err)
-	}
-	if ch != nil {
-		t.Errorf("InitChannel() = %v, want nil for disabled channel", ch)
-	}
-}
-
-func TestInitChannel_MissingRequiredEnvVar_ReturnsError(t *testing.T) {
-	_ = os.Unsetenv("MISSING_IMAP_USER")
-	raw := map[string]any{
-		"channels": map[string]any{
-			"email": map[string]any{
-				"enabled":       true,
-				"smtp_host":     "smtp.example.com",
-				"smtp_from":     "bot@example.com",
-				"imap_host":     "imap.example.com",
-				"imap_user":     "env://MISSING_IMAP_USER",
-				"imap_password": "env://MISSING_IMAP_USER",
-			},
-		},
-	}
-	t.Setenv("SUSHICLAW_CONFIG", writeConfigFile(t, raw))
-
-	_, err := InitChannel(bus.NewMessageBus())
-	if err == nil {
-		t.Fatal("InitChannel() = nil error, want error for missing env var")
-	}
-	if !strings.Contains(err.Error(), "MISSING_IMAP_USER") {
-		t.Errorf("error %q does not mention var name", err.Error())
-	}
+	t.Fatalf("enabled channels = %v, want email", m.GetEnabledChannels())
 }
 
 func TestExtractPlainText(t *testing.T) {
@@ -425,7 +421,7 @@ func TestSend_ReplyThreadingHeaders(t *testing.T) {
 			IMAPUser:       *config.NewSecureString("u"),
 			IMAPPassword:   *config.NewSecureString("p"),
 		}
-		ch, err := NewEmailChannel(cfg, bus.NewMessageBus())
+		ch, err := newTestEmailChannel(t, cfg, bus.NewMessageBus())
 		if err != nil {
 			t.Fatalf("NewEmailChannel: %v", err)
 		}
@@ -566,13 +562,13 @@ func TestSend_NewConversation_UniqueSubject(t *testing.T) {
 		IMAPPassword:   *config.NewSecureString("p"),
 	}
 
-	ch1, err := NewEmailChannel(cfg1, msgBus)
+	ch1, err := newTestEmailChannel(t, cfg1, msgBus)
 	if err != nil {
 		t.Fatalf("NewEmailChannel: %v", err)
 	}
 	ch1.SetRunning(true)
 
-	ch2, err := NewEmailChannel(cfg2, msgBus)
+	ch2, err := newTestEmailChannel(t, cfg2, msgBus)
 	if err != nil {
 		t.Fatalf("NewEmailChannel: %v", err)
 	}
@@ -670,7 +666,7 @@ func TestSend_ReplyDoesNotAddSuffix(t *testing.T) {
 		IMAPPassword:   *config.NewSecureString("p"),
 	}
 
-	ch, err := NewEmailChannel(cfg, bus.NewMessageBus())
+	ch, err := newTestEmailChannel(t, cfg, bus.NewMessageBus())
 	if err != nil {
 		t.Fatalf("NewEmailChannel: %v", err)
 	}
@@ -895,7 +891,7 @@ func TestSendMedia_WithAttachment(t *testing.T) {
 		IMAPPassword:   *config.NewSecureString("p"),
 	}
 
-	ch, err := NewEmailChannel(cfg, bus.NewMessageBus())
+	ch, err := newTestEmailChannel(t, cfg, bus.NewMessageBus())
 	if err != nil {
 		t.Fatalf("NewEmailChannel: %v", err)
 	}

--- a/pkg/channels/email/init.go
+++ b/pkg/channels/email/init.go
@@ -1,86 +1,14 @@
 package email
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-	"path/filepath"
-
 	"github.com/sushi30/sushiclaw/pkg/bus"
 	"github.com/sushi30/sushiclaw/pkg/channels"
+	"github.com/sushi30/sushiclaw/pkg/config"
 )
 
-// InitChannel loads email config, resolves env vars, and returns an initialized
-// EmailChannel. Returns (nil, nil) if email is disabled in config.
-// Returns an error if email is enabled but a required env var is unset.
-func InitChannel(b *bus.MessageBus) (channels.Channel, error) {
-	emailCfg, err := loadEmailConfig()
-	if err != nil {
-		return nil, err
-	}
-	if !emailCfg.Enabled {
-		return nil, nil
-	}
-	return NewEmailChannel(emailCfg, b)
-}
-
-// loadEmailConfig reads the "channels.email" section from the config file and
-// resolves env:// references. Required fields return an error if unresolved.
-func loadEmailConfig() (EmailConfig, error) {
-	path := configFilePath()
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return EmailConfig{}, nil // no config file = not enabled
-	}
-
-	// Try the new top-level "email_channel" key first (V3+ configs and new example format).
-	// Fall back to the legacy "channels"."email" location for backwards compat.
-	var raw struct {
-		EmailChannel EmailConfig `json:"email_channel"`
-		Channels     struct {
-			Email EmailConfig `json:"email"`
-		} `json:"channels"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return EmailConfig{}, err
-	}
-	cfg := raw.EmailChannel
-	if !cfg.Enabled && raw.Channels.Email.Enabled {
-		cfg = raw.Channels.Email
-	}
-	if !cfg.Enabled {
-		return cfg, nil
-	}
-
-	// Required fields — return an error if not set or unresolved env://.
-	if cfg.SMTPFrom.String() == "" || cfg.SMTPFrom.IsUnresolvedEnv() {
-		return EmailConfig{}, fmt.Errorf("smtp_from is required (unresolved: %s)", cfg.SMTPFrom.String())
-	}
-	if cfg.IMAPUser.String() == "" || cfg.IMAPUser.IsUnresolvedEnv() {
-		return EmailConfig{}, fmt.Errorf("imap_user is required (unresolved: %s)", cfg.IMAPUser.String())
-	}
-	if cfg.IMAPPassword.String() == "" || cfg.IMAPPassword.IsUnresolvedEnv() {
-		return EmailConfig{}, fmt.Errorf("imap_password is required (unresolved: %s)", cfg.IMAPPassword.String())
-	}
-
-	return cfg, nil
-}
-
-func configFilePath() string {
-	if p := os.Getenv("SUSHICLAW_CONFIG"); p != "" {
-		return p
-	}
-	if p := os.Getenv("PICOCLAW_CONFIG"); p != "" {
-		return p
-	}
-	home := os.Getenv("SUSHICLAW_HOME")
-	if home == "" {
-		home = os.Getenv("PICOCLAW_HOME")
-	}
-	if home == "" {
-		if h, err := os.UserHomeDir(); err == nil {
-			home = filepath.Join(h, ".picoclaw")
-		}
-	}
-	return filepath.Join(home, "config.json")
+func init() {
+	channels.RegisterSafeFactory(config.ChannelEmail,
+		func(bc *config.Channel, emailCfg *config.EmailSettings, b *bus.MessageBus) (channels.Channel, error) {
+			return NewEmailChannel(bc, emailCfg, b)
+		})
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,14 +17,13 @@ const (
 
 // Config is the top-level sushiclaw configuration.
 type Config struct {
-	Version      int            `json:"version,omitempty"`
-	Agents       AgentsConfig   `json:"agents"`
-	ModelList    []ModelConfig  `json:"model_list"`
-	Channels     ChannelsConfig `json:"channels"`
-	EmailChannel *EmailChanCfg  `json:"email_channel,omitempty"`
-	Gateway      GatewayConfig  `json:"gateway"`
-	Tools        ToolsConfig    `json:"tools"`
-	MCP          MCPConfig      `json:"mcp,omitempty"`
+	Version   int            `json:"version,omitempty"`
+	Agents    AgentsConfig   `json:"agents"`
+	ModelList []ModelConfig  `json:"model_list"`
+	Channels  ChannelsConfig `json:"channels"`
+	Gateway   GatewayConfig  `json:"gateway"`
+	Tools     ToolsConfig    `json:"tools"`
+	MCP       MCPConfig      `json:"mcp,omitempty"`
 }
 
 // MCPConfig holds MCP server configuration.
@@ -186,22 +185,19 @@ func (v VisionToolConfig) APIKeyString() string {
 	return ""
 }
 
-// EmailChanCfg is the top-level email_channel config in config.json.
-type EmailChanCfg struct {
-	Enabled            bool                `json:"enabled"`
-	SMTPHost           string              `json:"smtp_host"`
-	SMTPPort           int                 `json:"smtp_port"`
-	SMTPFrom           SecureString        `json:"smtp_from"`
-	SMTPUser           SecureString        `json:"smtp_user"`
-	SMTPPassword       SecureString        `json:"smtp_password"`
-	DefaultSubject     string              `json:"default_subject"`
-	IMAPHost           string              `json:"imap_host"`
-	IMAPPort           int                 `json:"imap_port"`
-	IMAPUser           SecureString        `json:"imap_user"`
-	IMAPPassword       SecureString        `json:"imap_password"`
-	PollIntervalSecs   int                 `json:"poll_interval_secs"`
-	AllowFrom          FlexibleStringSlice `json:"allow_from"`
-	ReasoningChannelID string              `json:"reasoning_channel_id"`
+// EmailSettings holds Email-specific channel settings.
+type EmailSettings struct {
+	SMTPHost         string       `json:"smtp_host"`
+	SMTPPort         int          `json:"smtp_port"`
+	SMTPFrom         SecureString `json:"smtp_from"`
+	SMTPUser         SecureString `json:"smtp_user"`
+	SMTPPassword     SecureString `json:"smtp_password"`
+	DefaultSubject   string       `json:"default_subject"`
+	IMAPHost         string       `json:"imap_host"`
+	IMAPPort         int          `json:"imap_port"`
+	IMAPUser         SecureString `json:"imap_user"`
+	IMAPPassword     SecureString `json:"imap_password"`
+	PollIntervalSecs int          `json:"poll_interval_secs"`
 }
 
 // GroupTriggerConfig controls when the bot responds in group chats.


### PR DESCRIPTION
## Summary
- Move email onto the standard channels registry path as channels.email.
- Remove the legacy top-level email_channel startup path and wire email through the normal channel factory lifecycle.
- Update example config, docs, and tests for the hard migration.

## Test Plan
- make test
- make lint

## Known gaps
- None