### PR TITLE
feat(agent): isolate memory per channel and per email thread

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	agentsdk "github.com/Ingenimax/agent-sdk-go/pkg/agent"
@@ -26,14 +27,26 @@ import (
 
 // SessionManager wraps an agent-sdk-go Agent and processes inbound bus messages.
 type SessionManager struct {
-	agent           agentRunner
-	bus             *bus.MessageBus
-	mem             *InMemoryMemory
 	cfg             *config.Config
+	bus             *bus.MessageBus
 	tools           []interfaces.Tool
-	activatedSkills map[string]bool
 	progress        ProgressSink
 	mediaStore      media.MediaStore
+	sessions        map[string]*Session
+	mu              sync.RWMutex
+	ttl             time.Duration
+	cleanupInterval time.Duration
+	cleanupStop     chan struct{}
+}
+
+// Session represents a single isolated conversation context.
+type Session struct {
+	agent           agentRunner
+	mem             *InMemoryMemory
+	activatedSkills map[string]bool
+	lastUsed        time.Time
+	mu              sync.RWMutex
+	mgr             *SessionManager
 }
 
 type agentRunner interface {
@@ -144,20 +157,18 @@ func toAgentSDKMCPConfig(cfg config.MCPConfig) *agentsdk.MCPConfiguration {
 
 // NewSessionManager creates a session manager from config.
 func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus, tools []interfaces.Tool, store media.MediaStore, opts ...SessionOption) (*SessionManager, error) {
-	mem := NewInMemoryMemory()
-	a, err := buildAgentWithMemory(cfg, tools, mem)
-	if err != nil {
-		return nil, err
+	if cfg.Agents.Defaults.MaxToolIterations < 0 {
+		return nil, fmt.Errorf("invalid max_tool_iterations %d: must be >= 0", cfg.Agents.Defaults.MaxToolIterations)
 	}
 
 	sm := &SessionManager{
-		agent:           a,
-		bus:             messageBus,
-		mem:             mem,
 		cfg:             cfg,
+		bus:             messageBus,
 		tools:           tools,
-		activatedSkills: make(map[string]bool),
 		mediaStore:      store,
+		sessions:        make(map[string]*Session),
+		ttl:             30 * 24 * time.Hour,
+		cleanupInterval: time.Hour,
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -167,16 +178,108 @@ func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus, tools []i
 	return sm, nil
 }
 
-// ClearHistory resets the agent's conversation memory.
-func (sm *SessionManager) ClearHistory() error {
-	return sm.mem.Clear(context.Background())
+// Start begins the background session eviction goroutine.
+func (sm *SessionManager) Start() {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if sm.cleanupStop != nil {
+		return
+	}
+	sm.cleanupStop = make(chan struct{})
+	go sm.cleanupLoop()
+}
+
+// Stop signals the background eviction goroutine to exit.
+func (sm *SessionManager) Stop() {
+	sm.mu.Lock()
+	stop := sm.cleanupStop
+	sm.cleanupStop = nil
+	sm.mu.Unlock()
+	if stop != nil {
+		close(stop)
+	}
+}
+
+func (sm *SessionManager) cleanupLoop() {
+	ticker := time.NewTicker(sm.cleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			sm.evictStaleSessions()
+		case <-sm.cleanupStop:
+			return
+		}
+	}
+}
+
+func (sm *SessionManager) evictStaleSessions() {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	cutoff := time.Now().Add(-sm.ttl)
+	for key, s := range sm.sessions {
+		s.mu.RLock()
+		lastUsed := s.lastUsed
+		s.mu.RUnlock()
+		if lastUsed.Before(cutoff) {
+			delete(sm.sessions, key)
+		}
+	}
+}
+
+func (sm *SessionManager) getOrCreateSession(key string) (*Session, error) {
+	sm.mu.RLock()
+	s, ok := sm.sessions[key]
+	sm.mu.RUnlock()
+	if ok {
+		s.mu.Lock()
+		s.lastUsed = time.Now()
+		s.mu.Unlock()
+		return s, nil
+	}
+
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if s, ok := sm.sessions[key]; ok {
+		s.lastUsed = time.Now()
+		return s, nil
+	}
+
+	mem := NewInMemoryMemory()
+	a, err := buildAgentWithMemory(sm.cfg, sm.tools, mem)
+	if err != nil {
+		return nil, err
+	}
+
+	s = &Session{
+		agent:           a,
+		mem:             mem,
+		activatedSkills: make(map[string]bool),
+		lastUsed:        time.Now(),
+		mgr:             sm,
+	}
+	sm.sessions[key] = s
+	return s, nil
+}
+
+// ClearHistory evicts the session from the registry entirely.
+func (sm *SessionManager) ClearHistory(sessionKey string) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	delete(sm.sessions, sessionKey)
+	return nil
 }
 
 // ActivateSkill reads a skill's SKILL.md and injects it into the conversation
 // memory as a system message. If the skill is already loaded, it returns
 // commands.ErrSkillAlreadyLoaded.
-func (sm *SessionManager) ActivateSkill(skillName string) error {
-	if sm.activatedSkills[skillName] {
+func (sm *SessionManager) ActivateSkill(sessionKey, skillName string) error {
+	s, err := sm.getOrCreateSession(sessionKey)
+	if err != nil {
+		return err
+	}
+
+	if s.activatedSkills[skillName] {
 		return commands.ErrSkillAlreadyLoaded
 	}
 
@@ -200,11 +303,11 @@ func (sm *SessionManager) ActivateSkill(skillName string) error {
 		Role:    interfaces.MessageRoleSystem,
 		Content: skillContent,
 	}
-	if err := sm.mem.AddMessage(context.Background(), msg); err != nil {
+	if err := s.mem.AddMessage(context.Background(), msg); err != nil {
 		return fmt.Errorf("inject skill into memory: %w", err)
 	}
 
-	sm.activatedSkills[skillName] = true
+	s.activatedSkills[skillName] = true
 	return nil
 }
 
@@ -256,29 +359,56 @@ func (sm *SessionManager) ToolNames() []string {
 	return names
 }
 
-// GetMessages returns all messages in the session memory.
-func (sm *SessionManager) GetMessages(ctx context.Context) ([]interfaces.Message, error) {
-	return sm.mem.GetMessages(ctx)
+// GetMessages returns all messages in the specified session memory.
+func (sm *SessionManager) GetMessages(sessionKey string, ctx context.Context) ([]interfaces.Message, error) {
+	sm.mu.RLock()
+	s, ok := sm.sessions[sessionKey]
+	sm.mu.RUnlock()
+	if !ok {
+		return nil, nil
+	}
+	return s.mem.GetMessages(ctx)
 }
 
 // Chat runs a single turn against the agent and returns the response.
 // Bypasses the bus — useful for CLI REPL.
 func (sm *SessionManager) Chat(ctx context.Context, input string) (string, error) {
 	actx := exec.WithChatID(ctx, "cli")
-	return sm.agent.Run(actx, input)
+	s, err := sm.getOrCreateSession("cli:local")
+	if err != nil {
+		return "", err
+	}
+	return s.agent.Run(actx, input)
 }
 
 // Dispatch processes a single inbound message through the agent.
 // Called by the gateway after command filtering and local execution.
 func (sm *SessionManager) Dispatch(ctx context.Context, msg bus.InboundMessage) {
-	sm.handleInbound(ctx, msg)
+	key := computeSessionKey(msg)
+	s, err := sm.getOrCreateSession(key)
+	if err != nil {
+		logger.ErrorCF("agent", "Failed to create session", map[string]any{"session_key": key, "error": err.Error()})
+		if sm.bus != nil {
+			_ = sm.bus.PublishOutbound(ctx, bus.OutboundMessage{
+				Channel: msg.Channel,
+				ChatID:  msg.ChatID,
+				Content: fmt.Sprintf("Error: %v", err),
+			})
+		}
+		return
+	}
+	s.handleInbound(ctx, msg, key)
 }
 
-func (sm *SessionManager) handleInbound(ctx context.Context, msg bus.InboundMessage) {
-	chatID := msg.Context.ChatID
-	if chatID == "" {
-		chatID = msg.ChatID
+func computeSessionKey(msg bus.InboundMessage) string {
+	if msg.SessionKey != "" {
+		return msg.SessionKey
 	}
+	return msg.Channel + ":" + msg.ChatID
+}
+
+func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, sessionKey string) {
+	chatID := msg.ChatID
 
 	// Attach chat ID to context for tool use.
 	actx := exec.WithChatID(ctx, chatID)
@@ -289,8 +419,8 @@ func (sm *SessionManager) handleInbound(ctx context.Context, msg bus.InboundMess
 	if len(msg.Media) > 0 {
 		paths := make([]string, 0, len(msg.Media))
 		for _, ref := range msg.Media {
-			if sm.mediaStore != nil && strings.HasPrefix(ref, "media://") {
-				if p, err := sm.mediaStore.Resolve(ref); err == nil {
+			if s.mgr.mediaStore != nil && strings.HasPrefix(ref, "media://") {
+				if p, err := s.mgr.mediaStore.Resolve(ref); err == nil {
 					paths = append(paths, p)
 					continue
 				}
@@ -312,44 +442,50 @@ func (sm *SessionManager) handleInbound(ctx context.Context, msg bus.InboundMess
 	})
 
 	start := time.Now()
-	sm.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressTurnStarted})
+	s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressTurnStarted})
 
-	response, err := sm.agent.Run(actx, input)
+	response, err := s.agent.Run(actx, input)
 	if err != nil {
 		logger.ErrorCF("agent", "Agent run failed", map[string]any{"error": err.Error()})
-		_ = sm.bus.PublishOutbound(ctx, bus.OutboundMessage{
-			Channel: msg.Channel,
-			ChatID:  chatID,
-			Content: fmt.Sprintf("Error: %v", err),
-		})
-		sm.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressFailed, Error: err, Elapsed: time.Since(start)})
-		sm.emitSummary(ctx, ProgressSummary{
-			Channel:   msg.Channel,
-			ChatID:    chatID,
-			Success:   false,
-			Duration:  time.Since(start),
-			Error:     err,
+		if s.mgr.bus != nil {
+			_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
+				Channel:    msg.Channel,
+				ChatID:     chatID,
+				SessionKey: sessionKey,
+				Content:    fmt.Sprintf("Error: %v", err),
+			})
+		}
+		s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressFailed, Error: err, Elapsed: time.Since(start)})
+		s.mgr.emitSummary(ctx, ProgressSummary{
+			Channel:  msg.Channel,
+			ChatID:   chatID,
+			Success:  false,
+			Duration: time.Since(start),
+			Error:    err,
 		})
 		return
 	}
 
 	if response != "" {
-		_ = sm.bus.PublishOutbound(ctx, bus.OutboundMessage{
-			Channel: msg.Channel,
-			ChatID:  chatID,
-			Content: response,
-		})
+		if s.mgr.bus != nil {
+			_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
+				Channel:    msg.Channel,
+				ChatID:     chatID,
+				SessionKey: sessionKey,
+				Content:    response,
+			})
+		}
 	}
-	sm.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressCompleted, Elapsed: time.Since(start)})
-	sm.emitSummary(ctx, ProgressSummary{
-		Channel:   msg.Channel,
-		ChatID:    chatID,
-		Success:   true,
-		Duration:  time.Since(start),
+	s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressCompleted, Elapsed: time.Since(start)})
+	s.mgr.emitSummary(ctx, ProgressSummary{
+		Channel:  msg.Channel,
+		ChatID:   chatID,
+		Success:  true,
+		Duration: time.Since(start),
 	})
 }
 
-func (sm *SessionManager) runStreamingTurn(
+func (s *Session) runStreamingTurn(
 	actx context.Context,
 	outCtx context.Context,
 	channel string,
@@ -357,21 +493,21 @@ func (sm *SessionManager) runStreamingTurn(
 	input string,
 	start time.Time,
 ) (string, *interfaces.TokenUsage, int, error) {
-	events, err := sm.agent.RunStream(actx, input)
+	events, err := s.agent.RunStream(actx, input)
 	if err != nil {
-		sm.emitProgress(outCtx, ProgressEvent{Channel: channel, ChatID: chatID, Kind: ProgressFallback, Error: err, Elapsed: time.Since(start)})
-		return sm.runDetailedTurn(actx, input)
+		s.mgr.emitProgress(outCtx, ProgressEvent{Channel: channel, ChatID: chatID, Kind: ProgressFallback, Error: err, Elapsed: time.Since(start)})
+		return s.runDetailedTurn(actx, input)
 	}
 	if events == nil {
 		err := errors.New("agent stream returned nil event channel")
-		sm.emitProgress(outCtx, ProgressEvent{Channel: channel, ChatID: chatID, Kind: ProgressFallback, Error: err, Elapsed: time.Since(start)})
-		return sm.runDetailedTurn(actx, input)
+		s.mgr.emitProgress(outCtx, ProgressEvent{Channel: channel, ChatID: chatID, Kind: ProgressFallback, Error: err, Elapsed: time.Since(start)})
+		return s.runDetailedTurn(actx, input)
 	}
 
 	var streamer bus.Streamer
 	var hasStreamer bool
-	if sm.bus != nil {
-		streamer, hasStreamer = sm.bus.GetStreamer(outCtx, channel, chatID)
+	if s.mgr.bus != nil {
+		streamer, hasStreamer = s.mgr.bus.GetStreamer(outCtx, channel, chatID)
 	}
 
 	var sb strings.Builder
@@ -380,7 +516,7 @@ func (sm *SessionManager) runStreamingTurn(
 	var streamErr error
 	firstActivity := false
 	lastActivity := time.Now()
-	heartbeatInterval := sm.heartbeatInterval()
+	heartbeatInterval := s.mgr.heartbeatInterval()
 	heartbeat := time.NewTimer(heartbeatInterval)
 	defer heartbeat.Stop()
 
@@ -400,7 +536,7 @@ func (sm *SessionManager) runStreamingTurn(
 			}
 			if !firstActivity {
 				firstActivity = true
-				sm.emitProgress(outCtx, ProgressEvent{Channel: channel, ChatID: chatID, Kind: ProgressFirstActivity, Elapsed: time.Since(start)})
+				s.mgr.emitProgress(outCtx, ProgressEvent{Channel: channel, ChatID: chatID, Kind: ProgressFirstActivity, Elapsed: time.Since(start)})
 			}
 			switch event.Type {
 			case interfaces.AgentEventContent:
@@ -412,7 +548,7 @@ func (sm *SessionManager) runStreamingTurn(
 				}
 			case interfaces.AgentEventToolCall:
 				toolCalls++
-				sm.emitProgress(outCtx, ProgressEvent{
+				s.mgr.emitProgress(outCtx, ProgressEvent{
 					Channel:  channel,
 					ChatID:   chatID,
 					Kind:     ProgressToolCallStarted,
@@ -420,7 +556,7 @@ func (sm *SessionManager) runStreamingTurn(
 					Elapsed:  time.Since(start),
 				})
 			case interfaces.AgentEventToolResult:
-				sm.emitProgress(outCtx, ProgressEvent{
+				s.mgr.emitProgress(outCtx, ProgressEvent{
 					Channel:  channel,
 					ChatID:   chatID,
 					Kind:     ProgressToolCallFinished,
@@ -444,7 +580,7 @@ func (sm *SessionManager) runStreamingTurn(
 				return sb.String(), usage, toolCalls, streamErr
 			}
 		case <-heartbeat.C:
-			sm.emitProgress(outCtx, ProgressEvent{
+			s.mgr.emitProgress(outCtx, ProgressEvent{
 				Channel: channel,
 				ChatID:  chatID,
 				Kind:    ProgressHeartbeat,
@@ -460,8 +596,8 @@ func (sm *SessionManager) runStreamingTurn(
 	}
 }
 
-func (sm *SessionManager) runDetailedTurn(ctx context.Context, input string) (string, *interfaces.TokenUsage, int, error) {
-	response, err := sm.agent.RunDetailed(ctx, input)
+func (s *Session) runDetailedTurn(ctx context.Context, input string) (string, *interfaces.TokenUsage, int, error) {
+	response, err := s.agent.RunDetailed(ctx, input)
 	if err != nil {
 		return "", nil, 0, err
 	}

--- a/internal/agent/session_debug_test.go
+++ b/internal/agent/session_debug_test.go
@@ -70,9 +70,10 @@ func (c *collectingProgress) Summary(_ context.Context, summary ProgressSummary)
 func TestSessionManagerDebugStartCompletionAndSummary(t *testing.T) {
 	extBus := bus.NewMessageBus()
 	progress := &collectingProgress{}
-	sm := &SessionManager{agent: &mockRunner{runResult: "hello"}, bus: extBus, progress: progress}
+	sm := &SessionManager{bus: extBus, progress: progress}
+	session := &Session{agent: &mockRunner{runResult: "hello"}, mgr: sm}
 
-	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "hi"))
+	session.handleInbound(t.Context(), inbound("telegram", "chat1", "hi"), "telegram:chat1")
 
 	msg := requireOutboundMessage(t, extBus)
 	assert.Equal(t, "hello", msg.Content)
@@ -101,9 +102,10 @@ func TestSessionManagerDebugToolEventsUseOnlyNames(t *testing.T) {
 		interfaces.AgentStreamEvent{Type: interfaces.AgentEventContent, Content: "done"},
 	)
 	progress := &collectingProgress{}
-	sm := &SessionManager{agent: &mockRunner{stream: events}, bus: bus.NewMessageBus(), progress: progress}
+	sm := &SessionManager{bus: bus.NewMessageBus(), progress: progress}
+	session := &Session{agent: &mockRunner{stream: events}, mgr: sm}
 
-	response, _, toolCalls, err := sm.runStreamingTurn(t.Context(), t.Context(), "telegram", "chat1", "run", time.Now())
+	response, _, toolCalls, err := session.runStreamingTurn(t.Context(), t.Context(), "telegram", "chat1", "run", time.Now())
 
 	require.NoError(t, err)
 	assert.Equal(t, "done", response)
@@ -137,9 +139,10 @@ func TestSessionManagerDebugTokenSummaryFromStreamMetadata(t *testing.T) {
 		},
 	)
 	progress := &collectingProgress{}
-	sm := &SessionManager{agent: &mockRunner{stream: events}, bus: bus.NewMessageBus(), progress: progress}
+	sm := &SessionManager{bus: bus.NewMessageBus(), progress: progress}
+	session := &Session{agent: &mockRunner{stream: events}, mgr: sm}
 
-	_, usage, _, err := sm.runStreamingTurn(t.Context(), t.Context(), "telegram", "chat1", "tokens", time.Now())
+	_, usage, _, err := session.runStreamingTurn(t.Context(), t.Context(), "telegram", "chat1", "tokens", time.Now())
 
 	require.NoError(t, err)
 	require.NotNil(t, usage)
@@ -156,9 +159,10 @@ func TestSessionManagerDebugHeartbeatAfterSilence(t *testing.T) {
 		close(ch)
 	}()
 	progress := &collectingProgress{heartbeat: 10 * time.Millisecond}
-	sm := &SessionManager{agent: &mockRunner{stream: ch}, bus: bus.NewMessageBus(), progress: progress}
+	sm := &SessionManager{bus: bus.NewMessageBus(), progress: progress}
+	session := &Session{agent: &mockRunner{stream: ch}, mgr: sm}
 
-	_, _, _, err := sm.runStreamingTurn(t.Context(), t.Context(), "telegram", "chat1", "slow", time.Now())
+	_, _, _, err := session.runStreamingTurn(t.Context(), t.Context(), "telegram", "chat1", "slow", time.Now())
 
 	require.NoError(t, err)
 	assertHasEvent(t, progress.events, ProgressHeartbeat)
@@ -168,9 +172,10 @@ func TestSessionManagerRunErrorPublishesOneUserErrorAndFailureSummary(t *testing
 	runErr := errors.New("run failed")
 	extBus := bus.NewMessageBus()
 	progress := &collectingProgress{}
-	sm := &SessionManager{agent: &mockRunner{runErr: runErr}, bus: extBus, progress: progress}
+	sm := &SessionManager{bus: extBus, progress: progress}
+	session := &Session{agent: &mockRunner{runErr: runErr}, mgr: sm}
 
-	sm.handleInbound(t.Context(), inbound("telegram", "chat1", "bad"))
+	session.handleInbound(t.Context(), inbound("telegram", "chat1", "bad"), "telegram:chat1")
 
 	msg := requireOutboundMessage(t, extBus)
 	assert.Equal(t, "Error: run failed", msg.Content)
@@ -184,7 +189,8 @@ func TestSessionManagerRunErrorPublishesOneUserErrorAndFailureSummary(t *testing
 func TestSessionManagerStreamingStartupFallbackUsesDetailedUsage(t *testing.T) {
 	startErr := errors.New("no streaming")
 	progress := &collectingProgress{}
-	sm := &SessionManager{
+	sm := &SessionManager{bus: bus.NewMessageBus(), progress: progress}
+	session := &Session{
 		agent: &mockRunner{
 			streamErr: startErr,
 			detailed: &interfaces.AgentResponse{
@@ -196,11 +202,10 @@ func TestSessionManagerStreamingStartupFallbackUsesDetailedUsage(t *testing.T) {
 				},
 			},
 		},
-		bus:      bus.NewMessageBus(),
-		progress: progress,
+		mgr: sm,
 	}
 
-	response, usage, toolCalls, err := sm.runStreamingTurn(t.Context(), t.Context(), "telegram", "chat1", "fallback", time.Now())
+	response, usage, toolCalls, err := session.runStreamingTurn(t.Context(), t.Context(), "telegram", "chat1", "fallback", time.Now())
 
 	require.NoError(t, err)
 	assert.Equal(t, "fallback", response)

--- a/internal/agent/session_integration_test.go
+++ b/internal/agent/session_integration_test.go
@@ -1,0 +1,295 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/config"
+)
+
+// TestSessionIsolation verifies that two sessions with different keys do not
+// share conversation memory.
+func TestSessionIsolation(t *testing.T) {
+	ws := t.TempDir()
+	skillsDir := filepath.Join(ws, "skills", "python")
+	require.NoError(t, os.MkdirAll(skillsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillsDir, "SKILL.md"), []byte("You are a Python expert."), 0644))
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{ModelName: "test-model"},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+	}
+	cfg.Agents.Defaults.Workspace = ws
+
+	sm, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
+	require.NoError(t, err)
+
+	// Activate a skill in session A.
+	err = sm.ActivateSkill("session-a", "python")
+	require.NoError(t, err)
+
+	// Session A should have the skill in memory.
+	msgsA, err := sm.GetMessages("session-a", context.Background())
+	require.NoError(t, err)
+	require.Len(t, msgsA, 1)
+	assert.Equal(t, "You are a Python expert.", msgsA[0].Content)
+
+	// Session B should have no messages.
+	msgsB, err := sm.GetMessages("session-b", context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, msgsB)
+
+	// Activating the same skill in session B should succeed (independent state).
+	err = sm.ActivateSkill("session-b", "python")
+	require.NoError(t, err)
+
+	msgsB, err = sm.GetMessages("session-b", context.Background())
+	require.NoError(t, err)
+	require.Len(t, msgsB, 1)
+	assert.Equal(t, "You are a Python expert.", msgsB[0].Content)
+
+	// Session A should still only have one message.
+	msgsA, err = sm.GetMessages("session-a", context.Background())
+	require.NoError(t, err)
+	require.Len(t, msgsA, 1)
+}
+
+// TestClearHistoryEvictsSession verifies that ClearHistory removes the session
+// from the registry so a subsequent dispatch creates a fresh empty session.
+func TestClearHistoryEvictsSession(t *testing.T) {
+	ws := t.TempDir()
+	skillsDir := filepath.Join(ws, "skills", "python")
+	require.NoError(t, os.MkdirAll(skillsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillsDir, "SKILL.md"), []byte("You are a Python expert."), 0644))
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{ModelName: "test-model"},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+	}
+	cfg.Agents.Defaults.Workspace = ws
+
+	sm, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
+	require.NoError(t, err)
+
+	// Load a skill into the session.
+	err = sm.ActivateSkill("telegram:chat1", "python")
+	require.NoError(t, err)
+
+	msgs, err := sm.GetMessages("telegram:chat1", context.Background())
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	// Clear history should evict the session entirely.
+	err = sm.ClearHistory("telegram:chat1")
+	require.NoError(t, err)
+
+	msgs, err = sm.GetMessages("telegram:chat1", context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, msgs)
+
+	// Re-activating the skill should work again (fresh session).
+	err = sm.ActivateSkill("telegram:chat1", "python")
+	require.NoError(t, err)
+
+	msgs, err = sm.GetMessages("telegram:chat1", context.Background())
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+}
+
+// TestSessionManagerEviction verifies that stale sessions are evicted by the
+// background cleanup goroutine.
+func TestSessionManagerEviction(t *testing.T) {
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{ModelName: "test-model"},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+	}
+
+	sm, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
+	require.NoError(t, err)
+
+	// Force a very short TTL and cleanup interval for testing.
+	sm.ttl = 50 * time.Millisecond
+	sm.cleanupInterval = 50 * time.Millisecond
+	sm.Start()
+	defer sm.Stop()
+
+	// Create a session by activating a skill.
+	ws := t.TempDir()
+	skillsDir := filepath.Join(ws, "skills", "python")
+	require.NoError(t, os.MkdirAll(skillsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillsDir, "SKILL.md"), []byte("Skill content."), 0644))
+	cfg.Agents.Defaults.Workspace = ws
+
+	err = sm.ActivateSkill("old-session", "python")
+	require.NoError(t, err)
+
+	// Verify session exists.
+	msgs, err := sm.GetMessages("old-session", context.Background())
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	// Wait for the session to become stale and be evicted.
+	time.Sleep(200 * time.Millisecond)
+
+	msgs, err = sm.GetMessages("old-session", context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, msgs)
+}
+
+// TestDispatchUsesSessionKey verifies that Dispatch routes to the correct
+// session based on the inbound message's SessionKey.
+func TestDispatchUsesSessionKey(t *testing.T) {
+	extBus := bus.NewMessageBus()
+	progress := &collectingProgress{}
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{ModelName: "test-model"},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+	}
+
+	sm, err := NewSessionManager(cfg, extBus, nil, nil, WithProgressSink(progress))
+	require.NoError(t, err)
+
+	// Use a mock session directly to avoid real LLM calls.
+	sm.mu.Lock()
+	sessionA := &Session{
+		agent:           &mockRunner{runResult: "response-a"},
+		mem:             NewInMemoryMemory(),
+		activatedSkills: make(map[string]bool),
+		lastUsed:        time.Now(),
+		mgr:             sm,
+	}
+	sm.sessions["email:thread-1"] = sessionA
+
+	sessionB := &Session{
+		agent:           &mockRunner{runResult: "response-b"},
+		mem:             NewInMemoryMemory(),
+		activatedSkills: make(map[string]bool),
+		lastUsed:        time.Now(),
+		mgr:             sm,
+	}
+	sm.sessions["email:thread-2"] = sessionB
+	sm.mu.Unlock()
+
+	// Dispatch to session A.
+	sm.Dispatch(context.Background(), bus.InboundMessage{
+		Channel:    "email",
+		ChatID:     "user@example.com",
+		Content:    "hello",
+		SessionKey: "email:thread-1",
+	})
+
+	msgA := requireOutboundMessage(t, extBus)
+	assert.Equal(t, "response-a", msgA.Content)
+	assert.Equal(t, "email:thread-1", msgA.SessionKey)
+
+	// Dispatch to session B.
+	sm.Dispatch(context.Background(), bus.InboundMessage{
+		Channel:    "email",
+		ChatID:     "user@example.com",
+		Content:    "world",
+		SessionKey: "email:thread-2",
+	})
+
+	msgB := requireOutboundMessage(t, extBus)
+	assert.Equal(t, "response-b", msgB.Content)
+	assert.Equal(t, "email:thread-2", msgB.SessionKey)
+}
+
+// TestComputeSessionKey verifies the session key computation logic.
+func TestComputeSessionKey(t *testing.T) {
+	cases := []struct {
+		name     string
+		msg      bus.InboundMessage
+		expected string
+	}{
+		{
+			name:     "explicit SessionKey",
+			msg:      bus.InboundMessage{Channel: "telegram", ChatID: "123", SessionKey: "custom:key"},
+			expected: "custom:key",
+		},
+		{
+			name:     "fallback to channel:chat_id",
+			msg:      bus.InboundMessage{Channel: "telegram", ChatID: "123"},
+			expected: "telegram:123",
+		},
+		{
+			name:     "empty SessionKey falls back",
+			msg:      bus.InboundMessage{Channel: "whatsapp", ChatID: "456", SessionKey: ""},
+			expected: "whatsapp:456",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := computeSessionKey(c.msg)
+			assert.Equal(t, c.expected, got)
+		})
+	}
+}
+
+// TestOutboundMessageIncludesSessionKey verifies that handleInbound propagates
+// the session key to outbound messages.
+func TestOutboundMessageIncludesSessionKey(t *testing.T) {
+	extBus := bus.NewMessageBus()
+	progress := &collectingProgress{}
+	sm := &SessionManager{bus: extBus, progress: progress}
+	session := &Session{agent: &mockRunner{runResult: "hi"}, mgr: sm}
+
+	session.handleInbound(context.Background(), bus.InboundMessage{
+		Channel: "telegram",
+		ChatID:  "chat1",
+		Content: "hello",
+	}, "telegram:chat1")
+
+	msg := requireOutboundMessage(t, extBus)
+	assert.Equal(t, "hi", msg.Content)
+	assert.Equal(t, "telegram:chat1", msg.SessionKey)
+}
+
+// mockRunner is reused from session_debug_test.go.
+var _ agentRunner = (*mockRunner)(nil)
+
+// collectingProgress is reused from session_debug_test.go.
+var _ ProgressSink = (*collectingProgress)(nil)
+
+// requireOutboundMessage is reused from session_debug_test.go.

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -303,11 +303,11 @@ func TestSessionManager_ActivateSkill(t *testing.T) {
 	require.NoError(t, err)
 
 	// First activation should succeed.
-	err = sm.ActivateSkill("python")
+	err = sm.ActivateSkill("test-session", "python")
 	require.NoError(t, err)
 
 	// Verify the skill content is in memory.
-	msgs, err := sm.GetMessages(context.Background())
+	msgs, err := sm.GetMessages("test-session", context.Background())
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 	assert.Equal(t, interfaces.MessageRoleSystem, msgs[0].Role)
@@ -337,8 +337,8 @@ func TestSessionManager_ActivateSkill_AlreadyLoaded(t *testing.T) {
 	sm, err := agent.NewSessionManager(cfg, nil, nil, nil)
 	require.NoError(t, err)
 
-	require.NoError(t, sm.ActivateSkill("python"))
-	err = sm.ActivateSkill("python")
+	require.NoError(t, sm.ActivateSkill("test-session", "python"))
+	err = sm.ActivateSkill("test-session", "python")
 	require.Error(t, err)
 	assert.ErrorIs(t, err, commands.ErrSkillAlreadyLoaded)
 }
@@ -363,7 +363,7 @@ func TestSessionManager_ActivateSkill_NotFound(t *testing.T) {
 	sm, err := agent.NewSessionManager(cfg, nil, nil, nil)
 	require.NoError(t, err)
 
-	err = sm.ActivateSkill("nonexistent")
+	err = sm.ActivateSkill("test-session", "nonexistent")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -138,6 +138,10 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 			return fmt.Errorf("error creating agent session: %w", err)
 		}
 	}
+	if sessionMgr != nil {
+		sessionMgr.Start()
+		defer sessionMgr.Stop()
+	}
 
 	cm, err := channels.NewManager(cfg, messageBus, mediaStore)
 	if err != nil {
@@ -170,11 +174,15 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 
 	rt.SetDebug = dm.Set
 	if sessionMgr != nil {
-		rt.ClearHistory = sessionMgr.ClearHistory
+		rt.ClearHistory = func(req commands.Request) error {
+			return sessionMgr.ClearHistory(req.SessionKey)
+		}
 		rt.GetModelInfo = sessionMgr.GetModelInfo
 		rt.ListModels = sessionMgr.ListModels
 		rt.ListSkills = sessionMgr.ListSkills
-		rt.ActivateSkill = sessionMgr.ActivateSkill
+		rt.ActivateSkill = func(req commands.Request, skillName string) error {
+			return sessionMgr.ActivateSkill(req.SessionKey, skillName)
+		}
 	}
 	executor := commands.NewExecutor(reg, rt)
 
@@ -211,14 +219,20 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 					continue
 				}
 
+				sessionKey := msg.SessionKey
+				if sessionKey == "" {
+					sessionKey = msg.Channel + ":" + msg.ChatID
+				}
+
 				if commands.HasCommandPrefix(msg.Content) {
 					var reply string
 					result := executor.Execute(ctx, commands.Request{
-						Channel:  msg.Channel,
-						ChatID:   msg.ChatID,
-						SenderID: msg.SenderID,
-						Text:     msg.Content,
-						Reply:    func(text string) error { reply = text; return nil },
+						Channel:    msg.Channel,
+						ChatID:     msg.ChatID,
+						SenderID:   msg.SenderID,
+						Text:       msg.Content,
+						SessionKey: sessionKey,
+						Reply:      func(text string) error { reply = text; return nil },
 					})
 					logger.DebugCF("executor", "Command executed",
 						map[string]any{

--- a/pkg/channels/base.go
+++ b/pkg/channels/base.go
@@ -219,6 +219,19 @@ func (c *BaseChannel) HandleMessageWithContext(
 	inboundCtx bus.InboundContext,
 	senderOpts ...bus.SenderInfo,
 ) {
+	c.HandleMessageWithContextAndSession(ctx, deliveryChatID, content, mediaFiles, inboundCtx, "", senderOpts...)
+}
+
+// HandleMessageWithContextAndSession is like HandleMessageWithContext but allows
+// the caller to specify an explicit session key for per-conversation isolation.
+func (c *BaseChannel) HandleMessageWithContextAndSession(
+	ctx context.Context,
+	deliveryChatID, content string,
+	mediaFiles []string,
+	inboundCtx bus.InboundContext,
+	sessionKey string,
+	senderOpts ...bus.SenderInfo,
+) {
 	var sender bus.SenderInfo
 	if len(senderOpts) > 0 {
 		sender = senderOpts[0]
@@ -258,6 +271,7 @@ func (c *BaseChannel) HandleMessageWithContext(
 		Content:    content,
 		Media:      mediaFiles,
 		MediaScope: scope,
+		SessionKey: sessionKey,
 	}
 	msg = bus.NormalizeInboundMessage(msg)
 
@@ -299,6 +313,19 @@ func (c *BaseChannel) HandleInboundContext(
 	senderOpts ...bus.SenderInfo,
 ) {
 	c.HandleMessageWithContext(ctx, deliveryChatID, content, mediaFiles, inboundCtx, senderOpts...)
+}
+
+// HandleInboundContextAndSession is like HandleInboundContext but allows the
+// caller to specify an explicit session key for per-conversation isolation.
+func (c *BaseChannel) HandleInboundContextAndSession(
+	ctx context.Context,
+	deliveryChatID, content string,
+	mediaFiles []string,
+	inboundCtx bus.InboundContext,
+	sessionKey string,
+	senderOpts ...bus.SenderInfo,
+) {
+	c.HandleMessageWithContextAndSession(ctx, deliveryChatID, content, mediaFiles, inboundCtx, sessionKey, senderOpts...)
 }
 
 // SetMediaStore injects a MediaStore into the channel.

--- a/pkg/channels/email/email.go
+++ b/pkg/channels/email/email.go
@@ -36,7 +36,7 @@ type EmailChannel struct {
 	cancel          context.CancelFunc
 	tm              *ThreadManager
 	tmMu            sync.RWMutex
-	lastMsgByChatID sync.Map // chatID/fromAddr (string) → most recent inbound messageID (string)
+	lastMsgByThread sync.Map // threadID (string) → most recent inbound messageID (string)
 }
 
 // NewEmailChannel creates a new email channel.
@@ -140,12 +140,14 @@ func (c *EmailChannel) Send(ctx context.Context, msg bus.OutboundMessage) ([]str
 	outboundMsgIDRaw := strings.Trim(outboundMsgID, "<>")
 
 	// Resolve reply target: use explicit ReplyToMessageID or fall back to the last
-	// inbound from this chat. The picoclaw framework's default response path
-	// (PublishResponseIfNeeded) never sets ReplyToMessageID on outbound messages,
-	// so the fallback is the primary way threading works in practice.
+	// inbound from this thread. SessionKey carries the thread ID for email.
 	replyToID := msg.ReplyToMessageID
 	if replyToID == "" {
-		if v, ok := c.lastMsgByChatID.Load(to); ok {
+		threadKey := msg.SessionKey
+		if threadKey == "" {
+			threadKey = to
+		}
+		if v, ok := c.lastMsgByThread.Load(threadKey); ok {
 			replyToID = v.(string)
 		}
 	}
@@ -292,7 +294,7 @@ func (c *EmailChannel) sendMultipartEmail(ctx context.Context, to, content, repl
 	outboundMsgIDRaw := strings.Trim(outboundMsgID, "<>")
 
 	if replyToID == "" {
-		if v, ok := c.lastMsgByChatID.Load(to); ok {
+		if v, ok := c.lastMsgByThread.Load(to); ok {
 			replyToID = v.(string)
 		}
 	}
@@ -621,6 +623,7 @@ func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope
 	})
 
 	metadata := map[string]string{}
+	var threadID string
 	if envelope.MessageID != "" {
 		rawID := strings.Trim(envelope.MessageID, "<>")
 
@@ -631,9 +634,11 @@ func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope
 
 		c.tmMu.Lock()
 		c.tm.ProcessHeaders(rawID, envelope.Subject, inReplyTo, references)
+		threadID = c.tm.ThreadID(rawID)
 		c.tmMu.Unlock()
 
-		c.lastMsgByChatID.Store(fromAddr, rawID)
+		sessionKey := c.Name() + ":" + threadID
+		c.lastMsgByThread.Store(sessionKey, rawID)
 		metadata["reply_to_message_id"] = rawID
 	}
 
@@ -646,19 +651,20 @@ func (c *EmailChannel) processEmail(ctx context.Context, envelope *imap.Envelope
 		DisplayName: displayName(envelope),
 	}
 
-	c.HandleMessageWithContext(ctx,
-		fromAddr,
-		plainText,
-		mediaPaths,
-		bus.InboundContext{
-			ChatType:  "direct",
-			ChatID:    fromAddr,
-			SenderID:  fromAddr,
-			MessageID: envelope.MessageID,
-			Raw:       metadata,
-		},
-		sender,
-	)
+	inboundCtx := bus.InboundContext{
+		ChatType:  "direct",
+		ChatID:    fromAddr,
+		SenderID:  fromAddr,
+		MessageID: envelope.MessageID,
+		Raw:       metadata,
+	}
+
+	sessionKey := ""
+	if threadID != "" {
+		sessionKey = c.Name() + ":" + threadID
+	}
+
+	c.HandleInboundContextAndSession(ctx, fromAddr, plainText, mediaPaths, inboundCtx, sessionKey, sender)
 
 	return true, plainText
 }

--- a/pkg/channels/email/email_test.go
+++ b/pkg/channels/email/email_test.go
@@ -403,6 +403,9 @@ func TestProcessEmail_TextInteraction(t *testing.T) {
 		if inbound.Context.Raw["reply_to_message_id"] != "mid-1" {
 			t.Errorf("metadata[reply_to_message_id] = %q, want %q", inbound.Context.Raw["reply_to_message_id"], "mid-1")
 		}
+		if inbound.SessionKey != "email:mid-1" {
+			t.Errorf("SessionKey = %q, want %q", inbound.SessionKey, "email:mid-1")
+		}
 	}
 }
 
@@ -507,13 +510,16 @@ func TestSend_ReplyThreadingHeaders(t *testing.T) {
 		}
 	})
 
-	t.Run("no ReplyToMessageID — fallback via lastMsgByChatID", func(t *testing.T) {
+	t.Run("no ReplyToMessageID — fallback via lastMsgByThread", func(t *testing.T) {
 		ch, received := newCh(t)
 		ch.tm.ProcessHeaders("inbound-msg@sender.com", "User question", "", "")
-		ch.lastMsgByChatID.Store("user@example.com", "inbound-msg@sender.com")
+		threadID := ch.tm.ThreadID("inbound-msg@sender.com")
+		sessionKey := ch.Name() + ":" + threadID
+		ch.lastMsgByThread.Store(sessionKey, "inbound-msg@sender.com")
 
 		_, err := ch.Send(context.Background(), bus.OutboundMessage{
 			ChatID: "user@example.com", Content: "Agent reply",
+			SessionKey: sessionKey,
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/channels/email/threading.go
+++ b/pkg/channels/email/threading.go
@@ -84,6 +84,19 @@ func (tm *ThreadManager) ProcessHeaders(msgID, subject, inReplyTo, references st
 	parentNode.Children = append(parentNode.Children, node)
 }
 
+// ThreadID returns the root Message-ID of the thread that msgID belongs to.
+// If msgID is unknown, it returns msgID itself.
+func (tm *ThreadManager) ThreadID(msgID string) string {
+	node, ok := tm.AllMessages[msgID]
+	if !ok {
+		return msgID
+	}
+	for node.Parent != nil {
+		node = node.Parent
+	}
+	return node.MessageID
+}
+
 // BuildThreads rebuilds the Threads slice from AllMessages.
 // Call after all ProcessHeaders calls are done if you need the root list.
 func (tm *ThreadManager) BuildThreads() {

--- a/pkg/channels/email/threading_test.go
+++ b/pkg/channels/email/threading_test.go
@@ -96,6 +96,26 @@ func TestThreadManager_ReferencesChain(t *testing.T) {
 	}
 }
 
+func TestThreadManager_ThreadID(t *testing.T) {
+	tm := NewThreadManager()
+	tm.ProcessHeaders("root@x.com", "Root", "", "")
+	tm.ProcessHeaders("child@x.com", "Re: Root", "root@x.com", "<root@x.com>")
+	tm.ProcessHeaders("grandchild@x.com", "Re: Root", "child@x.com", "<root@x.com> <child@x.com>")
+
+	if got := tm.ThreadID("root@x.com"); got != "root@x.com" {
+		t.Errorf("ThreadID(root) = %q, want root@x.com", got)
+	}
+	if got := tm.ThreadID("child@x.com"); got != "root@x.com" {
+		t.Errorf("ThreadID(child) = %q, want root@x.com", got)
+	}
+	if got := tm.ThreadID("grandchild@x.com"); got != "root@x.com" {
+		t.Errorf("ThreadID(grandchild) = %q, want root@x.com", got)
+	}
+	if got := tm.ThreadID("unknown@x.com"); got != "unknown@x.com" {
+		t.Errorf("ThreadID(unknown) = %q, want unknown@x.com", got)
+	}
+}
+
 func TestThreadManager_BuildThreads(t *testing.T) {
 	tm := NewThreadManager()
 	tm.ProcessHeaders("root1@x.com", "Thread A", "", "")

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -46,11 +46,12 @@ func (d Definition) EffectiveUsage() string {
 
 // Request is the input to a command handler.
 type Request struct {
-	Channel  string
-	ChatID   string
-	SenderID string
-	Text     string
-	Reply    func(text string) error
+	Channel    string
+	ChatID     string
+	SenderID   string
+	Text       string
+	SessionKey string
+	Reply      func(text string) error
 }
 
 // SkillInfo describes a skill available in the configured workspace.
@@ -66,9 +67,9 @@ type Runtime struct {
 	ListModels      func() []string
 	ListSkills      func() []SkillInfo
 	ListCronJobs    func() (string, error)
-	ClearHistory    func() error
+	ClearHistory    func(req Request) error
 	SetDebug        func(ctx context.Context, channel, chatID, mode string) string
-	ActivateSkill   func(skillName string) error
+	ActivateSkill   func(req Request, skillName string) error
 }
 
 // Registry stores command definitions indexed by name and alias.
@@ -353,7 +354,7 @@ func listCronHandler(_ context.Context, req Request, rt *Runtime) error {
 
 func clearHandler(_ context.Context, req Request, rt *Runtime) error {
 	if rt != nil && rt.ClearHistory != nil {
-		if err := rt.ClearHistory(); err != nil {
+		if err := rt.ClearHistory(req); err != nil {
 			return req.Reply("Failed to clear history: " + err.Error())
 		}
 	}
@@ -401,7 +402,7 @@ func useHandler(_ context.Context, req Request, rt *Runtime) error {
 	if rt == nil || rt.ActivateSkill == nil {
 		return req.Reply("Skill activation is not available.")
 	}
-	if err := rt.ActivateSkill(skillName); err != nil {
+	if err := rt.ActivateSkill(req, skillName); err != nil {
 		if errors.Is(err, ErrSkillAlreadyLoaded) {
 			return req.Reply(fmt.Sprintf("Skill %s is already loaded.", skillName))
 		}

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -90,7 +90,7 @@ func TestExecuteClearCallsCallback(t *testing.T) {
 	cleared := false
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
 	rt := &commands.Runtime{
-		ClearHistory: func() error { cleared = true; return nil },
+		ClearHistory: func(req commands.Request) error { cleared = true; return nil },
 	}
 	exec := commands.NewExecutor(reg, rt)
 
@@ -329,7 +329,7 @@ func TestExecuteListUnknownOptionIncludesSkills(t *testing.T) {
 func TestExecuteUseSuccess(t *testing.T) {
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
 	rt := &commands.Runtime{
-		ActivateSkill: func(name string) error { return nil },
+		ActivateSkill: func(req commands.Request, name string) error { return nil },
 	}
 	exec := commands.NewExecutor(reg, rt)
 
@@ -358,7 +358,7 @@ func TestExecuteUseMissingArg(t *testing.T) {
 func TestExecuteUseAlreadyLoaded(t *testing.T) {
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
 	rt := &commands.Runtime{
-		ActivateSkill: func(name string) error { return commands.ErrSkillAlreadyLoaded },
+		ActivateSkill: func(req commands.Request, name string) error { return commands.ErrSkillAlreadyLoaded },
 	}
 	exec := commands.NewExecutor(reg, rt)
 
@@ -374,7 +374,7 @@ func TestExecuteUseAlreadyLoaded(t *testing.T) {
 func TestExecuteUseCallbackError(t *testing.T) {
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
 	rt := &commands.Runtime{
-		ActivateSkill: func(name string) error { return assert.AnError },
+		ActivateSkill: func(req commands.Request, name string) error { return assert.AnError },
 	}
 	exec := commands.NewExecutor(reg, rt)
 

--- a/pkg/cron/scheduler.go
+++ b/pkg/cron/scheduler.go
@@ -265,6 +265,9 @@ func (s *Scheduler) executeJob(job Job) {
 }
 
 func (s *Scheduler) agentTurn(ctx context.Context, job Job) {
+	// Cron agent turns share the target chat's session (channel:chatID).
+	// If the session was evicted due to inactivity, getOrCreateSession
+	// lazily builds a fresh one, so the cron job always runs.
 	msg := bus.InboundMessage{
 		Context: bus.InboundContext{
 			Channel:  job.Channel,
@@ -274,7 +277,8 @@ func (s *Scheduler) agentTurn(ctx context.Context, job Job) {
 		Sender: bus.SenderInfo{
 			CanonicalID: job.SenderID,
 		},
-		Content: job.Message,
+		Content:    job.Message,
+		SessionKey: job.Channel + ":" + job.ChatID,
 	}
 	if err := s.bus.PublishInbound(ctx, msg); err != nil {
 		logger.ErrorCF("cron", "Failed to publish inbound cron job", map[string]any{


### PR DESCRIPTION
## Summary

All channels currently share a single SessionManager with one global InMemoryMemory. Messages from Telegram, Email, and WhatsApp are appended to the same conversation history, causing cross-channel contamination.

This PR isolates agent memory per `(channel, chat_id)` pair and scopes email sessions by thread root Message-ID instead of sender address.

## Changes

- **Session registry**: Introduced `Session` struct with own `agentRunner`, `InMemoryMemory`, and `activatedSkills`. `SessionManager` is now a registry keyed by session key.
- **Session key computation**: Defaults to `channel:chat_id`. Email overrides this with `email:<threadRootMessageID>`.
- **`/clear` evicts sessions**: `ClearHistory(sessionKey)` now removes the session from the registry entirely, allowing GC.
- **Background eviction**: Stale sessions are evicted after 30 days of inactivity (1h cleanup interval). Started via `SessionManager.Start()`, stopped on shutdown.
- **Email thread scoping**: Uses `ThreadManager.ThreadID()` to walk the parent chain to the root. Sets `SessionKey` on inbound messages and `lastMsgByThread` for reply threading.
- **Command scoping**: `/clear` and `/use` now operate on the current session only via `commands.Request.SessionKey`.
- **Cron jobs**: Explicitly set `SessionKey = channel:chat_id` so they share (or lazily recreate) the target chat's session.

## Test plan

- Full test suite: **458 passed in 27 packages**
- golangci-lint: **0 issues**
- New integration tests:
  - `TestSessionIsolation` — two sessions have independent memory
  - `TestClearHistoryEvictsSession` — `/clear` removes the session
  - `TestSessionManagerEviction` — background cleanup removes stale sessions
  - `TestDispatchUsesSessionKey` — messages route to the correct session
  - `TestComputeSessionKey` — key fallback logic
  - `TestOutboundMessageIncludesSessionKey` — outbound propagation
  - `TestThreadManager_ThreadID` — walks parent chain to root

## Related

Fixes #128