### PR TITLE
feat(agent): clarify workspace entrypoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,7 @@ The agent loads markdown files from `agents.defaults.workspace` at startup to bu
 |------|---------|
 | `AGENT.md` | Agent name, role, mission, capabilities |
 | `IDENTITY.md` | Identity, profile details, stable preferences |
+| `MEMORY.md` | Durable notes, long-lived facts, session-independent context |
 | `SOUL.md` | Personality and communication style |
 | `USER.md` | Legacy alias for `IDENTITY.md` in older workspaces |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,8 +195,9 @@ The agent loads markdown files from `agents.defaults.workspace` at startup to bu
 | File | Purpose |
 |------|---------|
 | `AGENT.md` | Agent name, role, mission, capabilities |
+| `IDENTITY.md` | Identity, profile details, stable preferences |
 | `SOUL.md` | Personality and communication style |
-| `USER.md` | Information about you (name, timezone, preferences) |
+| `USER.md` | Legacy alias for `IDENTITY.md` in older workspaces |
 
 `internal/agent/context.go` (`ContextBuilder`) assembles these into a single system prompt with
 mtime-based caching. Skills in `workspace/skills/*/SKILL.md` are also enumerated and included.

--- a/README.md
+++ b/README.md
@@ -222,13 +222,14 @@ The legacy top-level `email_channel` key is no longer supported.
 
 ## Workspace customization
 
-The agent loads three Markdown files from `agents.defaults.workspace` at startup:
+The agent loads workspace markdown entrypoints from `agents.defaults.workspace` at startup:
 
 | File | Purpose |
 |------|---------|
 | `AGENT.md` | Agent name, role, mission, capabilities |
+| `IDENTITY.md` | Identity, profile details, stable preferences |
 | `SOUL.md` | Personality and communication style |
-| `USER.md` | Information about you (name, timezone, preferences) |
+| `USER.md` | Legacy alias for `IDENTITY.md` in older workspaces |
 
 Edit these to shape how the agent behaves and presents itself.
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ The agent loads workspace markdown entrypoints from `agents.defaults.workspace` 
 |------|---------|
 | `AGENT.md` | Agent name, role, mission, capabilities |
 | `IDENTITY.md` | Identity, profile details, stable preferences |
+| `MEMORY.md` | Durable notes, long-lived facts, session-independent context |
 | `SOUL.md` | Personality and communication style |
 | `USER.md` | Legacy alias for `IDENTITY.md` in older workspaces |
 

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ContextBuilder assembles the agent system prompt from workspace files:
-// AGENT.md, SOUL.md, USER.md, and skills/*/SKILL.md.
+// AGENT.md, IDENTITY.md, SOUL.md, USER.md, and skills/*/SKILL.md.
 // Prompts are cached and invalidated when source file mtimes change.
 type ContextBuilder struct {
 	workspace string
@@ -71,12 +71,15 @@ func (b *ContextBuilder) buildPrompt() (string, error) {
 		}
 	}
 
-	if soul, ok := b.readFileIfExists(filepath.Join(b.workspace, "SOUL.md")); ok {
-		sections = append(sections, soul)
+	if identity, ok := b.readFirstExistingFile(
+		filepath.Join(b.workspace, "IDENTITY.md"),
+		filepath.Join(b.workspace, "USER.md"),
+	); ok {
+		sections = append(sections, "## Identity\n\n"+identity)
 	}
 
-	if user, ok := b.readFileIfExists(filepath.Join(b.workspace, "USER.md")); ok {
-		sections = append(sections, "## User Profile\n\n"+user)
+	if soul, ok := b.readFileIfExists(filepath.Join(b.workspace, "SOUL.md")); ok {
+		sections = append(sections, soul)
 	}
 
 	if summary := b.skillsSummary(filepath.Join(b.workspace, "skills")); summary != "" {
@@ -88,6 +91,7 @@ func (b *ContextBuilder) buildPrompt() (string, error) {
 		return "", nil
 	}
 
+	sections = append([]string{workspaceEntrypointsSection()}, sections...)
 	return strings.Join(sections, "\n\n---\n\n"), nil
 }
 
@@ -133,6 +137,7 @@ func (b *ContextBuilder) cacheValidLocked() bool {
 func (b *ContextBuilder) captureBaseline() (map[string]time.Time, map[string]bool) {
 	paths := []string{
 		filepath.Join(b.workspace, "AGENT.md"),
+		filepath.Join(b.workspace, "IDENTITY.md"),
 		filepath.Join(b.workspace, "SOUL.md"),
 		filepath.Join(b.workspace, "USER.md"),
 	}
@@ -211,6 +216,26 @@ func (b *ContextBuilder) readFileIfExists(path string) (string, bool) {
 		return "", false
 	}
 	return strings.TrimSpace(string(data)), true
+}
+
+func (b *ContextBuilder) readFirstExistingFile(paths ...string) (string, bool) {
+	for _, path := range paths {
+		if content, ok := b.readFileIfExists(path); ok {
+			return content, true
+		}
+	}
+	return "", false
+}
+
+func workspaceEntrypointsSection() string {
+	return strings.TrimSpace(`## Workspace entrypoints
+
+- ` + "`AGENT.md`" + `: authoritative source for role, mission, capabilities, tool scope, and other assistant-level behavior.
+- ` + "`IDENTITY.md`" + `: authoritative source for identity, profile details, naming, and stable preferences.
+- ` + "`SOUL.md`" + `: authoritative source for personality, tone, and communication style.
+- ` + "`USER.md`" + `: legacy alias for ` + "`IDENTITY.md`" + `; use only when a workspace has not been migrated yet.
+
+When a user asks you to change how the assistant behaves, infer the correct entrypoint from the requested change and edit that file directly. Do not ask the user which workspace file to touch.`)
 }
 
 // parseMarkdownBody strips YAML frontmatter (--- ... ---) from markdown content

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ContextBuilder assembles the agent system prompt from workspace files:
-// AGENT.md, IDENTITY.md, SOUL.md, USER.md, and skills/*/SKILL.md.
+// AGENT.md, IDENTITY.md, MEMORY.md, SOUL.md, USER.md, and skills/*/SKILL.md.
 // Prompts are cached and invalidated when source file mtimes change.
 type ContextBuilder struct {
 	workspace string
@@ -82,6 +82,10 @@ func (b *ContextBuilder) buildPrompt() (string, error) {
 		sections = append(sections, soul)
 	}
 
+	if memory, ok := b.readFileIfExists(filepath.Join(b.workspace, "memory", "MEMORY.md")); ok {
+		sections = append(sections, "## Memory\n\n"+memory)
+	}
+
 	if summary := b.skillsSummary(filepath.Join(b.workspace, "skills")); summary != "" {
 		sections = append(sections, summary)
 	}
@@ -138,6 +142,7 @@ func (b *ContextBuilder) captureBaseline() (map[string]time.Time, map[string]boo
 	paths := []string{
 		filepath.Join(b.workspace, "AGENT.md"),
 		filepath.Join(b.workspace, "IDENTITY.md"),
+		filepath.Join(b.workspace, "memory", "MEMORY.md"),
 		filepath.Join(b.workspace, "SOUL.md"),
 		filepath.Join(b.workspace, "USER.md"),
 	}
@@ -232,6 +237,7 @@ func workspaceEntrypointsSection() string {
 
 - ` + "`AGENT.md`" + `: authoritative source for role, mission, capabilities, tool scope, and other assistant-level behavior.
 - ` + "`IDENTITY.md`" + `: authoritative source for identity, profile details, naming, and stable preferences.
+- ` + "`MEMORY.md`" + `: authoritative source for durable notes, long-lived facts, and session-independent context.
 - ` + "`SOUL.md`" + `: authoritative source for personality, tone, and communication style.
 - ` + "`USER.md`" + `: legacy alias for ` + "`IDENTITY.md`" + `; use only when a workspace has not been migrated yet.
 

--- a/internal/agent/context_test.go
+++ b/internal/agent/context_test.go
@@ -60,9 +60,33 @@ Calm and concise.
 	assert.Contains(t, prompt, "Fallback identity content.")
 }
 
+func TestBuildSystemPromptIncludesMemoryEntryPoint(t *testing.T) {
+	workspace := t.TempDir()
+	writeWorkspaceFile(t, workspace, "AGENT.md", `You are the test agent.`)
+	writeWorkspaceFile(t, workspace, "IDENTITY.md", `Preferred identity content.`)
+	writeWorkspaceFile(t, workspace, "SOUL.md", `# Soul
+
+Calm and concise.
+`)
+	writeWorkspaceFile(t, workspace, filepath.Join("memory", "MEMORY.md"), `# Long-term Memory
+
+Remember to keep responses brief.
+`)
+
+	prompt, err := agent.NewContextBuilder(workspace).BuildSystemPromptWithCache()
+	require.NoError(t, err)
+
+	assert.Contains(t, prompt, "## Memory")
+	assert.Contains(t, prompt, "Remember to keep responses brief.")
+}
+
 func writeWorkspaceFile(t *testing.T, workspace, name, content string) {
 	t.Helper()
 
-	err := os.WriteFile(filepath.Join(workspace, name), []byte(content), 0o600)
+	path := filepath.Join(workspace, name)
+	err := os.MkdirAll(filepath.Dir(path), 0o755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(path, []byte(content), 0o600)
 	require.NoError(t, err)
 }

--- a/internal/agent/context_test.go
+++ b/internal/agent/context_test.go
@@ -1,0 +1,68 @@
+package agent_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sushi30/sushiclaw/internal/agent"
+)
+
+func TestBuildSystemPromptUsesIdentityEntryPoint(t *testing.T) {
+	workspace := t.TempDir()
+	writeWorkspaceFile(t, workspace, "AGENT.md", `---
+name: test-agent
+---
+
+You are the test agent.
+`)
+	writeWorkspaceFile(t, workspace, "IDENTITY.md", `# Identity
+
+Preferred identity content.
+`)
+	writeWorkspaceFile(t, workspace, "USER.md", `Legacy identity content should not be used when IDENTITY.md exists.
+`)
+	writeWorkspaceFile(t, workspace, "SOUL.md", `# Soul
+
+Calm and concise.
+`)
+
+	prompt, err := agent.NewContextBuilder(workspace).BuildSystemPromptWithCache()
+	require.NoError(t, err)
+
+	assert.Contains(t, prompt, "## Workspace entrypoints")
+	assert.Contains(t, prompt, "`AGENT.md`")
+	assert.Contains(t, prompt, "`IDENTITY.md`")
+	assert.Contains(t, prompt, "`SOUL.md`")
+	assert.Contains(t, prompt, "`USER.md`")
+	assert.Contains(t, prompt, "Preferred identity content.")
+	assert.NotContains(t, prompt, "Legacy identity content should not be used when IDENTITY.md exists.")
+	assert.Contains(t, prompt, "When a user asks you to change how the assistant behaves")
+}
+
+func TestBuildSystemPromptFallsBackToUserIdentity(t *testing.T) {
+	workspace := t.TempDir()
+	writeWorkspaceFile(t, workspace, "AGENT.md", `You are the test agent.`)
+	writeWorkspaceFile(t, workspace, "USER.md", `Fallback identity content.
+`)
+	writeWorkspaceFile(t, workspace, "SOUL.md", `# Soul
+
+Calm and concise.
+`)
+
+	prompt, err := agent.NewContextBuilder(workspace).BuildSystemPromptWithCache()
+	require.NoError(t, err)
+
+	assert.Contains(t, prompt, "## Identity")
+	assert.Contains(t, prompt, "Fallback identity content.")
+}
+
+func writeWorkspaceFile(t *testing.T, workspace, name, content string) {
+	t.Helper()
+
+	err := os.WriteFile(filepath.Join(workspace, name), []byte(content), 0o600)
+	require.NoError(t, err)
+}

--- a/workspace/AGENT.md
+++ b/workspace/AGENT.md
@@ -63,4 +63,4 @@ When the user asks to start a dev server:
 - Remain effective on constrained hardware
 - Improve through feedback and continued iteration
 
-Read `IDENTITY.md` for identity and stable preferences, and `SOUL.md` for personality and communication style.
+Read `IDENTITY.md` for identity and stable preferences, `MEMORY.md` for long-lived notes, and `SOUL.md` for personality and communication style.

--- a/workspace/AGENT.md
+++ b/workspace/AGENT.md
@@ -63,4 +63,4 @@ When the user asks to start a dev server:
 - Remain effective on constrained hardware
 - Improve through feedback and continued iteration
 
-Read `SOUL.md` as part of your identity and communication style.
+Read `IDENTITY.md` for identity and stable preferences, and `SOUL.md` for personality and communication style.

--- a/workspace/IDENTITY.md
+++ b/workspace/IDENTITY.md
@@ -1,0 +1,32 @@
+# Identity
+
+Use this file for identity, profile, and stable preference information.
+Prefer editing this file when a request changes who the assistant should be,
+how it should address the user, or what long-lived preferences should apply.
+`USER.md` is kept for compatibility with older workspaces.
+
+## Identity
+
+- **Name**: (fill in your name)
+- **Timezone**: (e.g., UTC+2, America/New_York)
+- **Language**: (your preferred language)
+
+## Preferences
+
+- **Communication style**: casual / formal / technical
+- **Response length**: brief / medium / detailed
+- **Code style**: (e.g., Pythonic, Go idiomatic, etc.)
+
+## Interests & Goals
+
+- (What do you want help with? e.g., "learning Go", "building side projects")
+- (What should the assistant prioritize?)
+
+## Context
+
+- (Add anything the assistant should always know about you)
+- (e.g., "I work remotely", "I prefer async communication")
+
+## Privacy Notes
+
+- (Any topics or data the assistant should be careful with)


### PR DESCRIPTION
## Summary
- Add explicit workspace entrypoint guidance to the embedded system prompt.
- Prefer `IDENTITY.md` as the identity source, while retaining `USER.md` as a legacy fallback.
- Add `MEMORY.md` as the durable workspace memory entrypoint.
- Add canonical workspace templates and update workspace docs to match.

## Test plan
- `GOCACHE=/tmp/gocache go test ./internal/agent`
- `go test ./...` was also attempted earlier, but unrelated sandbox socket restrictions blocked some integration-style tests in `pkg/channels/email`, `pkg/channels/websocket`, `pkg/tools/websearch`, and `pkg/utils`.

## Known gaps
- #134 Add skill activation observability to debug mode
- #135 Add skill activation and deactivation controls