### PR TITLE
feat(dev): add make air recipe and tmux dev script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ make vet             # go vet ./...
 make deps            # go mod tidy
 make test-integration # Run email integration tests
 make release-check   # Verify VERSION is set (not "dev")
+make air             # Start a dev server in a new tmux pane using `air`
 ```
 
 Always build with the `whatsapp_native` tag:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LDFLAGS     := -X $(VERSION_PKG).Version=$(VERSION) \
                -X $(VERSION_PKG).BuildTime=$(BUILDTIME) \
                -X $(VERSION_PKG).GoVersion=$(GOVER)
 
-.PHONY: build test install lint fmt vet deps test-integration release-check publish-version publish-version-dry-run
+.PHONY: build test install lint fmt vet deps test-integration release-check publish-version publish-version-dry-run air
 
 build:
 	CGO_ENABLED=0 go build -tags whatsapp_native -ldflags "$(LDFLAGS)" -o $(BINARY) .
@@ -57,3 +57,6 @@ publish-version:
 
 publish-version-dry-run:
 	./scripts/publish-version.sh --dry-run
+
+air:
+	./script/deh.sh

--- a/script/deh.sh
+++ b/script/deh.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate we are inside a tmux session
+if [ -z "${TMUX:-}" ]; then
+  echo "Error: not running inside a tmux session." >&2
+  exit 1
+fi
+
+# Get current session and window
+SESSION=$(tmux display-message -p '#S')
+WINDOW=$(tmux display-message -p '#I')
+
+# Split current pane vertically and run air in the new pane
+tmux split-window -v -t "${SESSION}:${WINDOW}" "air"
+
+# Give air a moment to start
+sleep 2
+
+# Capture last 5 lines from the new (bottom/right) pane to validate server is running
+NEW_PANE=$(tmux display-message -p '#P')
+# Since we split, the new pane is usually the one with the highest index or active pane.
+# We'll capture from the last pane in the window.
+PANES=$(tmux list-panes -t "${SESSION}:${WINDOW}" -F '#P')
+TARGET_PANE=$(echo "$PANES" | tail -n 1)
+
+echo "--- Air pane log (last 5 lines) ---"
+tmux capture-pane -t "${SESSION}:${WINDOW}.${TARGET_PANE}" -p | tail -n 5
+
+echo "---"
+echo "Air is running in pane ${TARGET_PANE} of window ${WINDOW}."


### PR DESCRIPTION
## Summary

Adds a `make air` recipe for quickly spinning up a live-reload dev server inside a tmux session. This is useful for local development when iterating on the gateway or chat commands.

### Changes
- **script/deh.sh**: New tmux helper script that:
  1. Validates the current shell is inside a tmux session
  2. Splits the current pane vertically and runs `air`
  3. Captures the last 5 lines from the new pane to confirm the server started
- **Makefile**: Adds `air` phony target that invokes `script/deh.sh`
- **AGENTS.md**: Updates the build commands reference table to document `make air`

## Test plan

- `make test` — all tests pass
- `make lint` — no issues
- Verified `script/deh.sh` is executable and syntax is valid via `bash -n`

## Known gaps

None.