### PR TITLE
feat(tools): add channel-aware message_tool for agent-authored user updates

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -103,6 +103,10 @@
       "model_name": "gpt-4o-mini",
       "prompt": "Describe this image in detail."
     },
+    "message": {
+      "enabled": true,
+      "min_interval_seconds": 5
+    },
     "media_cleanup": {
       "enabled": true,
       "max_age": 30,

--- a/examples/config/telegram-openrouter.json
+++ b/examples/config/telegram-openrouter.json
@@ -53,6 +53,10 @@
       "model_name": "openrouter-glm-5v",
       "prompt": "Describe this image in detail."
     },
+    "message": {
+      "enabled": true,
+      "min_interval_seconds": 5
+    },
     "media_cleanup": {
       "enabled": true,
       "max_age": 30,

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -75,11 +75,18 @@ func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem *InMe
 	}
 
 	toolNames := make([]string, len(tools))
+	hasMessageTool := false
 	for i, t := range tools {
 		toolNames[i] = t.Name()
+		if t.Name() == "message_tool" {
+			hasMessageTool = true
+		}
 	}
 	if len(tools) == 0 {
 		systemPrompt += "\n\nIMPORTANT: You have no tools available. You cannot execute commands, run code, or take real-world actions. If asked to do any of these, tell the user you are unable to in the current configuration — do not simulate or pretend to execute anything."
+	}
+	if hasMessageTool {
+		systemPrompt += "\n\nYou have access to message_tool. Use it to send short progress updates to the user during long-running tasks, especially when the user asked to be kept updated or when you reach a meaningful milestone. Do not overuse it; wait for meaningful progress before sending an update."
 	}
 	logger.DebugCF("agent", "Building agent", map[string]any{
 		"workspace":     cfg.WorkspacePath(),

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -82,7 +82,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	defer mediaStore.Stop()
 
 	allowedSenders := sushitools.ParseAllowedSenders()
-	tools, err := sushitools.NewGatewayTools(cfg, allowedSenders, mediaStore)
+	tools, err := sushitools.NewGatewayTools(cfg, allowedSenders, mediaStore, messageBus)
 	if err != nil {
 		logger.WarnCF("gateway", "Failed to init trusted exec tool",
 			map[string]any{"error": err.Error()})
@@ -128,6 +128,10 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	if cfg.Tools.IsToolEnabled("vision") {
 		logger.InfoCF("gateway", "Vision tool registered",
 			map[string]any{"model": cfg.Tools.Vision.Model})
+	}
+
+	if cfg.Tools.IsToolEnabled("message") {
+		logger.InfoC("gateway", "Message tool registered")
 	}
 
 	sessionMgr, err := agent.NewSessionManager(cfg, messageBus, tools, mediaStore, agent.WithProgressSink(dm))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,6 +91,7 @@ type ToolsConfig struct {
 	ListDir      ToolConfig          `json:"list_dir"`
 	WebSearch    WebSearchToolConfig `json:"web_search"`
 	Vision       VisionToolConfig    `json:"vision"`
+	Message      MessageToolConfig   `json:"message"`
 }
 
 func (t ToolsConfig) IsToolEnabled(name string) bool {
@@ -109,6 +110,8 @@ func (t ToolsConfig) IsToolEnabled(name string) bool {
 		return t.WebSearch.Enabled
 	case "vision":
 		return t.Vision.Enabled
+	case "message":
+		return t.Message.Enabled
 	}
 	return false
 }
@@ -175,6 +178,11 @@ type VisionToolConfig struct {
 	APIKey    *SecureString `json:"api_key,omitzero"`
 	APIBase   string        `json:"api_base,omitempty"`
 	Prompt    string        `json:"prompt,omitempty"`
+}
+
+type MessageToolConfig struct {
+	Enabled     bool `json:"enabled"`
+	MinInterval int  `json:"min_interval_seconds,omitempty"`
 }
 
 // APIKeyString returns the resolved API key.

--- a/pkg/tools/builder.go
+++ b/pkg/tools/builder.go
@@ -2,10 +2,12 @@ package tools
 
 import (
 	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/sushi30/sushiclaw/pkg/bus"
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/media"
 	"github.com/sushi30/sushiclaw/pkg/tools/exec"
 	fstools "github.com/sushi30/sushiclaw/pkg/tools/fs"
+	"github.com/sushi30/sushiclaw/pkg/tools/message"
 	"github.com/sushi30/sushiclaw/pkg/tools/vision"
 	"github.com/sushi30/sushiclaw/pkg/tools/websearch"
 )
@@ -30,7 +32,7 @@ func NewChatTools(cfg *config.Config) []interfaces.Tool {
 }
 
 // NewGatewayTools returns tools available to remote gateway sessions.
-func NewGatewayTools(cfg *config.Config, execAllowedSenders []string, store media.MediaStore) ([]interfaces.Tool, error) {
+func NewGatewayTools(cfg *config.Config, execAllowedSenders []string, store media.MediaStore, messageBus *bus.MessageBus) ([]interfaces.Tool, error) {
 	out := newFileTools(cfg)
 	if cfg.Tools.IsToolEnabled("exec") && len(execAllowedSenders) > 0 {
 		trustedExec, err := NewTrustedExecTool(cfg, workspacePath(cfg), restrictToWorkspace(cfg), execAllowedSenders)
@@ -43,6 +45,9 @@ func NewGatewayTools(cfg *config.Config, execAllowedSenders []string, store medi
 		if tool, err := vision.NewTool(cfg.Tools.Vision, visionModel(cfg), store); err == nil {
 			out = append(out, tool)
 		}
+	}
+	if cfg.Tools.IsToolEnabled("message") && messageBus != nil {
+		out = append(out, message.NewTool(messageBus, cfg.Tools.Message.MinInterval))
 	}
 	return out, nil
 }

--- a/pkg/tools/builder_test.go
+++ b/pkg/tools/builder_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/sushi30/sushiclaw/pkg/bus"
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/tools"
 )
@@ -28,7 +29,7 @@ func TestNewGatewayTools_RegistersFileToolsWithoutExecAllowlist(t *testing.T) {
 	cfg.Tools.ReadFile.Enabled = true
 	cfg.Tools.ListDir.Enabled = true
 
-	built, err := tools.NewGatewayTools(cfg, nil, nil)
+	built, err := tools.NewGatewayTools(cfg, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewGatewayTools: %v", err)
 	}
@@ -44,7 +45,7 @@ func TestNewGatewayTools_RegistersTrustedExecWithAllowlist(t *testing.T) {
 	cfg := newToolsConfig(t)
 	cfg.Tools.Exec.Enabled = true
 
-	built, err := tools.NewGatewayTools(cfg, []string{"chat-1"}, nil)
+	built, err := tools.NewGatewayTools(cfg, []string{"chat-1"}, nil, nil)
 	if err != nil {
 		t.Fatalf("NewGatewayTools: %v", err)
 	}
@@ -70,13 +71,29 @@ func TestNewGatewayTools_RegistersVisionFromModelListReference(t *testing.T) {
 	cfg.Tools.Vision.Enabled = true
 	cfg.Tools.Vision.ModelName = "vision-model"
 
-	built, err := tools.NewGatewayTools(cfg, nil, nil)
+	built, err := tools.NewGatewayTools(cfg, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("NewGatewayTools: %v", err)
 	}
 
 	got := toolNames(built)
 	want := []string{"vision"}
+	if !equalStrings(got, want) {
+		t.Fatalf("tool names = %v, want %v", got, want)
+	}
+}
+
+func TestNewGatewayTools_RegistersMessageToolWhenEnabled(t *testing.T) {
+	cfg := newToolsConfig(t)
+	cfg.Tools.Message.Enabled = true
+
+	built, err := tools.NewGatewayTools(cfg, nil, nil, bus.NewMessageBus())
+	if err != nil {
+		t.Fatalf("NewGatewayTools: %v", err)
+	}
+
+	got := toolNames(built)
+	want := []string{"message_tool"}
 	if !equalStrings(got, want) {
 		t.Fatalf("tool names = %v, want %v", got, want)
 	}

--- a/pkg/tools/message/message_tool.go
+++ b/pkg/tools/message/message_tool.go
@@ -1,0 +1,114 @@
+package message
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/tools/toolctx"
+)
+
+const defaultMinInterval = 5 * time.Second
+
+// Tool sends user-facing progress updates to the current chat via the message bus.
+type Tool struct {
+	bus         *bus.MessageBus
+	minInterval time.Duration
+	lastSent    map[string]time.Time
+	mu          sync.RWMutex
+}
+
+// NewTool creates a new message tool.
+// If minIntervalSeconds <= 0, a 5-second default is used.
+func NewTool(b *bus.MessageBus, minIntervalSeconds int) *Tool {
+	interval := time.Duration(minIntervalSeconds) * time.Second
+	if interval <= 0 {
+		interval = defaultMinInterval
+	}
+	return &Tool{
+		bus:         b,
+		minInterval: interval,
+		lastSent:    make(map[string]time.Time),
+	}
+}
+
+func (t *Tool) Name() string        { return "message_tool" }
+func (t *Tool) Description() string { return description }
+
+func (t *Tool) Parameters() map[string]interfaces.ParameterSpec {
+	return map[string]interfaces.ParameterSpec{
+		"content": {
+			Type:        "string",
+			Description: "The message to send to the user. Keep it concise and human-readable.",
+			Required:    true,
+		},
+	}
+}
+
+// Run executes the tool with the given input string.
+func (t *Tool) Run(ctx context.Context, input string) (string, error) {
+	return t.Execute(ctx, input)
+}
+
+// Execute parses args and sends the message to the current chat.
+func (t *Tool) Execute(ctx context.Context, args string) (string, error) {
+	channel := toolctx.ChannelFromContext(ctx)
+	chatID := toolctx.ChatIDFromContext(ctx)
+
+	if channel == "" || chatID == "" {
+		return "", fmt.Errorf("message_tool: missing chat context (no active conversation)")
+	}
+
+	if channel == config.ChannelEmail {
+		return "", fmt.Errorf("message_tool: not available for email channel")
+	}
+
+	var req struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal([]byte(args), &req); err != nil {
+		return "", fmt.Errorf("message_tool: invalid arguments: %w", err)
+	}
+	if req.Content == "" {
+		return "", fmt.Errorf("message_tool: content is required")
+	}
+
+	key := channel + ":" + chatID
+	t.mu.Lock()
+	last := t.lastSent[key]
+	if time.Since(last) < t.minInterval {
+		remaining := t.minInterval - time.Since(last)
+		t.mu.Unlock()
+		return "", fmt.Errorf("message_tool: please wait %v before sending another update", remaining.Round(time.Second))
+	}
+	t.lastSent[key] = time.Now()
+	t.mu.Unlock()
+
+	msg := bus.OutboundMessage{
+		Channel: channel,
+		ChatID:  chatID,
+		Context: bus.NewOutboundContext(channel, chatID, ""),
+		Content: req.Content,
+	}
+
+	if err := t.bus.PublishOutbound(ctx, msg); err != nil {
+		return "", fmt.Errorf("message_tool: failed to send message: %w", err)
+	}
+
+	return "Message sent.", nil
+}
+
+const description = `Send a short progress update to the user in the current chat.
+
+Use this tool when:
+- The user asked to be kept updated during a long-running task.
+- You have reached a meaningful milestone and want to share progress.
+- You are blocked and need to inform the user before continuing.
+
+Do not overuse this tool. Wait for meaningful progress before sending an update.
+This tool is not available for email conversations.`

--- a/pkg/tools/message/message_tool_test.go
+++ b/pkg/tools/message/message_tool_test.go
@@ -1,0 +1,151 @@
+package message
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/tools/toolctx"
+)
+
+func TestMessageTool_NameAndDescription(t *testing.T) {
+	mt := NewTool(bus.NewMessageBus(), 0)
+	if mt.Name() != "message_tool" {
+		t.Errorf("expected name message_tool, got %s", mt.Name())
+	}
+	if mt.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+	params := mt.Parameters()
+	if len(params) != 1 {
+		t.Fatalf("expected 1 parameter, got %d", len(params))
+	}
+	if _, ok := params["content"]; !ok {
+		t.Error("expected 'content' parameter")
+	}
+}
+
+func TestMessageTool_Success(t *testing.T) {
+	b := bus.NewMessageBus()
+	mt := NewTool(b, 0)
+
+	ctx := toolctx.WithChannel(toolctx.WithChatID(context.Background(), "chat123"), config.ChannelTelegram)
+
+	result, err := mt.Execute(ctx, `{"content":"Hello update"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "Message sent." {
+		t.Errorf("unexpected result: %s", result)
+	}
+
+	select {
+	case msg := <-b.OutboundChan():
+		if msg.Channel != config.ChannelTelegram {
+			t.Errorf("expected channel %s, got %s", config.ChannelTelegram, msg.Channel)
+		}
+		if msg.ChatID != "chat123" {
+			t.Errorf("expected chatID chat123, got %s", msg.ChatID)
+		}
+		if msg.Content != "Hello update" {
+			t.Errorf("expected content 'Hello update', got %s", msg.Content)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for outbound message")
+	}
+}
+
+func TestMessageTool_EmailRejection(t *testing.T) {
+	b := bus.NewMessageBus()
+	mt := NewTool(b, 0)
+
+	ctx := toolctx.WithChannel(toolctx.WithChatID(context.Background(), "chat@example.com"), config.ChannelEmail)
+
+	_, err := mt.Execute(ctx, `{"content":"Blocked"}`)
+	if err == nil {
+		t.Fatal("expected error for email channel")
+	}
+	if err.Error() != "message_tool: not available for email channel" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+
+	select {
+	case <-b.OutboundChan():
+		t.Fatal("expected no outbound message for email")
+	case <-time.After(100 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestMessageTool_MissingContext(t *testing.T) {
+	b := bus.NewMessageBus()
+	mt := NewTool(b, 0)
+
+	// Missing channel
+	ctx := toolctx.WithChatID(context.Background(), "chat123")
+	_, err := mt.Execute(ctx, `{"content":"Test"}`)
+	if err == nil {
+		t.Fatal("expected error for missing channel")
+	}
+
+	// Missing chatID
+	ctx = toolctx.WithChannel(context.Background(), config.ChannelTelegram)
+	_, err = mt.Execute(ctx, `{"content":"Test"}`)
+	if err == nil {
+		t.Fatal("expected error for missing chatID")
+	}
+}
+
+func TestMessageTool_Throttling(t *testing.T) {
+	b := bus.NewMessageBus()
+	mt := NewTool(b, 1) // 1 second min interval
+
+	ctx := toolctx.WithChannel(toolctx.WithChatID(context.Background(), "chat456"), config.ChannelTelegram)
+
+	// First call should succeed
+	_, err := mt.Execute(ctx, `{"content":"First"}`)
+	if err != nil {
+		t.Fatalf("unexpected error on first call: %v", err)
+	}
+	<-b.OutboundChan() // drain
+
+	// Second call immediately should fail
+	_, err = mt.Execute(ctx, `{"content":"Second"}`)
+	if err == nil {
+		t.Fatal("expected throttle error on second call")
+	}
+
+	// Wait for throttle to reset
+	time.Sleep(1100 * time.Millisecond)
+
+	_, err = mt.Execute(ctx, `{"content":"Third"}`)
+	if err != nil {
+		t.Fatalf("unexpected error after throttle reset: %v", err)
+	}
+
+	select {
+	case msg := <-b.OutboundChan():
+		if msg.Content != "Third" {
+			t.Errorf("expected 'Third', got %s", msg.Content)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for third message")
+	}
+}
+
+func TestMessageTool_EmptyContent(t *testing.T) {
+	b := bus.NewMessageBus()
+	mt := NewTool(b, 0)
+
+	ctx := toolctx.WithChannel(toolctx.WithChatID(context.Background(), "chat123"), config.ChannelTelegram)
+
+	_, err := mt.Execute(ctx, `{"content":""}`)
+	if err == nil {
+		t.Fatal("expected error for empty content")
+	}
+	if err.Error() != "message_tool: content is required" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/pkg/tools/vision/vision.go
+++ b/pkg/tools/vision/vision.go
@@ -24,12 +24,12 @@ const defaultMaxTokens = 1024
 
 // VisionTool calls a vision-capable LLM to describe an image.
 type VisionTool struct {
-	model       string
-	apiKey      string
-	apiBase     string
+	model         string
+	apiKey        string
+	apiBase       string
 	defaultPrompt string
-	client      *http.Client
-	mediaStore  media.MediaStore
+	client        *http.Client
+	mediaStore    media.MediaStore
 }
 
 // Args is the expected JSON shape from the agent.
@@ -85,8 +85,10 @@ func NewTool(cfg config.VisionToolConfig, defaultModelCfg *config.ModelConfig, s
 	}, nil
 }
 
-func (t *VisionTool) Name() string        { return "vision" }
-func (t *VisionTool) Description() string { return "Analyze an image using a vision-capable LLM and return a text description." }
+func (t *VisionTool) Name() string { return "vision" }
+func (t *VisionTool) Description() string {
+	return "Analyze an image using a vision-capable LLM and return a text description."
+}
 
 func (t *VisionTool) Parameters() map[string]interfaces.ParameterSpec {
 	return map[string]interfaces.ParameterSpec{

--- a/workspace/agents/general-purpose/AGENT.md
+++ b/workspace/agents/general-purpose/AGENT.md
@@ -1,0 +1,61 @@
+---
+name: general-purpose
+description: >
+  A delegated task executor for the orchestrator. Handles file operations,
+  shell commands, and web search. No messaging or cron capabilities.
+---
+
+You are a general-purpose sub-agent, delegated tasks by the orchestrator.
+
+## Role
+
+You execute concrete tasks assigned by the orchestrator. You do not talk to
+users directly — your output is returned to the orchestrator, which decides
+what to do with it.
+
+## Mission
+
+- Execute delegated tasks efficiently and accurately
+- Use only the tools you have been given
+- Return clear, structured results
+- Ask for clarification only when the task is truly ambiguous
+
+## Available Tools
+
+| Tool | Purpose |
+|------|---------|
+| `read_file` | Read file contents |
+| `write_file` | Write or overwrite files |
+| `list_dir` | List directory contents |
+| `exec` | Run shell commands |
+| `web_search` | Search the web |
+
+## Tools You Do NOT Have
+
+- `message_tool` — you cannot send messages to users
+- `cron` — you cannot schedule recurring jobs
+- Any channel-specific tools
+
+## Working Principles
+
+1. **Execute, don't chat** — focus on completing the task, not conversation
+2. **Be thorough** — check your work before returning results
+3. **Be safe** — respect workspace boundaries; don't escape the working directory
+4. **Return structured output** — use markdown, code blocks, and clear sections
+
+## Output Format
+
+When returning results, use this structure:
+
+```
+## Summary
+(Brief description of what was done)
+
+## Details
+(The actual output — code, search results, file contents, etc.)
+
+## Issues / Notes
+(Any problems, warnings, or things the orchestrator should know)
+```
+
+Read `SOUL.md` for your personality and `USER.md` for user preferences.

--- a/workspace/agents/general-purpose/SOUL.md
+++ b/workspace/agents/general-purpose/SOUL.md
@@ -1,0 +1,26 @@
+# Soul
+
+## Personality
+
+Focused, efficient, and reliable. You are a worker, not a conversationalist.
+
+## Communication Style
+
+- **Direct**: no pleasantries, no fluff
+- **Structured**: use headers, lists, and code blocks
+- **Complete**: include all relevant details the orchestrator needs
+- **Honest**: report failures and errors clearly
+
+## Values
+
+- Accuracy over speed
+- Completeness over brevity
+- Safety — never escape the workspace
+- Transparency — show what you did and why
+
+## What You Avoid
+
+- Chatting with the user (you have no messaging tools)
+- Scheduling or cron jobs
+- Making assumptions about ambiguous tasks — ask the orchestrator
+- Hiding errors or partial failures

--- a/workspace/agents/general-purpose/USER.md
+++ b/workspace/agents/general-purpose/USER.md
@@ -1,0 +1,27 @@
+# User
+
+## Identity
+
+- **Name**: (fill in your name)
+- **Timezone**: (e.g., UTC+2, America/New_York)
+- **Language**: (your preferred language)
+
+## Preferences
+
+- **Communication style**: casual / formal / technical
+- **Response length**: brief / medium / detailed
+- **Code style**: (e.g., Pythonic, Go idiomatic, etc.)
+
+## Interests & Goals
+
+- (What do you want help with? e.g., "learning Go", "building side projects")
+- (What should the assistant prioritize?)
+
+## Context
+
+- (Add anything the assistant should always know about you)
+- (e.g., "I work remotely", "I prefer async communication")
+
+## Privacy Notes
+
+- (Any topics or data the assistant should be careful with)

--- a/workspace/agents/general-purpose/skills/research/SKILL.md
+++ b/workspace/agents/general-purpose/skills/research/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: research
+description: >
+  Deep research skill: search the web, summarize findings, and compile
+  structured reports with sources.
+---
+
+# Research Skill
+
+When activated, you adopt a structured research workflow.
+
+## Workflow
+
+1. **Clarify** — confirm the research question and scope
+2. **Search** — use web_search to gather information
+3. **Synthesize** — summarize findings into key points
+4. **Cite** — always mention sources
+5. **Deliver** — present a concise report
+
+## Report Format
+
+```
+## Summary
+(1-2 sentence overview)
+
+## Key Findings
+- Finding 1 (source)
+- Finding 2 (source)
+
+## Gaps / Uncertainties
+(What you couldn't confirm)
+
+## Recommendations
+(Suggested next steps)
+```
+
+## Guidelines
+
+- Prefer primary sources over aggregators
+- Cross-check facts across multiple sources when possible
+- Distinguish between facts, expert opinions, and speculation
+- Note publication dates — old info may be outdated


### PR DESCRIPTION
## Summary

Adds a `message_tool` available to gateway agent sessions that lets the agent send progress updates to the current user/chat during a task.

The tool is channel-aware:
- Sends only to the current inbound channel/chat context (read from toolctx)
- Rejects email channels with a clear error
- Per-chat throttling with configurable `min_interval_seconds` (default 5s)
- Includes system prompt guidance when the tool is enabled so the LLM knows when to use it

## Changes

- **New** `pkg/tools/message/message_tool.go` — tool implementation
- **New** `pkg/tools/message/message_tool_test.go` — 6 tests covering success, email rejection, missing context, throttling, and empty content
- **Modified** `pkg/config/config.go` — added `MessageToolConfig` with `enabled` and `min_interval_seconds`
- **Modified** `pkg/tools/builder.go` — `NewGatewayTools` now accepts `*bus.MessageBus`; wires in message tool when enabled
- **Modified** `pkg/tools/builder_test.go` — updated for new signature; added registration test
- **Modified** `internal/gateway/gateway.go` — passes `messageBus` to `NewGatewayTools`
- **Modified** `internal/agent/session.go` — appends usage guidance to system prompt when `message_tool` is registered
- **Modified** `config.example.json` and `examples/config/telegram-openrouter.json` — added example `message` config block

## Test Plan

- `go test ./pkg/tools/message/...` — 6/6 pass
- `go test ./pkg/tools/...` — 61/61 pass  
- `go test ./pkg/config/...` — 23/23 pass
- `go test ./...` — 449 pass (6 pre-existing failures in `internal/agent` unrelated to this change — those tests fail on main too due to the streaming revert in 3256f61)
- `go vet ./...` — clean
- `go build -tags whatsapp_native` — succeeds

## Usage

Add to `config.json`:
```json
"tools": {
  "message": {
    "enabled": true,
    "min_interval_seconds": 5
  }
}
```

Resolves #119