### PR TITLE
feat(websocket): add websocket channel

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -60,6 +60,23 @@
       "poll_interval_secs": 30,
       "allow_from": [],
       "reasoning_channel_id": ""
+    },
+    "websocket": {
+      "enabled": false,
+      "type": "websocket",
+      "token": "env://PICO_TOKEN",
+      "allow_token_query": false,
+      "allow_origins": ["*"],
+      "ping_interval": 30,
+      "read_timeout": 60,
+      "write_timeout": 30,
+      "max_connections": 100,
+      "port": 18801,
+      "allow_from": ["*"],
+      "placeholder": {
+        "enabled": true,
+        "text": ["Thinking..."]
+      }
     }
   },
   "gateway": {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/emersion/go-message v0.18.2
 	github.com/gomarkdown/markdown v0.0.0-20260412113850-134a5b2cce7f
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/mdp/qrterminal/v3 v3.2.1
 	github.com/mymmrac/telego v1.8.0
 	github.com/robfig/cron/v3 v3.0.1
@@ -54,7 +55,6 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.7 // indirect
 	github.com/googleapis/gax-go/v2 v2.16.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grbit/go-json v0.11.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 
 	// Register owned channel implementations.
 	_ "github.com/sushi30/sushiclaw/pkg/channels/email"
+	_ "github.com/sushi30/sushiclaw/pkg/channels/websocket"
 	_ "github.com/sushi30/sushiclaw/pkg/channels/telegram"
 	_ "github.com/sushi30/sushiclaw/pkg/channels/whatsapp_native"
 )

--- a/pkg/bus/types.go
+++ b/pkg/bus/types.go
@@ -47,6 +47,15 @@ type InboundMessage struct {
 	MessageID string `json:"message_id,omitempty"`
 }
 
+// ContextUsage describes how much of the model's context window the current
+// session consumes, and how far it is from triggering compression.
+type ContextUsage struct {
+	UsedTokens       int `json:"used_tokens"`
+	TotalTokens      int `json:"total_tokens"`       // model context window
+	CompressAtTokens int `json:"compress_at_tokens"` // threshold that triggers compression
+	UsedPercent      int `json:"used_percent"`       // 0-100
+}
+
 // OutboundScope captures structured session scope without depending on the session package.
 type OutboundScope struct {
 	Version    int               `json:"version,omitempty"`
@@ -64,6 +73,7 @@ type OutboundMessage struct {
 	AgentID          string         `json:"agent_id,omitempty"`
 	SessionKey       string         `json:"session_key,omitempty"`
 	Scope            *OutboundScope `json:"scope,omitempty"`
+	ContextUsage     *ContextUsage  `json:"context_usage,omitempty"`
 	Content          string         `json:"content"`
 	ReplyToMessageID string         `json:"reply_to_message_id,omitempty"`
 }

--- a/pkg/channels/tool_feedback_animator.go
+++ b/pkg/channels/tool_feedback_animator.go
@@ -1,0 +1,248 @@
+package channels
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+)
+
+const toolFeedbackAnimationInterval = 3 * time.Second
+
+const initialToolFeedbackAnimationFrame = ""
+
+var toolFeedbackAnimationFrames = []string{"..", "."}
+
+// MaxToolFeedbackAnimationFrameLength returns the largest frame suffix length
+// so callers can reserve room before sending messages to length-limited APIs.
+func MaxToolFeedbackAnimationFrameLength() int {
+	maxLen := len([]rune(initialToolFeedbackAnimationFrame))
+	for _, frame := range toolFeedbackAnimationFrames {
+		if frameLen := len([]rune(frame)); frameLen > maxLen {
+			maxLen = frameLen
+		}
+	}
+	return maxLen
+}
+
+type toolFeedbackAnimationState struct {
+	messageID   string
+	baseContent string
+	stop        chan struct{}
+	done        chan struct{}
+}
+
+// ToolFeedbackAnimator tracks and animates tool-feedback messages for a channel.
+type ToolFeedbackAnimator struct {
+	mu      sync.Mutex
+	editFn  func(ctx context.Context, chatID, messageID, content string) error
+	entries map[string]*toolFeedbackAnimationState
+}
+
+// NewToolFeedbackAnimator creates a new animator with the given edit function.
+func NewToolFeedbackAnimator(
+	editFn func(ctx context.Context, chatID, messageID, content string) error,
+) *ToolFeedbackAnimator {
+	return &ToolFeedbackAnimator{
+		editFn:  editFn,
+		entries: make(map[string]*toolFeedbackAnimationState),
+	}
+}
+
+// Current returns the current tracked message ID for a chat, if any.
+func (a *ToolFeedbackAnimator) Current(chatID string) (string, bool) {
+	if a == nil || strings.TrimSpace(chatID) == "" {
+		return "", false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	entry, ok := a.entries[chatID]
+	if !ok || strings.TrimSpace(entry.messageID) == "" {
+		return "", false
+	}
+	return entry.messageID, true
+}
+
+// Record starts tracking a tool-feedback message for a chat.
+func (a *ToolFeedbackAnimator) Record(chatID, messageID, content string) {
+	if a == nil {
+		return
+	}
+	chatID = strings.TrimSpace(chatID)
+	messageID = strings.TrimSpace(messageID)
+	content = strings.TrimSpace(content)
+	if chatID == "" || messageID == "" || content == "" {
+		return
+	}
+
+	entry := &toolFeedbackAnimationState{
+		messageID:   messageID,
+		baseContent: content,
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
+	}
+
+	var previous *toolFeedbackAnimationState
+	a.mu.Lock()
+	if old, ok := a.entries[chatID]; ok {
+		previous = old
+	}
+	a.entries[chatID] = entry
+	a.mu.Unlock()
+
+	stopToolFeedbackAnimation(previous)
+	go a.run(chatID, entry)
+}
+
+// Clear stops tracking the tool-feedback message for a chat.
+func (a *ToolFeedbackAnimator) Clear(chatID string) {
+	if a == nil || strings.TrimSpace(chatID) == "" {
+		return
+	}
+	entry := a.detach(chatID)
+	stopToolFeedbackAnimation(entry)
+}
+
+// Take stops tracking and returns the current tracked state for a chat.
+func (a *ToolFeedbackAnimator) Take(chatID string) (string, string, bool) {
+	if a == nil || strings.TrimSpace(chatID) == "" {
+		return "", "", false
+	}
+	entry := a.detach(chatID)
+	if entry == nil || strings.TrimSpace(entry.messageID) == "" {
+		return "", "", false
+	}
+	stopToolFeedbackAnimation(entry)
+	return entry.messageID, entry.baseContent, true
+}
+
+// Update edits an existing tracked feedback message. If the edit fails, the
+// previous feedback state is restored so callers can retry without orphaning
+// the old progress message.
+func (a *ToolFeedbackAnimator) Update(ctx context.Context, chatID, content string) (string, bool, error) {
+	if a == nil || a.editFn == nil {
+		return "", false, nil
+	}
+	msgID, baseContent, ok := a.Take(chatID)
+	if !ok {
+		return "", false, nil
+	}
+
+	animatedContent := InitialAnimatedToolFeedbackContent(content)
+	if err := a.editFn(ctx, strings.TrimSpace(chatID), msgID, animatedContent); err != nil {
+		a.Record(chatID, msgID, baseContent)
+		return "", true, err
+	}
+
+	a.Record(chatID, msgID, content)
+	return msgID, true, nil
+}
+
+// StopAll stops all running animations.
+func (a *ToolFeedbackAnimator) StopAll() {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	entries := make([]*toolFeedbackAnimationState, 0, len(a.entries))
+	for chatID, entry := range a.entries {
+		entries = append(entries, entry)
+		delete(a.entries, chatID)
+	}
+	a.mu.Unlock()
+
+	for _, entry := range entries {
+		stopToolFeedbackAnimation(entry)
+	}
+}
+
+func (a *ToolFeedbackAnimator) detach(chatID string) *toolFeedbackAnimationState {
+	if a == nil || strings.TrimSpace(chatID) == "" {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	entry := a.entries[chatID]
+	delete(a.entries, chatID)
+	return entry
+}
+
+func (a *ToolFeedbackAnimator) run(chatID string, entry *toolFeedbackAnimationState) {
+	defer close(entry.done)
+
+	ticker := time.NewTicker(toolFeedbackAnimationInterval)
+	defer ticker.Stop()
+
+	frameIdx := 1
+
+	for {
+		select {
+		case <-entry.stop:
+			return
+		case <-ticker.C:
+			if a.editFn == nil {
+				continue
+			}
+			frame := toolFeedbackAnimationFrames[frameIdx%len(toolFeedbackAnimationFrames)]
+			content := formatAnimatedToolFeedbackContent(entry.baseContent, frame)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = a.editFn(ctx, chatID, entry.messageID, content)
+			cancel()
+			frameIdx++
+		}
+	}
+}
+
+// InitialAnimatedToolFeedbackContent returns the base content with the initial animation frame.
+func InitialAnimatedToolFeedbackContent(baseContent string) string {
+	return formatAnimatedToolFeedbackContent(baseContent, initialToolFeedbackAnimationFrame)
+}
+
+func formatAnimatedToolFeedbackContent(baseContent, frame string) string {
+	baseContent = strings.TrimSpace(baseContent)
+	frame = strings.TrimSpace(frame)
+	if baseContent == "" {
+		return ""
+	}
+	if frame == "" {
+		return baseContent
+	}
+	lineBreak := strings.IndexByte(baseContent, '\n')
+	if lineBreak < 0 {
+		return appendToolFeedbackFrame(baseContent, frame)
+	}
+	return appendToolFeedbackFrame(baseContent[:lineBreak], frame) + baseContent[lineBreak:]
+}
+
+func appendToolFeedbackFrame(firstLine, frame string) string {
+	firstLine = strings.TrimSpace(firstLine)
+	frame = strings.TrimSpace(frame)
+	if firstLine == "" {
+		return ""
+	}
+	if frame == "" {
+		return firstLine
+	}
+
+	openTick := strings.IndexByte(firstLine, '`')
+	if openTick >= 0 {
+		if closeOffset := strings.IndexByte(firstLine[openTick+1:], '`'); closeOffset >= 0 {
+			closeTick := openTick + 1 + closeOffset
+			return firstLine[:closeTick] + frame + firstLine[closeTick:]
+		}
+	}
+
+	return firstLine + frame
+}
+
+func stopToolFeedbackAnimation(entry *toolFeedbackAnimationState) {
+	if entry == nil {
+		return
+	}
+	select {
+	case <-entry.stop:
+	default:
+		close(entry.stop)
+	}
+	<-entry.done
+}

--- a/pkg/channels/tool_feedback_animator_test.go
+++ b/pkg/channels/tool_feedback_animator_test.go
@@ -1,0 +1,121 @@
+package channels
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestFormatAnimatedToolFeedbackContent(t *testing.T) {
+	got := formatAnimatedToolFeedbackContent("🔧 `read_file`\nReading config file", "running..")
+	want := "🔧 `read_filerunning..`\nReading config file"
+	if got != want {
+		t.Fatalf("formatAnimatedToolFeedbackContent() = %q, want %q", got, want)
+	}
+}
+
+func TestInitialAnimatedToolFeedbackContent(t *testing.T) {
+	got := InitialAnimatedToolFeedbackContent("🔧 `exec`\nRunning command")
+	want := "🔧 `exec`\nRunning command"
+	if got != want {
+		t.Fatalf("InitialAnimatedToolFeedbackContent() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatAnimatedToolFeedbackContent_WithoutCodeSpan(t *testing.T) {
+	got := formatAnimatedToolFeedbackContent("hello", "running..")
+	want := "hellorunning.."
+	if got != want {
+		t.Fatalf("formatAnimatedToolFeedbackContent() without code span = %q, want %q", got, want)
+	}
+}
+
+func TestToolFeedbackAnimator_RecordCurrentAndClear(t *testing.T) {
+	animator := NewToolFeedbackAnimator(nil)
+	animator.Record("chat-1", "msg-1", "🔧 `read_file`")
+
+	msgID, ok := animator.Current("chat-1")
+	if !ok || msgID != "msg-1" {
+		t.Fatalf("Current() = (%q, %v), want (msg-1, true)", msgID, ok)
+	}
+
+	animator.Clear("chat-1")
+
+	msgID, ok = animator.Current("chat-1")
+	if ok || msgID != "" {
+		t.Fatalf("Current() after Clear = (%q, %v), want (\"\", false)", msgID, ok)
+	}
+}
+
+func TestToolFeedbackAnimator_TakeStopsTrackingAndReturnsState(t *testing.T) {
+	animator := NewToolFeedbackAnimator(nil)
+	animator.Record("chat-1", "msg-1", "🔧 `read_file`\nChecking config")
+
+	msgID, baseContent, ok := animator.Take("chat-1")
+	if !ok {
+		t.Fatal("Take() = not found, want tracked message")
+	}
+	if msgID != "msg-1" {
+		t.Fatalf("Take() msgID = %q, want msg-1", msgID)
+	}
+	if baseContent != "🔧 `read_file`\nChecking config" {
+		t.Fatalf("Take() baseContent = %q", baseContent)
+	}
+	if _, ok := animator.Current("chat-1"); ok {
+		t.Fatal("expected tracked message to be removed after Take()")
+	}
+}
+
+func TestToolFeedbackAnimator_UpdateStopsTrackingBeforeEdit(t *testing.T) {
+	var animator *ToolFeedbackAnimator
+	animator = NewToolFeedbackAnimator(func(_ context.Context, chatID, messageID, content string) error {
+		if _, ok := animator.Current(chatID); ok {
+			t.Fatal("expected tracked tool feedback to be stopped before edit")
+		}
+		if messageID != "msg-1" {
+			t.Fatalf("messageID = %q, want msg-1", messageID)
+		}
+		if content != "🔧 `write_file`\nUpdating config" {
+			t.Fatalf("content = %q, want updated animated content", content)
+		}
+		return nil
+	})
+	defer animator.StopAll()
+
+	animator.Record("chat-1", "msg-1", "🔧 `read_file`\nChecking config")
+
+	msgID, handled, err := animator.Update(context.Background(), "chat-1", "🔧 `write_file`\nUpdating config")
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if !handled {
+		t.Fatal("Update() handled = false, want true")
+	}
+	if msgID != "msg-1" {
+		t.Fatalf("Update() msgID = %q, want msg-1", msgID)
+	}
+}
+
+func TestToolFeedbackAnimator_UpdateFailureRestoresTracking(t *testing.T) {
+	editErr := errors.New("edit failed")
+	animator := NewToolFeedbackAnimator(func(context.Context, string, string, string) error {
+		return editErr
+	})
+	defer animator.StopAll()
+
+	animator.Record("chat-1", "msg-1", "🔧 `read_file`\nChecking config")
+
+	msgID, handled, err := animator.Update(context.Background(), "chat-1", "🔧 `write_file`\nUpdating config")
+	if !handled {
+		t.Fatal("Update() handled = false, want true")
+	}
+	if !errors.Is(err, editErr) {
+		t.Fatalf("Update() error = %v, want editErr", err)
+	}
+	if msgID != "" {
+		t.Fatalf("Update() msgID = %q, want empty on failed edit", msgID)
+	}
+	if currentID, ok := animator.Current("chat-1"); !ok || currentID != "msg-1" {
+		t.Fatalf("Current() after failed Update = (%q, %v), want (msg-1, true)", currentID, ok)
+	}
+}

--- a/pkg/channels/websocket/client.go
+++ b/pkg/channels/websocket/client.go
@@ -1,0 +1,331 @@
+package websocket
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/channels"
+	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/identity"
+	"github.com/sushi30/sushiclaw/pkg/logger"
+)
+
+// WebSocketClientChannel connects to a remote Pico Protocol WebSocket server.
+type WebSocketClientChannel struct {
+	*channels.BaseChannel
+	config *config.WebSocketClientSettings
+	conn   *wsConn
+	mu     sync.Mutex
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewWebSocketClientChannel creates a new Pico Protocol client channel.
+func NewWebSocketClientChannel(
+	bc *config.Channel,
+	cfg *config.WebSocketClientSettings,
+	messageBus *bus.MessageBus,
+) (*WebSocketClientChannel, error) {
+	if cfg.URL == "" {
+		return nil, fmt.Errorf("pico_client url is required")
+	}
+
+	base := channels.NewBaseChannel("websocket_client", cfg, messageBus, bc.AllowFrom)
+
+	return &WebSocketClientChannel{
+		BaseChannel: base,
+		config:      cfg,
+	}, nil
+}
+
+// Start dials the remote server and begins reading.
+func (c *WebSocketClientChannel) Start(ctx context.Context) error {
+	logger.InfoC("websocket_client", "Starting Pico Client channel")
+	c.ctx, c.cancel = context.WithCancel(ctx)
+
+	if err := c.dial(); err != nil {
+		c.cancel()
+		return fmt.Errorf("pico_client initial connect: %w", err)
+	}
+
+	c.SetRunning(true)
+	go c.reconnectLoop()
+
+	logger.InfoCF("websocket_client", "Connected", map[string]any{"url": c.config.URL})
+	return nil
+}
+
+// Stop closes the connection.
+func (c *WebSocketClientChannel) Stop(ctx context.Context) error {
+	logger.InfoC("websocket_client", "Stopping Pico Client channel")
+	c.SetRunning(false)
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.mu.Lock()
+	if c.conn != nil {
+		c.conn.close()
+	}
+	c.mu.Unlock()
+	logger.InfoC("websocket_client", "Pico Client channel stopped")
+	return nil
+}
+
+func (c *WebSocketClientChannel) dial() error {
+	header := http.Header{}
+	if c.config.Token.String() != "" {
+		header.Set("Authorization", "Bearer "+c.config.Token.String())
+	}
+
+	ws, resp, err := websocket.DefaultDialer.DialContext(c.ctx, c.config.URL, header)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	connCtx, connCancel := context.WithCancel(c.ctx)
+
+	pc := &wsConn{
+		id:        uuid.New().String(),
+		conn:      ws,
+		sessionID: c.config.SessionID,
+		cancel:    connCancel,
+	}
+	if pc.sessionID == "" {
+		pc.sessionID = uuid.New().String()
+	}
+
+	c.mu.Lock()
+	c.conn = pc
+	c.mu.Unlock()
+
+	go c.readLoop(connCtx, pc)
+	return nil
+}
+
+// reconnectLoop re-dials when the connection drops.
+func (c *WebSocketClientChannel) reconnectLoop() {
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		default:
+		}
+
+		c.mu.Lock()
+		pc := c.conn
+		c.mu.Unlock()
+
+		if pc == nil || pc.closed.Load() {
+			backoff := 5 * time.Second
+			logger.InfoC("websocket_client", "Reconnecting...")
+			if err := c.dial(); err != nil {
+				logger.WarnCF("websocket_client", "Reconnect failed", map[string]any{
+					"error": err.Error(),
+				})
+				select {
+				case <-c.ctx.Done():
+					return
+				case <-time.After(backoff):
+				}
+				continue
+			}
+			logger.InfoC("websocket_client", "Reconnected")
+		}
+
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-time.After(1 * time.Second):
+		}
+	}
+}
+
+func (c *WebSocketClientChannel) readLoop(connCtx context.Context, pc *wsConn) {
+	defer pc.close()
+
+	readTimeout := time.Duration(c.config.ReadTimeout) * time.Second
+	if readTimeout <= 0 {
+		readTimeout = 60 * time.Second
+	}
+
+	_ = pc.conn.SetReadDeadline(time.Now().Add(readTimeout))
+	pc.conn.SetPongHandler(func(string) error {
+		return pc.conn.SetReadDeadline(time.Now().Add(readTimeout))
+	})
+
+	pingInterval := time.Duration(c.config.PingInterval) * time.Second
+	if pingInterval <= 0 {
+		pingInterval = 30 * time.Second
+	}
+	go c.pingLoop(connCtx, pc, pingInterval)
+
+	for {
+		select {
+		case <-connCtx.Done():
+			return
+		default:
+		}
+
+		_, raw, err := pc.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(
+				err,
+				websocket.CloseGoingAway,
+				websocket.CloseNormalClosure,
+			) {
+				logger.DebugCF("websocket_client", "Read error", map[string]any{
+					"error": err.Error(),
+				})
+			}
+			return
+		}
+
+		_ = pc.conn.SetReadDeadline(time.Now().Add(readTimeout))
+
+		var msg WebSocketMessage
+		if err := json.Unmarshal(raw, &msg); err != nil {
+			continue
+		}
+
+		c.handleInbound(pc, msg)
+	}
+}
+
+func (c *WebSocketClientChannel) pingLoop(connCtx context.Context, pc *wsConn, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-connCtx.Done():
+			return
+		case <-ticker.C:
+			if pc.closed.Load() {
+				return
+			}
+			pc.writeMu.Lock()
+			err := pc.conn.WriteMessage(websocket.PingMessage, nil)
+			pc.writeMu.Unlock()
+			if err != nil {
+				return
+			}
+		}
+	}
+}
+
+// handleInbound processes messages from the remote server.
+// In client mode the server sends message.create (responses) and the client
+// sends message.send (user input). We treat message.create from the server
+// as inbound user messages to feed into the agent loop.
+func (c *WebSocketClientChannel) handleInbound(pc *wsConn, msg WebSocketMessage) {
+	switch msg.Type {
+	case TypePong:
+		// response to our ping, ignore
+	case TypeMessageCreate:
+		// Server sent us a message — treat as inbound
+		c.handleServerMessage(pc, msg)
+	default:
+		logger.DebugCF("websocket_client", "Ignoring message type", map[string]any{
+			"type": msg.Type,
+		})
+	}
+}
+
+func (c *WebSocketClientChannel) handleServerMessage(pc *wsConn, msg WebSocketMessage) {
+	if isThoughtPayload(msg.Payload) {
+		return
+	}
+
+	content, _ := msg.Payload[PayloadKeyContent].(string)
+	if strings.TrimSpace(content) == "" {
+		return
+	}
+
+	sessionID := msg.SessionID
+	if sessionID == "" {
+		sessionID = pc.sessionID
+	}
+
+	chatID := "websocket_client:" + sessionID
+	senderID := "websocket-remote"
+	sender := bus.SenderInfo{
+		Platform:    "websocket_client",
+		PlatformID:  senderID,
+		CanonicalID: identity.BuildCanonicalID("websocket_client", senderID),
+	}
+
+	if !c.IsAllowedSender(sender) {
+		return
+	}
+
+	inboundCtx := bus.InboundContext{
+		Channel:   "websocket_client",
+		ChatID:    chatID,
+		ChatType:  "direct",
+		SenderID:  senderID,
+		MessageID: msg.ID,
+		Raw: map[string]string{
+			"platform":   "websocket_client",
+			"session_id": sessionID,
+		},
+	}
+
+	c.HandleInboundContext(c.ctx, chatID, content, nil, inboundCtx, sender)
+}
+
+// Send sends a message to the remote server.
+func (c *WebSocketClientChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]string, error) {
+	if !c.IsRunning() {
+		return nil, channels.ErrNotRunning
+	}
+	c.mu.Lock()
+	pc := c.conn
+	c.mu.Unlock()
+	if pc == nil || pc.closed.Load() {
+		return nil, channels.ErrSendFailed
+	}
+
+	outMsg := newMessage(TypeMessageSend, map[string]any{
+		PayloadKeyContent: msg.Content,
+	})
+	outMsg.SessionID = strings.TrimPrefix(msg.ChatID, "websocket_client:")
+	return nil, pc.writeJSON(outMsg)
+}
+
+// StartTyping implements channels.TypingCapable.
+func (c *WebSocketClientChannel) StartTyping(ctx context.Context, chatID string) (func(), error) {
+	c.mu.Lock()
+	pc := c.conn
+	c.mu.Unlock()
+	if pc == nil || pc.closed.Load() {
+		return func() {}, nil
+	}
+
+	startMsg := newMessage(TypeTypingStart, nil)
+	startMsg.SessionID = strings.TrimPrefix(chatID, "websocket_client:")
+	if err := pc.writeJSON(startMsg); err != nil {
+		return func() {}, err
+	}
+	return func() {
+		c.mu.Lock()
+		currentPC := c.conn
+		c.mu.Unlock()
+		if currentPC == nil {
+			return
+		}
+		stopMsg := newMessage(TypeTypingStop, nil)
+		stopMsg.SessionID = strings.TrimPrefix(chatID, "websocket_client:")
+		_ = currentPC.writeJSON(stopMsg)
+	}, nil
+}

--- a/pkg/channels/websocket/client_test.go
+++ b/pkg/channels/websocket/client_test.go
@@ -1,0 +1,392 @@
+package websocket
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/channels"
+	"github.com/sushi30/sushiclaw/pkg/config"
+)
+
+func TestNewWebSocketClientChannel_MissingURL(t *testing.T) {
+	bc := &config.Channel{Type: config.ChannelWebSocketClient, Enabled: true}
+	_, err := NewWebSocketClientChannel(bc, &config.WebSocketClientSettings{}, bus.NewMessageBus())
+	if err == nil {
+		t.Fatal("expected error for missing URL")
+	}
+	if !strings.Contains(err.Error(), "url is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewWebSocketClientChannel_OK(t *testing.T) {
+	bc := &config.Channel{Type: config.ChannelWebSocketClient, Enabled: true}
+	ch, err := NewWebSocketClientChannel(bc, &config.WebSocketClientSettings{
+		URL: "ws://localhost:9999/ws",
+	}, bus.NewMessageBus())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ch.Name() != "websocket_client" {
+		t.Fatalf("name = %q, want pico_client", ch.Name())
+	}
+}
+
+func TestSend_NotRunning(t *testing.T) {
+	bc := &config.Channel{Type: config.ChannelWebSocketClient, Enabled: true}
+	ch, err := NewWebSocketClientChannel(bc, &config.WebSocketClientSettings{
+		URL: "ws://localhost:9999/ws",
+	}, bus.NewMessageBus())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ch.Send(context.Background(), bus.OutboundMessage{Content: "hi"})
+	if !errors.Is(err, channels.ErrNotRunning) {
+		t.Fatalf("expected ErrNotRunning, got %v", err)
+	}
+}
+
+// testServer starts a WS server that echoes message.send back as message.create.
+func testServer(t *testing.T, token string) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if token != "" {
+			auth := r.Header.Get("Authorization")
+			if auth != "Bearer "+token {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Logf("upgrade error: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		for {
+			_, raw, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+
+			var msg WebSocketMessage
+			if err := json.Unmarshal(raw, &msg); err != nil {
+				continue
+			}
+
+			if msg.Type == TypeMessageSend {
+				reply := newMessage(TypeMessageCreate, msg.Payload)
+				reply.SessionID = msg.SessionID
+				if err := conn.WriteJSON(reply); err != nil {
+					return
+				}
+			}
+		}
+	}))
+}
+
+func wsURL(httpURL string) string {
+	return "ws" + strings.TrimPrefix(httpURL, "http")
+}
+
+func TestClientChannel_ConnectAndSend(t *testing.T) {
+	srv := testServer(t, "test-token")
+	defer srv.Close()
+
+	mb := bus.NewMessageBus()
+	bc := &config.Channel{Type: config.ChannelWebSocketClient, Enabled: true}
+	ch, err := NewWebSocketClientChannel(bc, &config.WebSocketClientSettings{
+		URL:          wsURL(srv.URL),
+		Token:        *config.NewSecureString("test-token"),
+		SessionID:    "sess-1",
+		PingInterval: 60,
+		ReadTimeout:  10,
+	}, mb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err = ch.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = ch.Stop(ctx) }()
+
+	// Send a message
+	_, err = ch.Send(ctx, bus.OutboundMessage{
+		ChatID:  "websocket_client:sess-1",
+		Content: "hello",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+}
+
+func TestClientChannel_AuthFailure(t *testing.T) {
+	srv := testServer(t, "correct-token")
+	defer srv.Close()
+
+	bc := &config.Channel{Type: config.ChannelWebSocketClient, Enabled: true}
+	ch, err := NewWebSocketClientChannel(bc, &config.WebSocketClientSettings{
+		URL:   wsURL(srv.URL),
+		Token: *config.NewSecureString("wrong-token"),
+	}, bus.NewMessageBus())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err = ch.Start(ctx)
+	if err == nil {
+		_ = ch.Stop(ctx)
+		t.Fatal("expected auth failure")
+	}
+}
+
+func TestClientChannel_ReceivesServerMessage(t *testing.T) {
+	srv := testServer(t, "")
+	defer srv.Close()
+
+	mb := bus.NewMessageBus()
+
+	bc := &config.Channel{Type: config.ChannelWebSocketClient, Enabled: true}
+	ch, err := NewWebSocketClientChannel(bc, &config.WebSocketClientSettings{
+		URL:         wsURL(srv.URL),
+		SessionID:   "sess-echo",
+		ReadTimeout: 10,
+	}, mb)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err = ch.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = ch.Stop(ctx) }()
+
+	// Send a message; the echo server replies with message.create
+	_, err = ch.Send(ctx, bus.OutboundMessage{
+		ChatID:  "websocket_client:sess-echo",
+		Content: "ping",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	// The echoed message.create is processed by handleServerMessage which
+	// calls HandleMessage → PublishInbound. Consume it from the bus.
+	select {
+	case msg := <-mb.InboundChan():
+		if msg.Content != "ping" {
+			t.Fatalf("received = %q, want %q", msg.Content, "ping")
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for echoed message")
+	}
+}
+
+func TestClientChannel_StartTyping(t *testing.T) {
+	srv := testServer(t, "")
+	defer srv.Close()
+
+	bc := &config.Channel{Type: config.ChannelWebSocketClient, Enabled: true}
+	ch, err := NewWebSocketClientChannel(bc, &config.WebSocketClientSettings{
+		URL:         wsURL(srv.URL),
+		SessionID:   "sess-type",
+		ReadTimeout: 10,
+	}, bus.NewMessageBus())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err = ch.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = ch.Stop(ctx) }()
+
+	stop, err := ch.StartTyping(ctx, "websocket_client:sess-type")
+	if err != nil {
+		t.Fatalf("StartTyping: %v", err)
+	}
+	stop() // should not panic
+}
+
+func TestSend_ClosedConnection(t *testing.T) {
+	srv := testServer(t, "")
+	defer srv.Close()
+
+	bc := &config.Channel{Type: config.ChannelWebSocketClient, Enabled: true}
+	ch, err := NewWebSocketClientChannel(bc, &config.WebSocketClientSettings{
+		URL:         wsURL(srv.URL),
+		SessionID:   "sess-close",
+		ReadTimeout: 10,
+	}, bus.NewMessageBus())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err = ch.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Force close the underlying connection
+	ch.mu.Lock()
+	ch.conn.close()
+	ch.mu.Unlock()
+
+	_, err = ch.Send(ctx, bus.OutboundMessage{
+		ChatID:  "websocket_client:sess-close",
+		Content: "should fail",
+	})
+	if !errors.Is(err, channels.ErrSendFailed) {
+		t.Fatalf("expected ErrSendFailed, got %v", err)
+	}
+
+	_ = ch.Stop(ctx)
+}
+
+func TestParseInlineImageMedia_Valid(t *testing.T) {
+	media, err := parseInlineImageMedia(map[string]any{
+		"media": []any{
+			"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=",
+		},
+	})
+	if err != nil {
+		t.Fatalf("parseInlineImageMedia() error = %v", err)
+	}
+	if len(media) != 1 {
+		t.Fatalf("len(media) = %d, want 1", len(media))
+	}
+}
+
+func TestWebSocketChannel_HandleMessageSend_AllowsMediaOnly(t *testing.T) {
+	mb := bus.NewMessageBus()
+	bc := &config.Channel{Type: "websocket", Enabled: true}
+	ch, err := NewWebSocketChannel(bc, &config.WebSocketSettings{
+		Token: *config.NewSecureString("test-token"),
+	}, mb)
+	if err != nil {
+		t.Fatalf("NewWebSocketChannel() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := ch.Start(ctx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer func() { _ = ch.Stop(ctx) }()
+
+	pc := &wsConn{id: "conn-1", sessionID: "sess-1"}
+	ch.handleMessageSend(pc, WebSocketMessage{
+		ID: "msg-1",
+		Payload: map[string]any{
+			"media": []any{
+				"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2ioAAAAASUVORK5CYII=",
+			},
+		},
+	})
+
+	select {
+	case msg := <-mb.InboundChan():
+		if msg.Content != "" {
+			t.Fatalf("msg.Content = %q, want empty", msg.Content)
+		}
+		if len(msg.Media) != 1 || !strings.HasPrefix(msg.Media[0], "data:image/png;base64,") {
+			t.Fatalf("msg.Media = %#v, want inline image payload", msg.Media)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for inbound media message")
+	}
+}
+
+func TestIsThoughtPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]any
+		want    bool
+	}{
+		{
+			name:    "explicit thought bool",
+			payload: map[string]any{PayloadKeyThought: true},
+			want:    true,
+		},
+		{
+			name:    "thought false",
+			payload: map[string]any{PayloadKeyThought: false},
+			want:    false,
+		},
+		{
+			name:    "thought string ignored",
+			payload: map[string]any{PayloadKeyThought: "true"},
+			want:    false,
+		},
+		{
+			name:    "default normal",
+			payload: map[string]any{PayloadKeyContent: "hello"},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isThoughtPayload(tt.payload); got != tt.want {
+				t.Fatalf("isThoughtPayload() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWebSocketClientChannel_HandleServerMessage_IgnoresThought(t *testing.T) {
+	mb := bus.NewMessageBus()
+	bc := &config.Channel{Type: config.ChannelWebSocketClient, Enabled: true}
+	ch, err := NewWebSocketClientChannel(bc, &config.WebSocketClientSettings{
+		URL: "ws://localhost:8080/ws",
+	}, mb)
+	if err != nil {
+		t.Fatalf("NewWebSocketClientChannel() error = %v", err)
+	}
+
+	ch.ctx = context.Background()
+	pc := &wsConn{sessionID: "sess-thought"}
+
+	ch.handleServerMessage(pc, WebSocketMessage{
+		Type: TypeMessageCreate,
+		Payload: map[string]any{
+			PayloadKeyContent: "internal reasoning",
+			PayloadKeyThought: true,
+		},
+	})
+
+	select {
+	case msg := <-mb.InboundChan():
+		t.Fatalf("expected no inbound publish for thought payload, got %+v", msg)
+	case <-time.After(150 * time.Millisecond):
+	}
+}

--- a/pkg/channels/websocket/init.go
+++ b/pkg/channels/websocket/init.go
@@ -1,0 +1,18 @@
+package websocket
+
+import (
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/channels"
+	"github.com/sushi30/sushiclaw/pkg/config"
+)
+
+func init() {
+	channels.RegisterSafeFactory(config.ChannelWebSocket,
+		func(bc *config.Channel, cfg *config.WebSocketSettings, b *bus.MessageBus) (channels.Channel, error) {
+			return NewWebSocketChannel(bc, cfg, b)
+		})
+	channels.RegisterSafeFactory(config.ChannelWebSocketClient,
+		func(bc *config.Channel, cfg *config.WebSocketClientSettings, b *bus.MessageBus) (channels.Channel, error) {
+			return NewWebSocketClientChannel(bc, cfg, b)
+		})
+}

--- a/pkg/channels/websocket/protocol.go
+++ b/pkg/channels/websocket/protocol.go
@@ -1,0 +1,65 @@
+package websocket
+
+import "time"
+
+// Protocol message types.
+const (
+	// TypeMessageSend is sent from client to server.
+	TypeMessageSend = "message.send"
+	TypeMediaSend   = "media.send"
+	TypePing        = "ping"
+
+	// TypeMessageCreate is sent from server to client.
+	TypeMessageCreate = "message.create"
+	TypeMessageUpdate = "message.update"
+	TypeMessageDelete = "message.delete"
+	TypeMediaCreate   = "media.create"
+	TypeTypingStart   = "typing.start"
+	TypeTypingStop    = "typing.stop"
+	TypeError         = "error"
+	TypePong          = "pong"
+
+	PayloadKeyContent = "content"
+	PayloadKeyThought = "thought"
+
+	MessageKindThought = "thought"
+)
+
+// WebSocketMessage is the wire format for all Pico Protocol messages.
+type WebSocketMessage struct {
+	Type      string         `json:"type"`
+	ID        string         `json:"id,omitempty"`
+	SessionID string         `json:"session_id,omitempty"`
+	Timestamp int64          `json:"timestamp,omitempty"`
+	Payload   map[string]any `json:"payload,omitempty"`
+}
+
+// newMessage creates a WebSocketMessage with the given type and payload.
+func newMessage(msgType string, payload map[string]any) WebSocketMessage {
+	return WebSocketMessage{
+		Type:      msgType,
+		Timestamp: time.Now().UnixMilli(),
+		Payload:   payload,
+	}
+}
+
+func isThoughtPayload(payload map[string]any) bool {
+	thought, _ := payload[PayloadKeyThought].(bool)
+	return thought
+}
+
+func newErrorWithPayload(code, message string, extra map[string]any) WebSocketMessage {
+	payload := map[string]any{
+		"code":    code,
+		"message": message,
+	}
+	for key, value := range extra {
+		payload[key] = value
+	}
+	return newMessage(TypeError, payload)
+}
+
+// newError creates an error WebSocketMessage.
+func newError(code, message string) WebSocketMessage {
+	return newErrorWithPayload(code, message, nil)
+}

--- a/pkg/channels/websocket/websocket.go
+++ b/pkg/channels/websocket/websocket.go
@@ -1,0 +1,1115 @@
+package websocket
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/channels"
+	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/identity"
+	"github.com/sushi30/sushiclaw/pkg/logger"
+)
+
+// wsConn represents a single WebSocket connection.
+type wsConn struct {
+	id        string
+	conn      *websocket.Conn
+	sessionID string
+	writeMu   sync.Mutex
+	closed    atomic.Bool
+	cancel    context.CancelFunc // cancels per-connection goroutines (e.g. pingLoop)
+}
+
+var allowedInlineImageMIMETypes = map[string]struct{}{
+	"image/jpeg": {},
+	"image/png":  {},
+	"image/gif":  {},
+	"image/webp": {},
+	"image/bmp":  {},
+}
+
+func outboundMessageIsThought(msg bus.OutboundMessage) bool {
+	if len(msg.Context.Raw) == 0 {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(msg.Context.Raw["message_kind"]), MessageKindThought)
+}
+
+func outboundMessageIsToolFeedback(msg bus.OutboundMessage) bool {
+	if len(msg.Context.Raw) == 0 {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(msg.Context.Raw["message_kind"]), "tool_feedback")
+}
+
+func outboundMessageFinalizesTrackedToolFeedback(msg bus.OutboundMessage) bool {
+	return !outboundMessageIsToolFeedback(msg) && !outboundMessageIsThought(msg)
+}
+
+// writeJSON sends a JSON message to the connection with write locking.
+func (pc *wsConn) writeJSON(v any) error {
+	if pc.closed.Load() {
+		return fmt.Errorf("connection closed")
+	}
+	pc.writeMu.Lock()
+	defer pc.writeMu.Unlock()
+	return pc.conn.WriteJSON(v)
+}
+
+// close closes the connection.
+func (pc *wsConn) close() {
+	if pc.closed.CompareAndSwap(false, true) {
+		if pc.cancel != nil {
+			pc.cancel()
+		}
+		_ = pc.conn.Close()
+	}
+}
+
+// WebSocketChannel implements the native Pico Protocol WebSocket channel.
+// It serves as the reference implementation for all optional capability interfaces.
+type WebSocketChannel struct {
+	*channels.BaseChannel
+	bc                 *config.Channel
+	config             *config.WebSocketSettings
+	upgrader           websocket.Upgrader
+	connections        map[string]*wsConn            // connID -> *wsConn
+	sessionConnections map[string]map[string]*wsConn // sessionID -> connID -> *wsConn
+	connsMu            sync.RWMutex
+	ctx                context.Context
+	cancel             context.CancelFunc
+	progress           *channels.ToolFeedbackAnimator
+	deleteMessageFn    func(context.Context, string, string) error
+	httpServer         *http.Server
+}
+
+// NewWebSocketChannel creates a new Pico Protocol channel.
+func NewWebSocketChannel(
+	bc *config.Channel,
+	cfg *config.WebSocketSettings,
+	messageBus *bus.MessageBus,
+) (*WebSocketChannel, error) {
+	if cfg.Token.String() == "" {
+		return nil, fmt.Errorf("pico token is required")
+	}
+
+	base := channels.NewBaseChannel("websocket", cfg, messageBus, bc.AllowFrom)
+
+	allowOrigins := cfg.AllowOrigins
+	checkOrigin := func(r *http.Request) bool {
+		if len(allowOrigins) == 0 {
+			return true // allow all if not configured
+		}
+		origin := r.Header.Get("Origin")
+		for _, allowed := range allowOrigins {
+			if allowed == "*" || allowed == origin {
+				return true
+			}
+		}
+		return false
+	}
+
+	ch := &WebSocketChannel{
+		BaseChannel: base,
+		bc:          bc,
+		config:      cfg,
+		upgrader: websocket.Upgrader{
+			CheckOrigin:     checkOrigin,
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+		},
+		connections:        make(map[string]*wsConn),
+		sessionConnections: make(map[string]map[string]*wsConn),
+	}
+	ch.progress = channels.NewToolFeedbackAnimator(ch.EditMessage)
+	ch.deleteMessageFn = ch.DeleteMessage
+	return ch, nil
+}
+
+// createAndAddConnection checks MaxConnections and registers a connection atomically.
+func (c *WebSocketChannel) createAndAddConnection(conn *websocket.Conn, sessionID string, maxConns int) (*wsConn, error) {
+	c.connsMu.Lock()
+	defer c.connsMu.Unlock()
+	if len(c.connections) >= maxConns {
+		return nil, channels.ErrTemporary
+	}
+
+	var connID string
+	for {
+		connID = uuid.New().String()
+		if _, exists := c.connections[connID]; !exists {
+			break
+		}
+	}
+
+	pc := &wsConn{
+		id:        connID,
+		conn:      conn,
+		sessionID: sessionID,
+	}
+
+	c.connections[pc.id] = pc
+	bySession, ok := c.sessionConnections[pc.sessionID]
+	if !ok {
+		bySession = make(map[string]*wsConn)
+		c.sessionConnections[pc.sessionID] = bySession
+	}
+	bySession[pc.id] = pc
+
+	return pc, nil
+}
+
+// removeConnection deletes a connection from indexes and returns it when found.
+func (c *WebSocketChannel) removeConnection(connID string) *wsConn {
+	c.connsMu.Lock()
+	defer c.connsMu.Unlock()
+
+	pc, ok := c.connections[connID]
+	if !ok {
+		return nil
+	}
+
+	delete(c.connections, connID)
+	if bySession, ok := c.sessionConnections[pc.sessionID]; ok {
+		delete(bySession, connID)
+		if len(bySession) == 0 {
+			delete(c.sessionConnections, pc.sessionID)
+		}
+	}
+
+	return pc
+}
+
+// takeAllConnections snapshots and clears all connection indexes.
+func (c *WebSocketChannel) takeAllConnections() []*wsConn {
+	c.connsMu.Lock()
+	defer c.connsMu.Unlock()
+
+	all := make([]*wsConn, 0, len(c.connections))
+	for _, pc := range c.connections {
+		all = append(all, pc)
+	}
+	clear(c.connections)
+	clear(c.sessionConnections)
+
+	return all
+}
+
+// sessionConnectionsSnapshot returns all active connections for a session.
+func (c *WebSocketChannel) sessionConnectionsSnapshot(sessionID string) []*wsConn {
+	c.connsMu.RLock()
+	defer c.connsMu.RUnlock()
+
+	bySession, ok := c.sessionConnections[sessionID]
+	if !ok || len(bySession) == 0 {
+		return nil
+	}
+
+	conns := make([]*wsConn, 0, len(bySession))
+	for _, pc := range bySession {
+		conns = append(conns, pc)
+	}
+	return conns
+}
+
+// currentConnCount returns a lock-protected snapshot of active connection count.
+func (c *WebSocketChannel) currentConnCount() int {
+	c.connsMu.RLock()
+	defer c.connsMu.RUnlock()
+	return len(c.connections)
+}
+
+// Start implements Channel.
+func (c *WebSocketChannel) Start(ctx context.Context) error {
+	logger.InfoC("websocket", "Starting Pico Protocol channel")
+	c.ctx, c.cancel = context.WithCancel(ctx)
+	c.SetRunning(true)
+
+	port := c.config.Port
+	if port <= 0 {
+		port = 18801
+	}
+	addr := fmt.Sprintf(":%d", port)
+
+	c.httpServer = &http.Server{
+		Addr:    addr,
+		Handler: c,
+	}
+	go func() {
+		if err := c.httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.ErrorCF("websocket", "HTTP server error", map[string]any{"error": err.Error()})
+		}
+	}()
+
+	logger.InfoCF("websocket", "Pico Protocol channel started", map[string]any{"addr": addr})
+	return nil
+}
+
+// Stop implements Channel.
+func (c *WebSocketChannel) Stop(ctx context.Context) error {
+	logger.InfoC("websocket", "Stopping Pico Protocol channel")
+	c.SetRunning(false)
+
+	// Close all connections
+	for _, pc := range c.takeAllConnections() {
+		pc.close()
+	}
+
+	if c.httpServer != nil {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = c.httpServer.Shutdown(shutdownCtx)
+	}
+
+	if c.cancel != nil {
+		c.cancel()
+	}
+	if c.progress != nil {
+		c.progress.StopAll()
+	}
+
+	logger.InfoC("websocket", "Pico Protocol channel stopped")
+	return nil
+}
+
+// WebhookPath implements channels.WebhookHandler.
+func (c *WebSocketChannel) WebhookPath() string { return "/pico/" }
+
+// ServeHTTP implements http.Handler for the shared HTTP server.
+func (c *WebSocketChannel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/pico")
+
+	switch path {
+	case "/ws", "/ws/":
+		c.handleWebSocket(w, r)
+	default:
+		if strings.HasPrefix(path, "/media/") {
+			c.handleMediaDownload(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	}
+}
+
+// Send implements Channel — sends a message to the appropriate WebSocket connection.
+func (c *WebSocketChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]string, error) {
+	if !c.IsRunning() {
+		return nil, channels.ErrNotRunning
+	}
+	isThought := outboundMessageIsThought(msg)
+	isToolFeedback := outboundMessageIsToolFeedback(msg)
+	if isToolFeedback {
+		if msgID, handled, err := c.progress.Update(ctx, msg.ChatID, msg.Content); handled {
+			if err != nil {
+				return nil, err
+			}
+			return []string{msgID}, nil
+		}
+	}
+	trackedMsgID, hasTrackedMsg := c.currentToolFeedbackMessage(msg.ChatID)
+	if outboundMessageFinalizesTrackedToolFeedback(msg) {
+		if msgIDs, handled := c.FinalizeToolFeedbackMessage(ctx, msg); handled {
+			return msgIDs, nil
+		}
+	}
+
+	content := msg.Content
+	if isToolFeedback {
+		content = channels.InitialAnimatedToolFeedbackContent(msg.Content)
+	}
+	msgID := uuid.New().String()
+
+	payload := map[string]any{
+		PayloadKeyContent: content,
+		PayloadKeyThought: isThought,
+		"message_id":      msgID,
+	}
+	setContextUsagePayload(payload, msg.ContextUsage)
+	outMsg := newMessage(TypeMessageCreate, payload)
+
+	if err := c.broadcastToSession(msg.ChatID, outMsg); err != nil {
+		return nil, err
+	}
+	if isToolFeedback {
+		c.RecordToolFeedbackMessage(msg.ChatID, msgID, msg.Content)
+	} else if hasTrackedMsg && outboundMessageFinalizesTrackedToolFeedback(msg) {
+		c.dismissTrackedToolFeedbackMessage(ctx, msg.ChatID, trackedMsgID)
+	}
+	return []string{msgID}, nil
+}
+
+// EditMessage implements channels.MessageEditor.
+func (c *WebSocketChannel) EditMessage(ctx context.Context, chatID string, messageID string, content string) error {
+	return c.editMessage(ctx, chatID, messageID, content, nil)
+}
+
+// DeleteMessage implements channels.MessageDeleter.
+func (c *WebSocketChannel) DeleteMessage(ctx context.Context, chatID string, messageID string) error {
+	outMsg := newMessage(TypeMessageDelete, map[string]any{
+		"message_id": messageID,
+	})
+	return c.broadcastToSession(chatID, outMsg)
+}
+
+func (c *WebSocketChannel) currentToolFeedbackMessage(chatID string) (string, bool) {
+	if c.progress == nil {
+		return "", false
+	}
+	return c.progress.Current(chatID)
+}
+
+func (c *WebSocketChannel) takeToolFeedbackMessage(chatID string) (string, string, bool) {
+	if c.progress == nil {
+		return "", "", false
+	}
+	return c.progress.Take(chatID)
+}
+
+// RecordToolFeedbackMessage records a tool feedback message for a chat.
+func (c *WebSocketChannel) RecordToolFeedbackMessage(chatID, messageID, content string) {
+	if c.progress == nil {
+		return
+	}
+	c.progress.Record(chatID, messageID, content)
+}
+
+// ClearToolFeedbackMessage clears the tracked tool feedback message for a chat.
+func (c *WebSocketChannel) ClearToolFeedbackMessage(chatID string) {
+	if c.progress == nil {
+		return
+	}
+	c.progress.Clear(chatID)
+}
+
+// DismissToolFeedbackMessage dismisses the tracked tool feedback message.
+func (c *WebSocketChannel) DismissToolFeedbackMessage(ctx context.Context, chatID string) {
+	msgID, ok := c.currentToolFeedbackMessage(chatID)
+	if !ok {
+		return
+	}
+	c.dismissTrackedToolFeedbackMessage(ctx, chatID, msgID)
+}
+
+func (c *WebSocketChannel) dismissTrackedToolFeedbackMessage(ctx context.Context, chatID, messageID string) {
+	if strings.TrimSpace(chatID) == "" || strings.TrimSpace(messageID) == "" {
+		return
+	}
+	c.ClearToolFeedbackMessage(chatID)
+	deleteFn := c.deleteMessageFn
+	if deleteFn == nil {
+		deleteFn = c.DeleteMessage
+	}
+	_ = deleteFn(ctx, chatID, messageID)
+}
+
+func (c *WebSocketChannel) finalizeTrackedToolFeedbackMessage(
+	ctx context.Context,
+	chatID string,
+	content string,
+	editFn func(context.Context, string, string, string, *bus.ContextUsage) error,
+	contextUsage *bus.ContextUsage,
+) ([]string, bool) {
+	msgID, baseContent, ok := c.takeToolFeedbackMessage(chatID)
+	if !ok || editFn == nil {
+		return nil, false
+	}
+	if err := editFn(ctx, chatID, msgID, content, contextUsage); err != nil {
+		c.RecordToolFeedbackMessage(chatID, msgID, baseContent)
+		return nil, false
+	}
+	return []string{msgID}, true
+}
+
+// FinalizeToolFeedbackMessage finalizes a tracked tool feedback message with the actual content.
+func (c *WebSocketChannel) FinalizeToolFeedbackMessage(ctx context.Context, msg bus.OutboundMessage) ([]string, bool) {
+	if !outboundMessageFinalizesTrackedToolFeedback(msg) {
+		return nil, false
+	}
+	return c.finalizeTrackedToolFeedbackMessage(ctx, msg.ChatID, msg.Content, c.editMessage, msg.ContextUsage)
+}
+
+// StartTyping implements channels.TypingCapable.
+func (c *WebSocketChannel) StartTyping(ctx context.Context, chatID string) (func(), error) {
+	startMsg := newMessage(TypeTypingStart, nil)
+	if err := c.broadcastToSession(chatID, startMsg); err != nil {
+		return func() {}, err
+	}
+	return func() {
+		stopMsg := newMessage(TypeTypingStop, nil)
+		_ = c.broadcastToSession(chatID, stopMsg)
+	}, nil
+}
+
+// SendPlaceholder implements channels.PlaceholderCapable.
+// It sends a placeholder message via the Pico Protocol that will later be
+// edited to the actual response via EditMessage (channels.MessageEditor).
+func (c *WebSocketChannel) SendPlaceholder(ctx context.Context, chatID string) (string, error) {
+	if !c.bc.Placeholder.Enabled {
+		return "", nil
+	}
+
+	text := c.bc.Placeholder.GetRandomText()
+
+	msgID := uuid.New().String()
+	outMsg := newMessage(TypeMessageCreate, map[string]any{
+		PayloadKeyContent: text,
+		PayloadKeyThought: false,
+		"message_id":      msgID,
+	})
+
+	if err := c.broadcastToSession(chatID, outMsg); err != nil {
+		return "", err
+	}
+
+	return msgID, nil
+}
+
+// SendMedia implements channels.MediaSender for the Pico web UI.
+// Media is delivered as a normal assistant message carrying structured
+// attachments plus an authenticated same-origin download URL.
+func (c *WebSocketChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaMessage) ([]string, error) {
+	if !c.IsRunning() {
+		return nil, channels.ErrNotRunning
+	}
+	trackedMsgID, hasTrackedMsg := c.currentToolFeedbackMessage(msg.ChatID)
+
+	store := c.GetMediaStore()
+	if store == nil {
+		return nil, fmt.Errorf("no media store available: %w", channels.ErrSendFailed)
+	}
+
+	attachments := make([]map[string]any, 0, len(msg.Parts))
+	caption := ""
+
+	for _, part := range msg.Parts {
+		localPath, meta, err := store.ResolveWithMeta(part.Ref)
+		if err != nil {
+			logger.ErrorCF("websocket", "Failed to resolve media ref", map[string]any{
+				"ref":   part.Ref,
+				"error": err.Error(),
+			})
+			continue
+		}
+
+		filename := strings.TrimSpace(part.Filename)
+		if filename == "" {
+			filename = strings.TrimSpace(meta.Filename)
+		}
+		if filename == "" {
+			filename = filepath.Base(localPath)
+		}
+
+		contentType := strings.TrimSpace(part.ContentType)
+		if contentType == "" {
+			contentType = strings.TrimSpace(meta.ContentType)
+		}
+		if contentType == "" {
+			contentType = "application/octet-stream"
+		}
+
+		attachmentType := strings.TrimSpace(part.Type)
+		if attachmentType == "" {
+			attachmentType = picoInferAttachmentType(filename, contentType)
+		}
+
+		attachmentURL, err := picoDownloadURLForRef(part.Ref)
+		if err != nil {
+			logger.ErrorCF("websocket", "Failed to build media download URL", map[string]any{
+				"ref":   part.Ref,
+				"error": err.Error(),
+			})
+			continue
+		}
+
+		attachments = append(attachments, map[string]any{
+			"type":         attachmentType,
+			"url":          attachmentURL,
+			"filename":     filename,
+			"content_type": contentType,
+		})
+
+		if caption == "" && strings.TrimSpace(part.Caption) != "" {
+			caption = strings.TrimSpace(part.Caption)
+		}
+	}
+
+	if len(attachments) == 0 {
+		return nil, fmt.Errorf("no deliverable media parts: %w", channels.ErrSendFailed)
+	}
+
+	msgID := uuid.New().String()
+	outMsg := newMessage(TypeMessageCreate, map[string]any{
+		PayloadKeyContent: caption,
+		"attachments":     attachments,
+		"message_id":      msgID,
+	})
+
+	if err := c.broadcastToSession(msg.ChatID, outMsg); err != nil {
+		return nil, err
+	}
+	if hasTrackedMsg {
+		c.dismissTrackedToolFeedbackMessage(ctx, msg.ChatID, trackedMsgID)
+	}
+
+	return []string{msgID}, nil
+}
+
+func picoDownloadURLForRef(ref string) (string, error) {
+	refID, err := picoMediaRefID(ref)
+	if err != nil {
+		return "", err
+	}
+	return "/pico/media/" + url.PathEscape(refID), nil
+}
+
+func picoMediaRefID(ref string) (string, error) {
+	refID := strings.TrimSpace(strings.TrimPrefix(ref, "media://"))
+	if refID == "" || strings.Contains(refID, "/") {
+		return "", fmt.Errorf("invalid media ref %q", ref)
+	}
+	return refID, nil
+}
+
+func picoInferAttachmentType(filename, contentType string) string {
+	contentType = strings.ToLower(strings.TrimSpace(contentType))
+	filename = strings.ToLower(strings.TrimSpace(filename))
+
+	switch {
+	case strings.HasPrefix(contentType, "image/"):
+		return "image"
+	case strings.HasPrefix(contentType, "audio/"):
+		return "audio"
+	case strings.HasPrefix(contentType, "video/"):
+		return "video"
+	}
+
+	switch ext := filepath.Ext(filename); ext {
+	case ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg":
+		return "image"
+	case ".mp3", ".wav", ".ogg", ".m4a", ".flac", ".aac", ".wma", ".opus":
+		return "audio"
+	case ".mp4", ".avi", ".mov", ".webm", ".mkv":
+		return "video"
+	default:
+		return "file"
+	}
+}
+
+func picoAllowsInlineDisplay(filename, contentType string) bool {
+	contentType = strings.ToLower(strings.TrimSpace(contentType))
+	filename = strings.ToLower(strings.TrimSpace(filename))
+
+	if strings.Contains(contentType, "svg") || filepath.Ext(filename) == ".svg" {
+		return false
+	}
+
+	return picoInferAttachmentType(filename, contentType) == "image"
+}
+
+func (c *WebSocketChannel) handleMediaDownload(w http.ResponseWriter, r *http.Request) {
+	if !c.IsRunning() {
+		http.Error(w, "channel not running", http.StatusServiceUnavailable)
+		return
+	}
+	if !c.authenticate(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	refID := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, "/pico/media/"), "/"))
+	if refID == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	store := c.GetMediaStore()
+	if store == nil {
+		http.Error(w, "media store unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	localPath, meta, err := store.ResolveWithMeta("media://" + refID)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	file, err := os.Open(localPath)
+	if err != nil {
+		http.Error(w, "failed to open media", http.StatusInternalServerError)
+		return
+	}
+	defer func() { _ = file.Close() }()
+
+	info, err := file.Stat()
+	if err != nil {
+		http.Error(w, "failed to stat media", http.StatusInternalServerError)
+		return
+	}
+
+	filename := strings.TrimSpace(meta.Filename)
+	if filename == "" {
+		filename = filepath.Base(localPath)
+	}
+	contentType := strings.TrimSpace(meta.ContentType)
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	dispositionType := "attachment"
+	if picoAllowsInlineDisplay(filename, contentType) {
+		dispositionType = "inline"
+	}
+
+	if cd := mime.FormatMediaType(dispositionType, map[string]string{"filename": filename}); cd != "" {
+		w.Header().Set("Content-Disposition", cd)
+	}
+	w.Header().Set("Content-Type", contentType)
+	http.ServeContent(w, r, filename, info.ModTime(), file)
+}
+
+// broadcastToSession sends a message to all connections with a matching session.
+func (c *WebSocketChannel) broadcastToSession(chatID string, msg WebSocketMessage) error {
+	// chatID format: "websocket:<sessionID>"
+	sessionID := strings.TrimPrefix(chatID, "websocket:")
+	msg.SessionID = sessionID
+
+	var sent bool
+	for _, pc := range c.sessionConnectionsSnapshot(sessionID) {
+		if err := pc.writeJSON(msg); err != nil {
+			logger.DebugCF("websocket", "Write to connection failed", map[string]any{
+				"conn_id": pc.id,
+				"error":   err.Error(),
+			})
+		} else {
+			sent = true
+		}
+	}
+
+	if !sent {
+		return fmt.Errorf("no active connections for session %s: %w", sessionID, channels.ErrSendFailed)
+	}
+	return nil
+}
+
+// handleWebSocket upgrades the HTTP connection and manages the WebSocket lifecycle.
+func (c *WebSocketChannel) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	if !c.IsRunning() {
+		http.Error(w, "channel not running", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Authenticate
+	if !c.authenticate(r) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Check connection limit
+	maxConns := c.config.MaxConnections
+	if maxConns <= 0 {
+		maxConns = 100
+	}
+	if c.currentConnCount() >= maxConns {
+		http.Error(w, "too many connections", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Echo the matched subprotocol back so the browser accepts the upgrade.
+	var responseHeader http.Header
+	if proto := c.matchedSubprotocol(r); proto != "" {
+		responseHeader = http.Header{"Sec-WebSocket-Protocol": {proto}}
+	}
+
+	conn, err := c.upgrader.Upgrade(w, r, responseHeader)
+	if err != nil {
+		logger.ErrorCF("websocket", "WebSocket upgrade failed", map[string]any{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	// Determine session ID from query param or generate one
+	sessionID := r.URL.Query().Get("session_id")
+	if sessionID == "" {
+		sessionID = uuid.New().String()
+	}
+
+	pc, err := c.createAndAddConnection(conn, sessionID, maxConns)
+	if err != nil {
+		_ = conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseTryAgainLater, "too many connections"),
+			time.Now().Add(2*time.Second),
+		)
+		_ = conn.Close()
+		return
+	}
+
+	logger.InfoCF("websocket", "WebSocket client connected", map[string]any{
+		"conn_id":    pc.id,
+		"session_id": sessionID,
+	})
+
+	go c.readLoop(pc)
+}
+
+// authenticate checks the request for a valid token:
+//  1. Authorization: Bearer <token> header
+//  2. Sec-WebSocket-Protocol "token.<value>" (for browsers that can't set headers)
+//  3. Query parameter "token" (only when AllowTokenQuery is on)
+func (c *WebSocketChannel) authenticate(r *http.Request) bool {
+	token := c.config.Token.String()
+	if token == "" {
+		return false
+	}
+
+	// Check Authorization header
+	auth := r.Header.Get("Authorization")
+	if after, ok := strings.CutPrefix(auth, "Bearer "); ok {
+		if after == token {
+			return true
+		}
+	}
+
+	// Check Sec-WebSocket-Protocol subprotocol ("token.<value>")
+	if c.matchedSubprotocol(r) != "" {
+		return true
+	}
+
+	// Check query parameter only when explicitly allowed
+	if c.config.AllowTokenQuery {
+		if r.URL.Query().Get("token") == token {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchedSubprotocol returns the "token.<value>" subprotocol that matches
+// the configured token, or "" if none do.
+func (c *WebSocketChannel) matchedSubprotocol(r *http.Request) string {
+	token := c.config.Token.String()
+	for _, proto := range websocket.Subprotocols(r) {
+		if after, ok := strings.CutPrefix(proto, "token."); ok && after == token {
+			return proto
+		}
+	}
+	return ""
+}
+
+// readLoop reads messages from a WebSocket connection.
+func (c *WebSocketChannel) readLoop(pc *wsConn) {
+	defer func() {
+		pc.close()
+		if removed := c.removeConnection(pc.id); removed != nil {
+			logger.InfoCF("websocket", "WebSocket client disconnected", map[string]any{
+				"conn_id":    removed.id,
+				"session_id": removed.sessionID,
+			})
+		}
+	}()
+
+	readTimeout := time.Duration(c.config.ReadTimeout) * time.Second
+	if readTimeout <= 0 {
+		readTimeout = 60 * time.Second
+	}
+
+	_ = pc.conn.SetReadDeadline(time.Now().Add(readTimeout))
+	pc.conn.SetPongHandler(func(appData string) error {
+		_ = pc.conn.SetReadDeadline(time.Now().Add(readTimeout))
+		return nil
+	})
+
+	// Start ping ticker
+	pingInterval := time.Duration(c.config.PingInterval) * time.Second
+	if pingInterval <= 0 {
+		pingInterval = 30 * time.Second
+	}
+	go c.pingLoop(pc, pingInterval)
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		default:
+		}
+
+		_, rawMsg, err := pc.conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+				logger.DebugCF("websocket", "WebSocket read error", map[string]any{
+					"conn_id": pc.id,
+					"error":   err.Error(),
+				})
+			}
+			return
+		}
+
+		_ = pc.conn.SetReadDeadline(time.Now().Add(readTimeout))
+
+		var msg WebSocketMessage
+		if err := json.Unmarshal(rawMsg, &msg); err != nil {
+			errMsg := newError("invalid_message", "failed to parse message")
+			_ = pc.writeJSON(errMsg)
+			continue
+		}
+
+		c.handleMessage(pc, msg)
+	}
+}
+
+// pingLoop sends periodic ping frames to keep the connection alive.
+func (c *WebSocketChannel) pingLoop(pc *wsConn, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-ticker.C:
+			if pc.closed.Load() {
+				return
+			}
+			pc.writeMu.Lock()
+			err := pc.conn.WriteMessage(websocket.PingMessage, nil)
+			pc.writeMu.Unlock()
+			if err != nil {
+				return
+			}
+		}
+	}
+}
+
+// handleMessage processes an inbound Pico Protocol message.
+func (c *WebSocketChannel) handleMessage(pc *wsConn, msg WebSocketMessage) {
+	switch msg.Type {
+	case TypePing:
+		pong := newMessage(TypePong, nil)
+		pong.ID = msg.ID
+		_ = pc.writeJSON(pong)
+
+	case TypeMessageSend:
+		c.handleMessageSend(pc, msg)
+
+	case TypeMediaSend:
+		c.handleMessageSend(pc, msg)
+
+	default:
+		errMsg := newError("unknown_type", fmt.Sprintf("unknown message type: %s", msg.Type))
+		_ = pc.writeJSON(errMsg)
+	}
+}
+
+// handleMessageSend processes an inbound message.send from a client.
+func (c *WebSocketChannel) handleMessageSend(pc *wsConn, msg WebSocketMessage) {
+	content, _ := msg.Payload["content"].(string)
+	media, err := parseInlineImageMedia(msg.Payload)
+	if err != nil {
+		errMsg := newErrorWithPayload("invalid_media", err.Error(), map[string]any{
+			"request_id": msg.ID,
+		})
+		_ = pc.writeJSON(errMsg)
+		return
+	}
+
+	if strings.TrimSpace(content) == "" && len(media) == 0 {
+		errMsg := newErrorWithPayload("empty_content", "message content is empty", map[string]any{
+			"request_id": msg.ID,
+		})
+		_ = pc.writeJSON(errMsg)
+		return
+	}
+
+	sessionID := msg.SessionID
+	if sessionID == "" {
+		sessionID = pc.sessionID
+	}
+
+	chatID := "websocket:" + sessionID
+	senderID := "websocket-user"
+
+	metadata := map[string]string{
+		"platform":   "websocket",
+		"session_id": sessionID,
+		"conn_id":    pc.id,
+	}
+
+	logger.DebugCF("websocket", "Received message", map[string]any{
+		"session_id": sessionID,
+		"preview":    truncate(content, 50),
+		"media":      len(media),
+	})
+
+	sender := bus.SenderInfo{
+		Platform:    "websocket",
+		PlatformID:  senderID,
+		CanonicalID: identity.BuildCanonicalID("websocket", senderID),
+	}
+
+	if !c.IsAllowedSender(sender) {
+		return
+	}
+
+	inboundCtx := bus.InboundContext{
+		Channel:   "websocket",
+		ChatID:    chatID,
+		ChatType:  "direct",
+		SenderID:  senderID,
+		MessageID: msg.ID,
+		Raw:       metadata,
+	}
+
+	c.HandleInboundContext(c.ctx, chatID, content, media, inboundCtx, sender)
+}
+
+// truncate truncates a string to maxLen runes.
+func truncate(s string, maxLen int) string {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen]) + "..."
+}
+
+func parseInlineImageMedia(payload map[string]any) ([]string, error) {
+	if len(payload) == 0 {
+		return nil, nil
+	}
+
+	raw, ok := payload["media"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+
+	switch values := raw.(type) {
+	case []any:
+		media := make([]string, 0, len(values))
+		for i, item := range values {
+			value, err := inlineImageValue(item)
+			if err != nil {
+				return nil, fmt.Errorf("media[%d]: %w", i, err)
+			}
+			if err := validateInlineImageDataURL(value); err != nil {
+				return nil, fmt.Errorf("media[%d]: %w", i, err)
+			}
+			media = append(media, value)
+		}
+		return media, nil
+	case []string:
+		media := make([]string, 0, len(values))
+		for i, value := range values {
+			value = strings.TrimSpace(value)
+			if err := validateInlineImageDataURL(value); err != nil {
+				return nil, fmt.Errorf("media[%d]: %w", i, err)
+			}
+			media = append(media, value)
+		}
+		return media, nil
+	case string:
+		value := strings.TrimSpace(values)
+		if err := validateInlineImageDataURL(value); err != nil {
+			return nil, err
+		}
+		return []string{value}, nil
+	default:
+		return nil, fmt.Errorf("media must be a string or array of strings")
+	}
+}
+
+func inlineImageValue(item any) (string, error) {
+	switch value := item.(type) {
+	case string:
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return "", fmt.Errorf("image payload is empty")
+		}
+		return value, nil
+	case map[string]any:
+		for _, key := range []string{"url", "data_url"} {
+			if raw, ok := value[key].(string); ok && strings.TrimSpace(raw) != "" {
+				return strings.TrimSpace(raw), nil
+			}
+		}
+		return "", fmt.Errorf("image payload must include url or data_url")
+	default:
+		return "", fmt.Errorf("image payload must be a string or object")
+	}
+}
+
+func validateInlineImageDataURL(mediaURL string) error {
+	if mediaURL == "" {
+		return fmt.Errorf("image payload is empty")
+	}
+	if !strings.HasPrefix(mediaURL, "data:image/") {
+		return fmt.Errorf("only inline image data URLs are supported")
+	}
+
+	header, data, found := strings.Cut(mediaURL, ",")
+	if !found || strings.TrimSpace(data) == "" {
+		return fmt.Errorf("image data URL is malformed")
+	}
+	if !strings.Contains(header, ";base64") {
+		return fmt.Errorf("image data URL must be base64 encoded")
+	}
+	mimeType, _, _ := strings.Cut(strings.TrimPrefix(header, "data:"), ";")
+	if _, ok := allowedInlineImageMIMETypes[mimeType]; !ok {
+		return fmt.Errorf("unsupported image format: %s", mimeType)
+	}
+
+	data = strings.TrimSpace(data)
+	if base64.StdEncoding.DecodedLen(len(data)) > config.DefaultMaxMediaSize {
+		return fmt.Errorf("image exceeds %d byte limit", config.DefaultMaxMediaSize)
+	}
+	if _, err := base64.StdEncoding.DecodeString(data); err != nil {
+		return fmt.Errorf("invalid base64 image data")
+	}
+
+	return nil
+}
+
+// setContextUsagePayload adds context window usage stats to a pico payload.
+func setContextUsagePayload(payload map[string]any, u *bus.ContextUsage) {
+	if u == nil {
+		return
+	}
+	payload["context_usage"] = map[string]any{
+		"used_tokens":        u.UsedTokens,
+		"total_tokens":       u.TotalTokens,
+		"compress_at_tokens": u.CompressAtTokens,
+		"used_percent":       u.UsedPercent,
+	}
+}
+
+func (c *WebSocketChannel) editMessage(
+	ctx context.Context,
+	chatID string,
+	messageID string,
+	content string,
+	contextUsage *bus.ContextUsage,
+) error {
+	payload := map[string]any{
+		"message_id": messageID,
+		"content":    content,
+	}
+	setContextUsagePayload(payload, contextUsage)
+	outMsg := newMessage(TypeMessageUpdate, payload)
+	return c.broadcastToSession(chatID, outMsg)
+}

--- a/pkg/channels/websocket/websocket_test.go
+++ b/pkg/channels/websocket/websocket_test.go
@@ -1,0 +1,508 @@
+package websocket
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/channels"
+	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/media"
+)
+
+func newTestWebSocketChannel(t *testing.T) *WebSocketChannel {
+	t.Helper()
+
+	bc := &config.Channel{Type: config.ChannelWebSocket, Enabled: true}
+	cfg := &config.WebSocketSettings{Port: 0} // random available port
+	cfg.SetToken("test-token")
+	ch, err := NewWebSocketChannel(bc, cfg, bus.NewMessageBus())
+	if err != nil {
+		t.Fatalf("NewWebSocketChannel: %v", err)
+	}
+
+	ch.ctx = context.Background()
+	return ch
+}
+
+func TestFinalizeTrackedToolFeedbackMessage_StopsTrackingBeforeEdit(t *testing.T) {
+	ch := &WebSocketChannel{
+		progress: channels.NewToolFeedbackAnimator(nil),
+	}
+	ch.RecordToolFeedbackMessage("websocket:chat-1", "msg-1", "🔧 `read_file`")
+
+	msgIDs, handled := ch.finalizeTrackedToolFeedbackMessage(
+		context.Background(),
+		"websocket:chat-1",
+		"final reply",
+		func(_ context.Context, chatID, messageID, content string, contextUsage *bus.ContextUsage) error {
+			if _, ok := ch.currentToolFeedbackMessage(chatID); ok {
+				t.Fatal("expected tracked tool feedback to be stopped before edit")
+			}
+			if chatID != "websocket:chat-1" || messageID != "msg-1" || content != "final reply" {
+				t.Fatalf("unexpected edit args: %s %s %s", chatID, messageID, content)
+			}
+			if contextUsage != nil {
+				t.Fatalf("unexpected context usage: %+v", contextUsage)
+			}
+			return nil
+		},
+		nil,
+	)
+	if !handled {
+		t.Fatal("expected finalizeTrackedToolFeedbackMessage to handle tracked message")
+	}
+	if len(msgIDs) != 1 || msgIDs[0] != "msg-1" {
+		t.Fatalf("finalizeTrackedToolFeedbackMessage() ids = %v, want [msg-1]", msgIDs)
+	}
+}
+
+func TestDismissTrackedToolFeedbackMessage_DeletesProgressMessage(t *testing.T) {
+	ch := &WebSocketChannel{
+		progress: channels.NewToolFeedbackAnimator(nil),
+	}
+	ch.RecordToolFeedbackMessage("websocket:chat-1", "msg-1", "🔧 `read_file`")
+
+	var deleted struct {
+		chatID    string
+		messageID string
+	}
+	ch.deleteMessageFn = func(_ context.Context, chatID string, messageID string) error {
+		deleted.chatID = chatID
+		deleted.messageID = messageID
+		return nil
+	}
+
+	ch.DismissToolFeedbackMessage(context.Background(), "websocket:chat-1")
+
+	if deleted.chatID != "websocket:chat-1" || deleted.messageID != "msg-1" {
+		t.Fatalf("unexpected delete target: %+v", deleted)
+	}
+	if _, ok := ch.currentToolFeedbackMessage("websocket:chat-1"); ok {
+		t.Fatal("expected tracked tool feedback to be cleared after dismissal")
+	}
+}
+
+func TestSend_ThoughtMessageDoesNotFinalizeTrackedToolFeedback(t *testing.T) {
+	ch := newTestWebSocketChannel(t)
+
+	if err := ch.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer func() { _ = ch.Stop(context.Background()) }()
+
+	clientConn, received, cleanup := newTestPicoWebSocket(t)
+	defer cleanup()
+	ch.addConnForTest(&wsConn{id: "conn-1", conn: clientConn, sessionID: "sess-1"})
+
+	ch.RecordToolFeedbackMessage("websocket:sess-1", "msg-progress", "🔧 `read_file`\nReading config")
+
+	if _, err := ch.Send(context.Background(), bus.OutboundMessage{
+		ChatID:  "websocket:sess-1",
+		Content: "thinking trace",
+		Context: bus.InboundContext{
+			Channel: "websocket",
+			ChatID:  "websocket:sess-1",
+			Raw: map[string]string{
+				"message_kind": MessageKindThought,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Send(thought) error = %v", err)
+	}
+
+	select {
+	case msg := <-received:
+		if msg.Type != TypeMessageCreate {
+			t.Fatalf("thought message type = %q, want %q", msg.Type, TypeMessageCreate)
+		}
+		payload := msg.Payload
+		if got := payload[PayloadKeyContent]; got != "thinking trace" {
+			t.Fatalf("thought content = %#v, want %q", got, "thinking trace")
+		}
+		if got := payload[PayloadKeyThought]; got != true {
+			t.Fatalf("thought flag = %#v, want true", got)
+		}
+		if got := payload["message_id"]; got == "msg-progress" || got == nil || got == "" {
+			t.Fatalf("thought message_id = %#v, want new non-progress id", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected thought message to be delivered")
+	}
+
+	if msgID, ok := ch.currentToolFeedbackMessage("websocket:sess-1"); !ok || msgID != "msg-progress" {
+		t.Fatalf("tracked tool feedback = (%q, %v), want (msg-progress, true)", msgID, ok)
+	}
+
+	if _, err := ch.Send(context.Background(), bus.OutboundMessage{
+		ChatID:  "websocket:sess-1",
+		Content: "final reply",
+		Context: bus.InboundContext{
+			Channel: "websocket",
+			ChatID:  "websocket:sess-1",
+		},
+		ContextUsage: &bus.ContextUsage{
+			UsedTokens:       321,
+			TotalTokens:      4096,
+			CompressAtTokens: 3072,
+			UsedPercent:      8,
+		},
+	}); err != nil {
+		t.Fatalf("Send(final) error = %v", err)
+	}
+
+	select {
+	case msg := <-received:
+		if msg.Type != TypeMessageUpdate {
+			t.Fatalf("final message type = %q, want %q", msg.Type, TypeMessageUpdate)
+		}
+		payload := msg.Payload
+		if got := payload["message_id"]; got != "msg-progress" {
+			t.Fatalf("final message_id = %#v, want %q", got, "msg-progress")
+		}
+		if got := payload[PayloadKeyContent]; got != "final reply" {
+			t.Fatalf("final content = %#v, want %q", got, "final reply")
+		}
+		rawUsage, ok := payload["context_usage"].(map[string]any)
+		if !ok {
+			t.Fatalf("final context_usage = %#v, want map payload", payload["context_usage"])
+		}
+		if got, ok := rawUsage["used_tokens"].(float64); !ok || got != 321 {
+			t.Fatalf("used_tokens = %#v, want 321", rawUsage["used_tokens"])
+		}
+		if got, ok := rawUsage["total_tokens"].(float64); !ok || got != 4096 {
+			t.Fatalf("total_tokens = %#v, want 4096", rawUsage["total_tokens"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected final reply to finalize tracked tool feedback")
+	}
+
+	if _, ok := ch.currentToolFeedbackMessage("websocket:sess-1"); ok {
+		t.Fatal("expected tracked tool feedback to be cleared after final reply")
+	}
+}
+
+func TestCreateAndAddConnection_RespectsMaxConnectionsConcurrently(t *testing.T) {
+	ch := newTestWebSocketChannel(t)
+
+	const (
+		maxConns   = 5
+		goroutines = 64
+		sessionID  = "session-a"
+	)
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	successCount := 0
+	errCount := 0
+
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+
+			pc, err := ch.createAndAddConnection(nil, sessionID, maxConns)
+			mu.Lock()
+			defer mu.Unlock()
+
+			if err == nil {
+				successCount++
+				if pc == nil {
+					t.Errorf("pc is nil on success")
+				}
+				return
+			}
+			if !errors.Is(err, channels.ErrTemporary) {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			errCount++
+		}()
+	}
+	wg.Wait()
+
+	if successCount > maxConns {
+		t.Fatalf("successCount=%d > maxConns=%d", successCount, maxConns)
+	}
+	if successCount+errCount != goroutines {
+		t.Fatalf("success=%d err=%d total=%d want=%d", successCount, errCount, successCount+errCount, goroutines)
+	}
+	if got := ch.currentConnCount(); got != maxConns {
+		t.Fatalf("currentConnCount=%d want=%d", got, maxConns)
+	}
+}
+
+func TestRemoveConnection_CleansBothIndexes(t *testing.T) {
+	ch := newTestWebSocketChannel(t)
+
+	pc, err := ch.createAndAddConnection(nil, "session-cleanup", 10)
+	if err != nil {
+		t.Fatalf("createAndAddConnection: %v", err)
+	}
+
+	removed := ch.removeConnection(pc.id)
+	if removed == nil {
+		t.Fatal("removeConnection returned nil")
+	}
+
+	ch.connsMu.RLock()
+	defer ch.connsMu.RUnlock()
+
+	if _, ok := ch.connections[pc.id]; ok {
+		t.Fatalf("connID %s still exists in connections", pc.id)
+	}
+	if _, ok := ch.sessionConnections[pc.sessionID]; ok {
+		t.Fatalf("session %s still exists in sessionConnections", pc.sessionID)
+	}
+	if got := len(ch.connections); got != 0 {
+		t.Fatalf("len(connections)=%d want=0", got)
+	}
+}
+
+func TestBroadcastToSession_TargetsOnlyRequestedSession(t *testing.T) {
+	ch := newTestWebSocketChannel(t)
+
+	target := &wsConn{id: "target", sessionID: "s-target"}
+	target.closed.Store(true)
+	ch.addConnForTest(target)
+
+	other := &wsConn{id: "other", sessionID: "s-other"}
+	ch.addConnForTest(other)
+
+	err := ch.broadcastToSession("websocket:s-target", newMessage(TypeMessageCreate, map[string]any{"content": "hello"}))
+	if err == nil {
+		t.Fatal("expected send failure due to closed target connection")
+	}
+	if !errors.Is(err, channels.ErrSendFailed) {
+		t.Fatalf("expected ErrSendFailed, got %v", err)
+	}
+}
+
+func TestSendMedia_ResolvesMediaBeforeDelivery(t *testing.T) {
+	ch := newTestWebSocketChannel(t)
+	store := media.NewFileMediaStore()
+	ch.SetMediaStore(store)
+
+	if err := ch.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer func() { _ = ch.Stop(context.Background()) }()
+
+	localPath := filepath.Join(t.TempDir(), "report.txt")
+	if err := os.WriteFile(localPath, []byte("attachment body"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	ref, err := store.Store(localPath, media.MediaMeta{
+		Filename:    "report.txt",
+		ContentType: "text/plain",
+	}, "test-scope")
+	if err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+
+	closedConn := &wsConn{id: "closed", sessionID: "sess-1"}
+	closedConn.closed.Store(true)
+	ch.addConnForTest(closedConn)
+
+	_, err = ch.SendMedia(context.Background(), bus.OutboundMediaMessage{
+		ChatID: "websocket:sess-1",
+		Parts: []bus.MediaPart{{
+			Ref:         ref,
+			Type:        "file",
+			Filename:    "report.txt",
+			ContentType: "text/plain",
+		}},
+	})
+	if !errors.Is(err, channels.ErrSendFailed) {
+		t.Fatalf("SendMedia() error = %v, want ErrSendFailed", err)
+	}
+}
+
+func TestSendMedia_DismissesTrackedToolFeedbackMessage(t *testing.T) {
+	ch := newTestWebSocketChannel(t)
+	store := media.NewFileMediaStore()
+	ch.SetMediaStore(store)
+
+	if err := ch.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer func() { _ = ch.Stop(context.Background()) }()
+
+	clientConn, received, cleanup := newTestPicoWebSocket(t)
+	defer cleanup()
+	ch.addConnForTest(&wsConn{id: "conn-1", conn: clientConn, sessionID: "sess-1"})
+
+	localPath := filepath.Join(t.TempDir(), "report.txt")
+	if err := os.WriteFile(localPath, []byte("attachment body"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	ref, err := store.Store(localPath, media.MediaMeta{
+		Filename:    "report.txt",
+		ContentType: "text/plain",
+	}, "test-scope")
+	if err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+
+	ch.RecordToolFeedbackMessage("websocket:sess-1", "msg-progress", "🔧 `read_file`")
+
+	var deleted struct {
+		chatID    string
+		messageID string
+	}
+	ch.deleteMessageFn = func(_ context.Context, chatID string, messageID string) error {
+		deleted.chatID = chatID
+		deleted.messageID = messageID
+		return nil
+	}
+
+	_, err = ch.SendMedia(context.Background(), bus.OutboundMediaMessage{
+		ChatID: "websocket:sess-1",
+		Parts: []bus.MediaPart{{
+			Ref:         ref,
+			Type:        "file",
+			Filename:    "report.txt",
+			ContentType: "text/plain",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SendMedia() error = %v", err)
+	}
+
+	select {
+	case msg := <-received:
+		if msg.Type != TypeMessageCreate {
+			t.Fatalf("message type = %q, want %q", msg.Type, TypeMessageCreate)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected media message to be delivered")
+	}
+
+	if deleted.chatID != "websocket:sess-1" || deleted.messageID != "msg-progress" {
+		t.Fatalf("unexpected delete target: %+v", deleted)
+	}
+	if _, ok := ch.currentToolFeedbackMessage("websocket:sess-1"); ok {
+		t.Fatal("expected tracked tool feedback to be cleared after media delivery")
+	}
+}
+
+func TestPicoDownloadURLForRef(t *testing.T) {
+	got, err := picoDownloadURLForRef("media://attachment-1")
+	if err != nil {
+		t.Fatalf("picoDownloadURLForRef() error = %v", err)
+	}
+	if got != "/pico/media/attachment-1" {
+		t.Fatalf("picoDownloadURLForRef() = %q, want %q", got, "/pico/media/attachment-1")
+	}
+}
+
+func TestHandleMediaDownload_ServesStoredFile(t *testing.T) {
+	ch := newTestWebSocketChannel(t)
+	store := media.NewFileMediaStore()
+	ch.SetMediaStore(store)
+
+	if err := ch.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer func() { _ = ch.Stop(context.Background()) }()
+
+	localPath := filepath.Join(t.TempDir(), "report.txt")
+	if err := os.WriteFile(localPath, []byte("downloadable"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	ref, err := store.Store(localPath, media.MediaMeta{
+		Filename:    "report.txt",
+		ContentType: "text/plain",
+	}, "test-scope")
+	if err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+
+	refID := strings.TrimPrefix(ref, "media://")
+	req := httptest.NewRequest("GET", "/pico/media/"+refID, nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rec := httptest.NewRecorder()
+
+	ch.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if body := rec.Body.String(); body != "downloadable" {
+		t.Fatalf("body = %q, want %q", body, "downloadable")
+	}
+	if got := rec.Header().Get("Content-Type"); got != "text/plain" {
+		t.Fatalf("Content-Type = %q, want %q", got, "text/plain")
+	}
+}
+
+func (c *WebSocketChannel) addConnForTest(pc *wsConn) {
+	c.connsMu.Lock()
+	defer c.connsMu.Unlock()
+	if c.connections == nil {
+		c.connections = make(map[string]*wsConn)
+	}
+	if c.sessionConnections == nil {
+		c.sessionConnections = make(map[string]map[string]*wsConn)
+	}
+	if _, exists := c.connections[pc.id]; exists {
+		panic(fmt.Sprintf("duplicate conn id in test: %s", pc.id))
+	}
+	c.connections[pc.id] = pc
+	bySession, ok := c.sessionConnections[pc.sessionID]
+	if !ok {
+		bySession = make(map[string]*wsConn)
+		c.sessionConnections[pc.sessionID] = bySession
+	}
+	bySession[pc.id] = pc
+}
+
+func newTestPicoWebSocket(t *testing.T) (*websocket.Conn, <-chan WebSocketMessage, func()) {
+	t.Helper()
+
+	received := make(chan WebSocketMessage, 4)
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("Upgrade() error = %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			var msg WebSocketMessage
+			if err := conn.ReadJSON(&msg); err != nil {
+				return
+			}
+			received <- msg
+		}
+	}))
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	clientConn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		server.Close()
+		t.Fatalf("Dial() error = %v", err)
+	}
+
+	cleanup := func() {
+		_ = clientConn.Close()
+		server.Close()
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return clientConn, received, cleanup
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,7 +13,12 @@ const (
 	ChannelTelegram       = "telegram"
 	ChannelWhatsAppNative = "whatsapp_native"
 	ChannelEmail          = "email"
+	ChannelWebSocket       = "websocket"
+	ChannelWebSocketClient = "websocket_client"
 )
+
+// DefaultMaxMediaSize is the maximum allowed inline media payload size (20 MB).
+const DefaultMaxMediaSize = 20 * 1024 * 1024
 
 // Config is the top-level sushiclaw configuration.
 type Config struct {
@@ -249,6 +254,37 @@ type WhatsAppSettings struct {
 	BridgeURL        string `json:"bridge_url"`
 	UseNative        bool   `json:"use_native"`
 	SessionStorePath string `json:"session_store_path"`
+}
+
+// WebSocketSettings holds Pico Protocol server channel settings.
+type WebSocketSettings struct {
+	Token           SecureString `json:"token,omitzero"`
+	AllowTokenQuery bool         `json:"allow_token_query,omitempty"`
+	AllowOrigins    []string     `json:"allow_origins,omitempty"`
+	PingInterval    int          `json:"ping_interval,omitempty"`
+	ReadTimeout     int          `json:"read_timeout,omitempty"`
+	WriteTimeout    int          `json:"write_timeout,omitempty"`
+	MaxConnections  int          `json:"max_connections,omitempty"`
+	Port            int          `json:"port,omitempty"`
+}
+
+// SetToken sets the Pico token.
+func (c *WebSocketSettings) SetToken(token string) {
+	c.Token = *NewSecureString(token)
+}
+
+// WebSocketClientSettings holds Pico Protocol client channel settings.
+type WebSocketClientSettings struct {
+	URL          string       `json:"url"`
+	Token        SecureString `json:"token,omitzero"`
+	SessionID    string       `json:"session_id,omitempty"`
+	PingInterval int          `json:"ping_interval,omitempty"`
+	ReadTimeout  int          `json:"read_timeout,omitempty"`
+}
+
+// SetToken sets the Pico client token.
+func (c *WebSocketClientSettings) SetToken(token string) {
+	c.Token = *NewSecureString(token)
 }
 
 // VoiceConfig holds voice/ASR settings.


### PR DESCRIPTION
## Summary

Adds a standalone WebSocket channel to sushiclaw and wires the local `chat` command through that implemented channel. The agent can now be reached by WebSocket clients, and the terminal chat path exercises the same bus/channel/session flow instead of calling the agent directly.

Closes #71

## What changed

- Added `pkg/channels/websocket/` with server and client channel implementations.
- Registered the `websocket` and `websocket_client` channel factories and documented example config.
- Added WebSocket message types, connection/session handling, token authentication, media delivery, typing events, message edit/delete support, and tool-feedback animation support.
- Added context usage propagation on outbound messages for WebSocket clients.
- Updated `sushiclaw chat` to define an in-process `websocket` channel on the fly, connect a local websocket client to it, and route terminal input/output through the normal bus and channel manager pipeline.

## Test plan

- `go test ./...`
- `go test ./internal/chat`
