### PR TITLE
fix(agent): revert handleInbound to non-streaming path

### DIFF
--- a/docs/release/YANK.md
+++ b/docs/release/YANK.md
@@ -1,0 +1,101 @@
+# Yanking a Release
+
+This guide documents how to retract a buggy release (tag, GitHub Release, and Docker image) from GitHub.
+
+## When to Yank
+
+Yank a release when it contains a critical bug that makes it unusable or dangerous to deploy. Document the reason in a follow-up issue so users know why the release disappeared.
+
+## Step-by-Step
+
+### 1. Delete the GitHub Release
+
+```bash
+gh release delete <TAG> --yes
+```
+
+Example:
+```bash
+gh release delete 2026.04.4 --yes
+```
+
+### 2. Delete the Git Tag
+
+Local:
+```bash
+git tag -d <TAG>
+```
+
+Remote:
+```bash
+git push --delete origin <TAG>
+```
+
+Example:
+```bash
+git tag -d 2026.04.4
+git push --delete origin 2026.04.4
+```
+
+### 3. Delete the Docker Image from GHCR
+
+#### 3a. Find the version ID
+
+```bash
+gh api "users/<OWNER>/packages/container/<PACKAGE>/versions" \
+  --jq '.[] | select(.metadata.container.tags[] | contains("<TAG>")) | {id, tags: .metadata.container.tags}'
+```
+
+Example:
+```bash
+gh api "users/sushi30/packages/container/sushiclaw/versions" \
+  --jq '.[] | select(.metadata.container.tags[] | contains("2026.04.4")) | {id, tags: .metadata.container.tags}'
+```
+
+#### 3b. Delete the version
+
+```bash
+gh api --method DELETE "users/<OWNER>/packages/container/<PACKAGE>/versions/<VERSION_ID>"
+```
+
+Example:
+```bash
+gh api --method DELETE "users/sushi30/packages/container/sushiclaw/versions/823757800"
+```
+
+> **Note:** This requires a GitHub token with `delete:packages` and `read:packages` scopes. If you get a 403, your token lacks the `delete:packages` scope.
+
+#### Alternative: Delete via GitHub Web UI
+
+If API deletion fails due to permissions, you can delete the package version manually:
+
+1. Go to **Packages** in your profile or organization settings
+2. Find the `sushiclaw` container package
+3. Click **Manage versions**
+4. Find the version tagged with the release
+5. Click the trash icon to delete
+
+### 4. Verify Retraction
+
+- [ ] Tag no longer appears in `git tag --sort=-creatordate`
+- [ ] Release no longer appears on the GitHub releases page
+- [ ] Docker image no longer pullable: `docker pull ghcr.io/<OWNER>/<PACKAGE>:<TAG>` should fail
+
+### 5. Communicate
+
+- Create a GitHub issue documenting why the release was yanked
+- If users may have the bad release deployed, announce the yank in relevant channels
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---|---|---|
+| `gh release delete` fails | Release doesn't exist | Skip this step |
+| `git push --delete origin` fails | Tag already deleted remotely | Skip this step |
+| `gh api ... 403` for image delete | Token lacks `delete:packages` scope | Use GitHub web UI or regenerate token with correct scopes |
+| `gh api ... 404` for package list | Wrong package name or org vs user namespace | Try `orgs/<OWNER>` instead of `users/<OWNER>` |
+
+## See Also
+
+- [GitHub Docs: Deleting a package version](https://docs.github.com/en/packages/learn-github-packages/deleting-and-restoring-a-package)
+- `RELEASE.md` — normal release process

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -314,7 +314,7 @@ func (sm *SessionManager) handleInbound(ctx context.Context, msg bus.InboundMess
 	start := time.Now()
 	sm.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressTurnStarted})
 
-	response, usage, toolCalls, err := sm.runStreamingTurn(actx, ctx, msg.Channel, chatID, input, start)
+	response, err := sm.agent.Run(actx, input)
 	if err != nil {
 		logger.ErrorCF("agent", "Agent run failed", map[string]any{"error": err.Error()})
 		_ = sm.bus.PublishOutbound(ctx, bus.OutboundMessage{
@@ -327,8 +327,6 @@ func (sm *SessionManager) handleInbound(ctx context.Context, msg bus.InboundMess
 			Channel:   msg.Channel,
 			ChatID:    chatID,
 			Success:   false,
-			ToolCalls: toolCalls,
-			Usage:     usage,
 			Duration:  time.Since(start),
 			Error:     err,
 		})
@@ -347,8 +345,6 @@ func (sm *SessionManager) handleInbound(ctx context.Context, msg bus.InboundMess
 		Channel:   msg.Channel,
 		ChatID:    chatID,
 		Success:   true,
-		ToolCalls: toolCalls,
-		Usage:     usage,
 		Duration:  time.Since(start),
 	})
 }

--- a/internal/agent/session_debug_test.go
+++ b/internal/agent/session_debug_test.go
@@ -19,9 +19,17 @@ type mockRunner struct {
 	streamErr   error
 	detailed    *interfaces.AgentResponse
 	detailedErr error
+	runResult   string
+	runErr      error
 }
 
 func (m *mockRunner) Run(context.Context, string) (string, error) {
+	if m.runErr != nil {
+		return "", m.runErr
+	}
+	if m.runResult != "" {
+		return m.runResult, nil
+	}
 	return "", errors.New("Run should not be called")
 }
 
@@ -60,23 +68,17 @@ func (c *collectingProgress) Summary(_ context.Context, summary ProgressSummary)
 }
 
 func TestSessionManagerDebugStartCompletionAndSummary(t *testing.T) {
-	events := streamEvents(
-		interfaces.AgentStreamEvent{Type: interfaces.AgentEventContent, Content: "hello"},
-		interfaces.AgentStreamEvent{Type: interfaces.AgentEventComplete},
-	)
 	extBus := bus.NewMessageBus()
 	progress := &collectingProgress{}
-	sm := &SessionManager{agent: &mockRunner{stream: events}, bus: extBus, progress: progress}
+	sm := &SessionManager{agent: &mockRunner{runResult: "hello"}, bus: extBus, progress: progress}
 
 	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "hi"))
 
 	msg := requireOutboundMessage(t, extBus)
 	assert.Equal(t, "hello", msg.Content)
-	assertEventKinds(t, progress.events, ProgressTurnStarted, ProgressFirstActivity, ProgressCompleted)
+	assertEventKinds(t, progress.events, ProgressTurnStarted, ProgressCompleted)
 	require.Len(t, progress.summaries, 1)
 	assert.True(t, progress.summaries[0].Success)
-	assert.Equal(t, 0, progress.summaries[0].ToolCalls)
-	assert.Nil(t, progress.summaries[0].Usage)
 	assert.GreaterOrEqual(t, progress.summaries[0].Duration, time.Duration(0))
 }
 
@@ -98,15 +100,14 @@ func TestSessionManagerDebugToolEventsUseOnlyNames(t *testing.T) {
 		},
 		interfaces.AgentStreamEvent{Type: interfaces.AgentEventContent, Content: "done"},
 	)
-	extBus := bus.NewMessageBus()
 	progress := &collectingProgress{}
-	sm := &SessionManager{agent: &mockRunner{stream: events}, bus: extBus, progress: progress}
+	sm := &SessionManager{agent: &mockRunner{stream: events}, bus: bus.NewMessageBus(), progress: progress}
 
-	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "run"))
+	response, _, toolCalls, err := sm.runStreamingTurn(t.Context(), t.Context(), "telegram", "chat1", "run", time.Now())
 
-	requireOutboundMessage(t, extBus)
-	require.Len(t, progress.summaries, 1)
-	assert.Equal(t, 1, progress.summaries[0].ToolCalls)
+	require.NoError(t, err)
+	assert.Equal(t, "done", response)
+	assert.Equal(t, 1, toolCalls)
 
 	var toolEvents []ProgressEvent
 	for _, event := range progress.events {
@@ -138,13 +139,13 @@ func TestSessionManagerDebugTokenSummaryFromStreamMetadata(t *testing.T) {
 	progress := &collectingProgress{}
 	sm := &SessionManager{agent: &mockRunner{stream: events}, bus: bus.NewMessageBus(), progress: progress}
 
-	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "tokens"))
+	_, usage, _, err := sm.runStreamingTurn(t.Context(), t.Context(), "telegram", "chat1", "tokens", time.Now())
 
-	require.Len(t, progress.summaries, 1)
-	require.NotNil(t, progress.summaries[0].Usage)
-	assert.Equal(t, 4, progress.summaries[0].Usage.InputTokens)
-	assert.Equal(t, 6, progress.summaries[0].Usage.OutputTokens)
-	assert.Equal(t, 10, progress.summaries[0].Usage.TotalTokens)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Equal(t, 4, usage.InputTokens)
+	assert.Equal(t, 6, usage.OutputTokens)
+	assert.Equal(t, 10, usage.TotalTokens)
 }
 
 func TestSessionManagerDebugHeartbeatAfterSilence(t *testing.T) {
@@ -157,36 +158,32 @@ func TestSessionManagerDebugHeartbeatAfterSilence(t *testing.T) {
 	progress := &collectingProgress{heartbeat: 10 * time.Millisecond}
 	sm := &SessionManager{agent: &mockRunner{stream: ch}, bus: bus.NewMessageBus(), progress: progress}
 
-	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "slow"))
+	_, _, _, err := sm.runStreamingTurn(t.Context(), t.Context(), "telegram", "chat1", "slow", time.Now())
 
+	require.NoError(t, err)
 	assertHasEvent(t, progress.events, ProgressHeartbeat)
 }
 
-func TestSessionManagerStreamErrorPublishesOneUserErrorAndFailureSummary(t *testing.T) {
-	streamErr := errors.New("stream failed")
-	events := streamEvents(
-		interfaces.AgentStreamEvent{Type: interfaces.AgentEventContent, Content: "partial"},
-		interfaces.AgentStreamEvent{Type: interfaces.AgentEventError, Error: streamErr},
-	)
+func TestSessionManagerRunErrorPublishesOneUserErrorAndFailureSummary(t *testing.T) {
+	runErr := errors.New("run failed")
 	extBus := bus.NewMessageBus()
 	progress := &collectingProgress{}
-	sm := &SessionManager{agent: &mockRunner{stream: events}, bus: extBus, progress: progress}
+	sm := &SessionManager{agent: &mockRunner{runErr: runErr}, bus: extBus, progress: progress}
 
 	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "bad"))
 
 	msg := requireOutboundMessage(t, extBus)
-	assert.Equal(t, "Error: stream failed", msg.Content)
+	assert.Equal(t, "Error: run failed", msg.Content)
 	assertNoOutboundMessage(t, extBus)
 	require.Len(t, progress.summaries, 1)
 	assert.False(t, progress.summaries[0].Success)
-	assert.ErrorIs(t, progress.summaries[0].Error, streamErr)
+	assert.ErrorIs(t, progress.summaries[0].Error, runErr)
 	assertHasEvent(t, progress.events, ProgressFailed)
 }
 
 func TestSessionManagerStreamingStartupFallbackUsesDetailedUsage(t *testing.T) {
 	startErr := errors.New("no streaming")
 	progress := &collectingProgress{}
-	extBus := bus.NewMessageBus()
 	sm := &SessionManager{
 		agent: &mockRunner{
 			streamErr: startErr,
@@ -199,19 +196,18 @@ func TestSessionManagerStreamingStartupFallbackUsesDetailedUsage(t *testing.T) {
 				},
 			},
 		},
-		bus:      extBus,
+		bus:      bus.NewMessageBus(),
 		progress: progress,
 	}
 
-	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "fallback"))
+	response, usage, toolCalls, err := sm.runStreamingTurn(t.Context(), t.Context(), "telegram", "chat1", "fallback", time.Now())
 
-	assert.Equal(t, "fallback", requireOutboundMessage(t, extBus).Content)
+	require.NoError(t, err)
+	assert.Equal(t, "fallback", response)
 	assertHasEvent(t, progress.events, ProgressFallback)
-	require.Len(t, progress.summaries, 1)
-	assert.True(t, progress.summaries[0].Success)
-	assert.Equal(t, 2, progress.summaries[0].ToolCalls)
-	require.NotNil(t, progress.summaries[0].Usage)
-	assert.Equal(t, 15, progress.summaries[0].Usage.TotalTokens)
+	assert.Equal(t, 2, toolCalls)
+	require.NotNil(t, usage)
+	assert.Equal(t, 15, usage.TotalTokens)
 }
 
 func streamEvents(events ...interfaces.AgentStreamEvent) <-chan interfaces.AgentStreamEvent {


### PR DESCRIPTION
## Summary

Reverts the switch from `sm.agent.Run()` to `runStreamingTurn()` in `handleInbound`, which introduced a regression where the agent silently dropped responses for messages that don't trigger tools (e.g. simple questions like "1+1?").

## Root Cause

The upstream `agent-sdk-go` v0.2.44 `GenerateWithToolsStream` discards content events when the model returns text without making tool calls. Content is captured into `iterationContentEvents` but only replayed if `len(assistantResponse.ToolCalls) > 0`, causing an empty response and no outbound message.

## Changes

- `internal/agent/session.go`: Switch `handleInbound` back to non-streaming `sm.agent.Run()`

## Related

- Fixes silent failure on simple queries
- Issue #126 tracks the deep fix (upstream bug + regression tests)