### PR TITLE
feat: transcribe voice messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,12 @@ See [docs/MCP.md](docs/MCP.md) for full configuration options and examples.
 
 ---
 
-### WhatsApp voice memo transcription
+### Voice transcription
 
-Incoming WhatsApp audio messages are transcribed before reaching the agent. Powered by the ASR provider in the `voice` config block. Set `echo_transcription: true` to send the transcript back to the sender.
+Incoming WhatsApp and Telegram audio messages can be transcribed before
+reaching the agent. Powered by the ASR provider in the `voice` config block.
 
-Requires the `whatsapp_native` build tag (included in `make build`).
+See [docs/VOICE.md](docs/VOICE.md) for configuration options and examples.
 
 ---
 

--- a/config.example.json
+++ b/config.example.json
@@ -28,6 +28,7 @@
     }
   ],
   "voice": {
+    "enabled": false,
     "model_name": "whisper-1",
     "echo_transcription": false
   },

--- a/config.example.json
+++ b/config.example.json
@@ -19,8 +19,18 @@
       "model": "gpt-4o-mini",
       "api_key": "env://OPENAI_API_KEY",
       "api_base": "https://api.openai.com/v1"
+    },
+    {
+      "model_name": "whisper-1",
+      "model": "whisper-1",
+      "api_key": "env://OPENAI_API_KEY",
+      "api_base": "https://api.openai.com/v1"
     }
   ],
+  "voice": {
+    "model_name": "whisper-1",
+    "echo_transcription": false
+  },
   "channels": {
     "whatsapp_native": {
       "enabled": false,

--- a/docs/VOICE.md
+++ b/docs/VOICE.md
@@ -1,0 +1,93 @@
+# Voice Transcription
+
+Sushiclaw can transcribe inbound voice and audio messages before they reach
+the agent. The LLM receives the transcript wrapped in `<transcription>` tags
+instead of raw audio.
+
+Supported inbound channels:
+
+- WhatsApp native voice/audio messages
+- Telegram voice messages (`.ogg`) and audio attachments
+
+Raw audio is stored through the media store and resolved only for
+transcription. The agent prompt receives text, not audio bytes.
+
+## Configuration
+
+Add an ASR-capable model to `model_list`, then reference it from the
+top-level `voice` block:
+
+```json
+{
+  "model_list": [
+    {
+      "model_name": "gpt-4o-mini",
+      "model": "gpt-4o-mini",
+      "api_key": "env://OPENAI_API_KEY",
+      "api_base": "https://api.openai.com/v1"
+    },
+    {
+      "model_name": "whisper-1",
+      "model": "whisper-1",
+      "api_key": "env://OPENAI_API_KEY",
+      "api_base": "https://api.openai.com/v1"
+    }
+  ],
+  "voice": {
+    "model_name": "whisper-1",
+    "echo_transcription": false
+  }
+}
+```
+
+`voice.model_name` must match a `model_list[].model_name` entry. If it is empty,
+voice transcription is disabled.
+
+## Providers
+
+The transcriber uses an OpenAI-compatible `POST /audio/transcriptions` endpoint.
+Set `api_base` to the provider base URL and `model` to that provider's ASR
+model ID.
+
+Examples:
+
+- OpenAI: `api_base: "https://api.openai.com/v1"`, `model: "whisper-1"`
+- Groq or another compatible provider: use that provider's base URL and ASR
+  model ID
+
+API keys can use the existing `env://VAR_NAME` form:
+
+```json
+{
+  "api_key": "env://OPENAI_API_KEY"
+}
+```
+
+## Behavior
+
+When a supported channel receives audio:
+
+1. The channel downloads the audio and stores a media ref.
+2. The agent session resolves the media ref through the media store.
+3. Audio files are sent to the configured ASR provider.
+4. `[voice]` or `[audio]` markers are replaced with transcription tags.
+5. The transcribed text is sent to the LLM as the user input.
+
+If transcription fails for all audio attachments in a message, the sender receives:
+
+```text
+Sorry, I couldn't transcribe that voice message.
+```
+
+If transcription succeeds but produces no text, the sender receives:
+
+```text
+Sorry, I couldn't understand that voice message.
+```
+
+## Notes
+
+- Telegram voice messages are downloaded as `.ogg` and are supported.
+- Supported audio extensions include `.ogg`, `.oga`, `.mp3`, `.wav`, `.m4a`, `.aac`,
+  `.flac`, `.opus`, and `.webm`.
+- `echo_transcription` is currently used by the WhatsApp native channel behavior.

--- a/docs/VOICE.md
+++ b/docs/VOICE.md
@@ -34,14 +34,16 @@ top-level `voice` block:
     }
   ],
   "voice": {
+    "enabled": true,
     "model_name": "whisper-1",
     "echo_transcription": false
   }
 }
 ```
 
-`voice.model_name` must match a `model_list[].model_name` entry. If it is empty,
-voice transcription is disabled.
+`voice.enabled` must be `true` for transcription to run. `voice.model_name`
+must match a `model_list[].model_name` entry. If `voice.enabled` is `false`
+or `voice.model_name` is empty, voice transcription is disabled.
 
 ## Providers
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -15,7 +15,9 @@ import (
 	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
 	"github.com/Ingenimax/agent-sdk-go/pkg/llm/openai"
 
+	"github.com/sushi30/sushiclaw/pkg/audio/asr"
 	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/channels"
 	"github.com/sushi30/sushiclaw/pkg/commands"
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/llm/openrouter"
@@ -32,6 +34,7 @@ type SessionManager struct {
 	tools           []interfaces.Tool
 	progress        ProgressSink
 	mediaStore      media.MediaStore
+	transcriber     asr.Transcriber
 	sessions        map[string]*Session
 	mu              sync.RWMutex
 	ttl             time.Duration
@@ -277,6 +280,16 @@ func (sm *SessionManager) ClearHistory(sessionKey string) error {
 	return nil
 }
 
+// SetMediaStore injects a MediaStore for resolving media refs (e.g. voice messages).
+func (sm *SessionManager) SetMediaStore(ms media.MediaStore) {
+	sm.mediaStore = ms
+}
+
+// SetTranscriber injects an ASR transcriber for voice message transcription.
+func (sm *SessionManager) SetTranscriber(t asr.Transcriber) {
+	sm.transcriber = t
+}
+
 // ActivateSkill reads a skill's SKILL.md and injects it into the conversation
 // memory as a system message. If the skill is already loaded, it returns
 // commands.ErrSkillAlreadyLoaded.
@@ -416,6 +429,32 @@ func computeSessionKey(msg bus.InboundMessage) string {
 
 func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, sessionKey string) {
 	chatID := msg.ChatID
+
+	// Transcribe audio before processing.
+	msg, hadAudio, err := s.mgr.transcribeAudioInMessage(ctx, msg)
+	if err != nil {
+		logger.WarnCF("agent", "Transcription failed", map[string]any{"error": err.Error()})
+		if s.mgr.bus != nil {
+			_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
+				Channel:    msg.Channel,
+				ChatID:     chatID,
+				SessionKey: sessionKey,
+				Content:    "Sorry, I couldn't transcribe that voice message.",
+			})
+		}
+		return
+	}
+	if hadAudio && msg.Content == "" {
+		if s.mgr.bus != nil {
+			_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
+				Channel:    msg.Channel,
+				ChatID:     chatID,
+				SessionKey: sessionKey,
+				Content:    "Sorry, I couldn't understand that voice message.",
+			})
+		}
+		return
+	}
 
 	// Attach chat ID to context for tool use.
 	actx := exec.WithChatID(ctx, chatID)
@@ -715,6 +754,91 @@ func firstInt(m map[string]interface{}, keys ...string) (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+// transcribeAudioInMessage resolves audio media refs, transcribes them, and
+// replaces [voice]/[audio] annotations with <transcription> tags.
+// Returns the modified message, whether audio was present, and any fatal error.
+func (sm *SessionManager) transcribeAudioInMessage(ctx context.Context, msg bus.InboundMessage) (bus.InboundMessage, bool, error) {
+	if sm.transcriber == nil || sm.mediaStore == nil {
+		return msg, false, nil
+	}
+
+	var transcriptions []string
+	var keptMedia []string
+	hadAudio := false
+	successCount := 0
+
+	for _, ref := range msg.Media {
+		path, meta, err := sm.mediaStore.ResolveWithMeta(ref)
+		if err != nil {
+			logger.WarnCF("voice", "Failed to resolve media ref", map[string]any{"ref": ref, "error": err.Error()})
+			keptMedia = append(keptMedia, ref)
+			continue
+		}
+		if !asr.IsAudioFile(meta.Filename, meta.ContentType) {
+			keptMedia = append(keptMedia, ref)
+			continue
+		}
+		hadAudio = true
+
+		result, err := sm.transcriber.Transcribe(ctx, path)
+		if err != nil {
+			logger.WarnCF("voice", "Transcription failed", map[string]any{"ref": ref, "error": err.Error()})
+			transcriptions = append(transcriptions, "")
+			keptMedia = append(keptMedia, ref)
+			continue
+		}
+		transcriptions = append(transcriptions, result.Text)
+		successCount++
+	}
+
+	if !hadAudio {
+		return msg, false, nil
+	}
+
+	if successCount == 0 {
+		return msg, true, fmt.Errorf("all transcriptions failed")
+	}
+
+	// Replace annotations sequentially.
+	idx := 0
+	newContent := channels.AudioAnnotationRe.ReplaceAllStringFunc(msg.Content, func(match string) string {
+		if idx >= len(transcriptions) {
+			return match
+		}
+		text := transcriptions[idx]
+		idx++
+		if text == "" {
+			return match
+		}
+		return asr.WrapTranscription(text)
+	})
+
+	// Append any leftover transcriptions.
+	for ; idx < len(transcriptions); idx++ {
+		if transcriptions[idx] != "" {
+			if newContent != "" {
+				newContent += "\n"
+			}
+			newContent += asr.WrapTranscription(transcriptions[idx])
+		}
+	}
+
+	// If no annotations were present but we had audio, wrap the transcriptions.
+	if msg.Content == "" && newContent == "" {
+		var parts []string
+		for _, t := range transcriptions {
+			if t != "" {
+				parts = append(parts, asr.WrapTranscription(t))
+			}
+		}
+		newContent = strings.Join(parts, "\n")
+	}
+
+	msg.Content = newContent
+	msg.Media = keptMedia
+	return msg, true, nil
 }
 
 func createLLM(cfg *config.Config) (interfaces.LLM, error) {

--- a/internal/agent/session_transcription_test.go
+++ b/internal/agent/session_transcription_test.go
@@ -1,0 +1,92 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sushi30/sushiclaw/pkg/audio/asr"
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/media"
+)
+
+type fakeTranscriber struct {
+	text string
+	err  error
+}
+
+func (f fakeTranscriber) Name() string { return "fake" }
+
+func (f fakeTranscriber) Transcribe(context.Context, string) (*asr.TranscriptionResponse, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &asr.TranscriptionResponse{Text: f.text}, nil
+}
+
+func TestTranscribeAudioInMessage_ReplacesTelegramVoiceMarker(t *testing.T) {
+	store := media.NewFileMediaStore()
+	audioPath := makeTempMediaFile(t, "voice-*.ogg")
+	ref, err := store.Store(audioPath, media.MediaMeta{
+		Filename: "voice.ogg",
+		Source:   "telegram",
+	}, "telegram:123:456")
+	require.NoError(t, err)
+
+	sm := &SessionManager{
+		mediaStore:  store,
+		transcriber: fakeTranscriber{text: "please summarize my day"},
+	}
+
+	msg, hadAudio, err := sm.transcribeAudioInMessage(context.Background(), bus.InboundMessage{
+		Channel: "telegram",
+		ChatID:  "123",
+		Content: "listen to this\n[voice]",
+		Media:   []string{ref},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, hadAudio)
+	assert.Equal(t, "listen to this\n<transcription>please summarize my day</transcription>", msg.Content)
+	assert.Empty(t, msg.Media)
+}
+
+func TestTranscribeAudioInMessage_ReturnsErrorWhenTelegramAudioFails(t *testing.T) {
+	store := media.NewFileMediaStore()
+	audioPath := makeTempMediaFile(t, "audio-*.mp3")
+	ref, err := store.Store(audioPath, media.MediaMeta{
+		Filename: "audio.mp3",
+		Source:   "telegram",
+	}, "telegram:123:456")
+	require.NoError(t, err)
+
+	sm := &SessionManager{
+		mediaStore:  store,
+		transcriber: fakeTranscriber{err: errors.New("asr unavailable")},
+	}
+
+	_, hadAudio, err := sm.transcribeAudioInMessage(context.Background(), bus.InboundMessage{
+		Channel: "telegram",
+		ChatID:  "123",
+		Content: "[audio]",
+		Media:   []string{ref},
+	})
+
+	require.Error(t, err)
+	assert.True(t, hadAudio)
+}
+
+func makeTempMediaFile(t *testing.T, pattern string) string {
+	t.Helper()
+
+	f, err := os.CreateTemp(t.TempDir(), pattern)
+	require.NoError(t, err)
+	_, err = f.WriteString("test audio bytes")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sushi30/sushiclaw/internal/agent"
 	"github.com/sushi30/sushiclaw/internal/commandfilter"
 	"github.com/sushi30/sushiclaw/internal/envresolve"
+	"github.com/sushi30/sushiclaw/pkg/audio/asr"
 	"github.com/sushi30/sushiclaw/pkg/bus"
 	"github.com/sushi30/sushiclaw/pkg/channels"
 	"github.com/sushi30/sushiclaw/pkg/commands"
@@ -145,6 +146,16 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	if sessionMgr != nil {
 		sessionMgr.Start()
 		defer sessionMgr.Stop()
+	}
+
+	if sessionMgr != nil {
+		sessionMgr.SetMediaStore(mediaStore)
+		if transcriber := asr.DetectTranscriber(cfg); transcriber != nil {
+			sessionMgr.SetTranscriber(transcriber)
+			logger.InfoCF("gateway", "Voice transcription registered", map[string]any{
+				"provider": transcriber.Name(),
+			})
+		}
 	}
 
 	cm, err := channels.NewManager(cfg, messageBus, mediaStore)

--- a/pkg/audio/asr/asr.go
+++ b/pkg/audio/asr/asr.go
@@ -27,6 +27,9 @@ type TranscriptionResponse struct {
 // It looks up cfg.Voice.ModelName in cfg.ModelList and creates the appropriate implementation.
 func DetectTranscriber(cfg *config.Config) Transcriber {
 	voiceCfg := cfg.Voice()
+	if !voiceCfg.Enabled {
+		return nil
+	}
 	if voiceCfg.ModelName == "" {
 		return nil
 	}

--- a/pkg/audio/asr/asr.go
+++ b/pkg/audio/asr/asr.go
@@ -1,0 +1,94 @@
+// Package asr provides automatic speech recognition (transcription) for voice messages.
+package asr
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/logger"
+)
+
+// Transcriber transcribes audio files to text.
+type Transcriber interface {
+	Name() string
+	Transcribe(ctx context.Context, audioFilePath string) (*TranscriptionResponse, error)
+}
+
+// TranscriptionResponse is the result of transcribing an audio file.
+type TranscriptionResponse struct {
+	Text     string  `json:"text"`
+	Language string  `json:"language,omitempty"`
+	Duration float64 `json:"duration,omitempty"`
+}
+
+// DetectTranscriber creates a Transcriber from config if voice transcription is configured.
+// It looks up cfg.Voice.ModelName in cfg.ModelList and creates the appropriate implementation.
+func DetectTranscriber(cfg *config.Config) Transcriber {
+	voiceCfg := cfg.Voice()
+	if voiceCfg.ModelName == "" {
+		return nil
+	}
+
+	var modelCfg *config.ModelConfig
+	for i := range cfg.ModelList {
+		if cfg.ModelList[i].ModelName == voiceCfg.ModelName {
+			modelCfg = &cfg.ModelList[i]
+			break
+		}
+	}
+	if modelCfg == nil {
+		logger.WarnCF("voice", "Voice model not found in model_list", map[string]any{
+			"model_name": voiceCfg.ModelName,
+		})
+		return nil
+	}
+
+	apiKey := modelCfg.APIKeyString()
+	if apiKey == "" {
+		logger.WarnCF("voice", "Voice model has no API key", map[string]any{
+			"model_name": voiceCfg.ModelName,
+		})
+		return nil
+	}
+	if strings.HasPrefix(apiKey, "env://") {
+		logger.WarnCF("voice", "Voice model API key env var is not set", map[string]any{
+			"model_name": voiceCfg.ModelName,
+			"api_key":    apiKey,
+		})
+		return nil
+	}
+
+	model := modelCfg.Model
+	if model == "" {
+		model = voiceCfg.ModelName
+	}
+
+	// Use WhisperTranscriber for any OpenAI-compatible endpoint.
+	// This covers Groq, OpenAI, OpenRouter, and any other provider
+	// that exposes /audio/transcriptions.
+	return NewWhisperTranscriber(apiKey, model, modelCfg.APIBase)
+}
+
+// IsAudioFile checks whether a file is audio based on its metadata.
+func IsAudioFile(filename, contentType string) bool {
+	if strings.HasPrefix(contentType, "audio/") {
+		return true
+	}
+	ext := strings.ToLower(filename)
+	for _, audioExt := range []string{".ogg", ".oga", ".mp3", ".wav", ".m4a", ".aac", ".flac", ".opus", ".webm"} {
+		if strings.HasSuffix(ext, audioExt) {
+			return true
+		}
+	}
+	return false
+}
+
+// WrapTranscription wraps transcribed text in <transcription> tags.
+func WrapTranscription(text string) string {
+	if text == "" {
+		return ""
+	}
+	return fmt.Sprintf("<transcription>%s</transcription>", text)
+}

--- a/pkg/audio/asr/asr_test.go
+++ b/pkg/audio/asr/asr_test.go
@@ -1,0 +1,37 @@
+package asr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sushi30/sushiclaw/pkg/config"
+)
+
+func TestDetectTranscriber_Disabled(t *testing.T) {
+	cfg := voiceTestConfig(false)
+
+	assert.Nil(t, DetectTranscriber(cfg))
+}
+
+func TestDetectTranscriber_Enabled(t *testing.T) {
+	cfg := voiceTestConfig(true)
+
+	assert.NotNil(t, DetectTranscriber(cfg))
+}
+
+func voiceTestConfig(enabled bool) *config.Config {
+	return &config.Config{
+		VoiceConfig: config.VoiceConfig{
+			Enabled:   enabled,
+			ModelName: "whisper-1",
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "whisper-1",
+				Model:     "whisper-1",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+	}
+}

--- a/pkg/audio/asr/whisper_transcriber.go
+++ b/pkg/audio/asr/whisper_transcriber.go
@@ -1,0 +1,140 @@
+package asr
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/sushi30/sushiclaw/pkg/logger"
+)
+
+const defaultWhisperBaseURL = "https://api.openai.com/v1"
+
+// WhisperTranscriber transcribes audio using an OpenAI-compatible /audio/transcriptions endpoint.
+type WhisperTranscriber struct {
+	apiKey  string
+	model   string
+	baseURL string
+	client  *http.Client
+}
+
+// NewWhisperTranscriber creates a new Whisper-compatible transcriber.
+func NewWhisperTranscriber(apiKey, model, baseURL string) *WhisperTranscriber {
+	if baseURL == "" {
+		baseURL = defaultWhisperBaseURL
+	}
+	return &WhisperTranscriber{
+		apiKey:  apiKey,
+		model:   model,
+		baseURL: baseURL,
+		client:  &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// Name returns the transcriber name.
+func (t *WhisperTranscriber) Name() string {
+	return "whisper"
+}
+
+// Transcribe sends the audio file to the transcription endpoint and returns the text.
+func (t *WhisperTranscriber) Transcribe(ctx context.Context, audioFilePath string) (*TranscriptionResponse, error) {
+	file, err := os.Open(audioFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("open audio file: %w", err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			logger.WarnCF("voice", "Failed to close audio file", map[string]any{
+				"error": err.Error(),
+			})
+		}
+	}()
+
+	var requestBody bytes.Buffer
+	writer := multipart.NewWriter(&requestBody)
+
+	// Add the audio file.
+	fileName := filepath.Base(audioFilePath)
+	filePart, err := writer.CreateFormFile("file", fileName)
+	if err != nil {
+		return nil, fmt.Errorf("create form file: %w", err)
+	}
+	if _, err := io.Copy(filePart, file); err != nil {
+		return nil, fmt.Errorf("copy file to form: %w", err)
+	}
+
+	// Add model field.
+	if err := writer.WriteField("model", t.model); err != nil {
+		return nil, fmt.Errorf("write model field: %w", err)
+	}
+
+	// Request JSON response for structured parsing.
+	if err := writer.WriteField("response_format", "json"); err != nil {
+		return nil, fmt.Errorf("write response_format field: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("close multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.baseURL+"/audio/transcriptions", &requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+t.apiKey)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	logger.DebugCF("voice", "Sending transcription request", map[string]any{
+		"model":    t.model,
+		"base_url": t.baseURL,
+		"file":     fileName,
+	})
+
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("transcription request failed: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			logger.WarnCF("voice", "Failed to close transcription response body", map[string]any{
+				"error": err.Error(),
+			})
+		}
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("transcription API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Text     string  `json:"text"`
+		Language string  `json:"language,omitempty"`
+		Duration float64 `json:"duration,omitempty"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse transcription response: %w", err)
+	}
+
+	logger.DebugCF("voice", "Transcription received", map[string]any{
+		"language": result.Language,
+		"duration": result.Duration,
+	})
+
+	return &TranscriptionResponse{
+		Text:     result.Text,
+		Language: result.Language,
+		Duration: result.Duration,
+	}, nil
+}

--- a/pkg/channels/base.go
+++ b/pkg/channels/base.go
@@ -31,7 +31,8 @@ func init() {
 	uniqueIDPrefix = hex.EncodeToString(b[:])
 }
 
-var audioAnnotationRe = regexp.MustCompile(`\[(voice|audio)(?::[^\]]*)?\]`)
+// AudioAnnotationRe matches [voice] and [audio] annotations in message content.
+var AudioAnnotationRe = regexp.MustCompile(`\[(voice|audio)(?::[^\]]*)?\]`)
 
 func uniqueID() string {
 	n := atomic.AddUint64(&uniqueIDCounter, 1)
@@ -286,7 +287,7 @@ func (c *BaseChannel) HandleMessageWithContextAndSession(
 				c.placeholderRecorder.RecordReactionUndo(c.name, deliveryChatID, undo)
 			}
 		}
-		if !audioAnnotationRe.MatchString(content) {
+		if !AudioAnnotationRe.MatchString(content) {
 			if pc, ok := c.owner.(PlaceholderCapable); ok {
 				if phID, err := pc.SendPlaceholder(ctx, deliveryChatID); err == nil && phID != "" {
 					c.placeholderRecorder.RecordPlaceholder(c.name, deliveryChatID, phID)

--- a/pkg/channels/whatsapp_native/whatsapp_native.go
+++ b/pkg/channels/whatsapp_native/whatsapp_native.go
@@ -446,6 +446,12 @@ func (c *WhatsAppNativeChannel) handleIncoming(evt *events.Message) {
 					}, scope)
 					if storeErr == nil {
 						mediaPaths = append(mediaPaths, ref)
+						if strings.HasPrefix(mimetype, "audio/") {
+							if content != "" {
+								content += "\n"
+							}
+							content += "[voice]"
+						}
 					}
 				}
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,9 +10,9 @@ import (
 
 // Channel type constants.
 const (
-	ChannelTelegram       = "telegram"
-	ChannelWhatsAppNative = "whatsapp_native"
-	ChannelEmail          = "email"
+	ChannelTelegram        = "telegram"
+	ChannelWhatsAppNative  = "whatsapp_native"
+	ChannelEmail           = "email"
 	ChannelWebSocket       = "websocket"
 	ChannelWebSocketClient = "websocket_client"
 )
@@ -22,13 +22,14 @@ const DefaultMaxMediaSize = 20 * 1024 * 1024
 
 // Config is the top-level sushiclaw configuration.
 type Config struct {
-	Version   int            `json:"version,omitempty"`
-	Agents    AgentsConfig   `json:"agents"`
-	ModelList []ModelConfig  `json:"model_list"`
-	Channels  ChannelsConfig `json:"channels"`
-	Gateway   GatewayConfig  `json:"gateway"`
-	Tools     ToolsConfig    `json:"tools"`
-	MCP       MCPConfig      `json:"mcp,omitempty"`
+	Version     int            `json:"version,omitempty"`
+	Agents      AgentsConfig   `json:"agents"`
+	ModelList   []ModelConfig  `json:"model_list"`
+	Channels    ChannelsConfig `json:"channels"`
+	Gateway     GatewayConfig  `json:"gateway"`
+	Tools       ToolsConfig    `json:"tools"`
+	MCP         MCPConfig      `json:"mcp,omitempty"`
+	VoiceConfig VoiceConfig    `json:"voice,omitempty"`
 }
 
 // MCPConfig holds MCP server configuration.
@@ -379,8 +380,8 @@ func expandHome(p string) string {
 	return p
 }
 
-// Voice returns a zero VoiceConfig (sushiclaw doesn't configure voice globally).
-func (c *Config) Voice() VoiceConfig { return VoiceConfig{} }
+// Voice returns the voice configuration.
+func (c *Config) Voice() VoiceConfig { return c.VoiceConfig }
 
 // GetHome returns the sushiclaw home directory.
 func GetHome() string {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -298,6 +298,7 @@ func (c *WebSocketClientSettings) SetToken(token string) {
 
 // VoiceConfig holds voice/ASR settings.
 type VoiceConfig struct {
+	Enabled           bool   `json:"enabled"`
 	ModelName         string `json:"model_name,omitempty"`
 	TTSModelName      string `json:"tts_model_name,omitempty"`
 	EchoTranscription bool   `json:"echo_transcription"`

--- a/workspace/AGENT.md
+++ b/workspace/AGENT.md
@@ -34,6 +34,9 @@ be practical, accurate, and efficient.
 - Be transparent about actions and limits
 - Respect user control, privacy, and safety
 - Aim for fast, efficient help without sacrificing quality
+- Gate optional features through configuration, especially when they add
+  dependencies, external services, credentials, network calls, or extra runtime
+  cost. Prefer explicit enablement over surprising default behavior.
 
 ## Dev Server Workflow
 


### PR DESCRIPTION
## Summary
- Add OpenAI-compatible ASR support for inbound voice/audio attachments.
- Transcribe WhatsApp and Telegram voice/audio before agent execution, replacing raw audio markers with transcription text.
- Add voice config plumbing and focused tests for Telegram-origin audio refs.

Closes #108

## Test plan
- make test
- make lint