### PR TITLE
feat(websocket): route chat through websocket channel

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -75,7 +75,7 @@
     "websocket": {
       "enabled": false,
       "type": "websocket",
-      "token": "env://PICO_TOKEN",
+      "token": "env://SUSHICLAW_WEBSOCKET_TOKEN",
       "allow_token_query": false,
       "allow_origins": ["*"],
       "ping_interval": 30,

--- a/internal/chat/repl.go
+++ b/internal/chat/repl.go
@@ -4,42 +4,97 @@ package chat
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"os"
+	"sync"
+	"time"
 
-	agentsdk "github.com/Ingenimax/agent-sdk-go/pkg/agent"
+	"github.com/gorilla/websocket"
 
 	"github.com/sushi30/sushiclaw/internal/agent"
+	"github.com/sushi30/sushiclaw/internal/commandfilter"
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/channels"
+	wschannel "github.com/sushi30/sushiclaw/pkg/channels/websocket"
+	"github.com/sushi30/sushiclaw/pkg/commands"
 	"github.com/sushi30/sushiclaw/pkg/config"
 	sushitools "github.com/sushi30/sushiclaw/pkg/tools"
-	"github.com/sushi30/sushiclaw/pkg/tools/exec"
 )
 
 // ErrQuit signals the REPL should exit cleanly.
 var ErrQuit = errors.New("user quit")
 
+const chatSessionKey = "websocket:cli"
+
 // Runner holds the REPL state.
 type Runner struct {
-	agent   *agentsdk.Agent
 	scanner *bufio.Scanner
 	out     io.Writer
+	outMu   sync.Mutex
+	session *agent.SessionManager
+	bus     *bus.MessageBus
+	manager *channels.Manager
+	conn    *websocket.Conn
+	token   string
+	port    int
 }
 
 // NewRunner creates a chat runner from config.
 func NewRunner(cfg *config.Config) (*Runner, error) {
 	tools := sushitools.NewChatTools(cfg)
 
-	agentsdkAgent, err := agent.BuildAgent(cfg, tools)
+	messageBus := bus.NewMessageBus()
+	sessionMgr, err := agent.NewSessionManager(cfg, messageBus, tools, nil)
 	if err != nil {
-		return nil, fmt.Errorf("build agent: %w", err)
+		return nil, fmt.Errorf("create agent session: %w", err)
 	}
 
+	cm, err := channels.NewManager(&config.Config{}, messageBus, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create channel manager: %w", err)
+	}
+	messageBus.SetStreamDelegate(cm)
+
+	token, err := randomToken()
+	if err != nil {
+		return nil, fmt.Errorf("generate websocket token: %w", err)
+	}
+	port, err := availablePort()
+	if err != nil {
+		return nil, fmt.Errorf("find websocket port: %w", err)
+	}
+
+	bc := &config.Channel{
+		Enabled:   true,
+		Type:      config.ChannelWebSocket,
+		AllowFrom: config.FlexibleStringSlice{"*"},
+	}
+	bc.SetName(config.ChannelWebSocket)
+	wsCfg := &config.WebSocketSettings{
+		Port:         port,
+		AllowOrigins: []string{"*"},
+	}
+	wsCfg.SetToken(token)
+	wsChannel, err := wschannel.NewWebSocketChannel(bc, wsCfg, messageBus)
+	if err != nil {
+		return nil, fmt.Errorf("create websocket channel: %w", err)
+	}
+	cm.RegisterChannel(config.ChannelWebSocket, wsChannel)
+
 	return &Runner{
-		agent:   agentsdkAgent,
 		scanner: bufio.NewScanner(os.Stdin),
 		out:     os.Stdout,
+		session: sessionMgr,
+		bus:     messageBus,
+		manager: cm,
+		token:   token,
+		port:    port,
 	}, nil
 }
 
@@ -55,12 +110,21 @@ func (r *Runner) SetOutput(w io.Writer) {
 }
 
 func (r *Runner) Run(ctx context.Context) error {
-	_, _ = fmt.Fprintln(r.out, "Sushiclaw Chat")
-	_, _ = fmt.Fprintln(r.out, "Type /quit to exit, /help for commands")
-	_, _ = fmt.Fprintln(r.out)
+	runCtx, cancel := context.WithCancel(ctx)
+
+	if err := r.start(runCtx); err != nil {
+		cancel()
+		return err
+	}
+	defer r.stop()
+	defer cancel()
+
+	r.println("Sushiclaw Chat")
+	r.println("Type /quit to exit, /help for commands")
+	r.println("")
 
 	for {
-		_, _ = fmt.Fprint(r.out, "> ")
+		r.print("> ")
 		if !r.scanner.Scan() {
 			break
 		}
@@ -80,15 +144,10 @@ func (r *Runner) Run(ctx context.Context) error {
 			continue
 		}
 
-		// Send to agent
-		actx := exec.WithChatID(ctx, "cli")
-		response, err := r.agent.Run(actx, line)
-		if err != nil {
-			_, _ = fmt.Fprintf(r.out, "Error: %v\n", err)
+		if err := r.send(line); err != nil {
+			r.printf("Error: %v\n", err)
 			continue
 		}
-
-		_, _ = fmt.Fprintln(r.out, response)
 	}
 
 	return r.scanner.Err()
@@ -98,20 +157,226 @@ func (r *Runner) handleCommand(ctx context.Context, line string) (bool, error) {
 	_ = ctx
 	switch line {
 	case "/quit", "/q", "/exit":
-		_, _ = fmt.Fprintln(r.out, "Goodbye!")
+		r.println("Goodbye!")
 		return true, ErrQuit
 	case "/clear":
-		// In-memory memory is per-agent-instance, so "clear" just means
-		// we can't easily clear it without access to the memory interface.
-		// For now, tell the user.
-		_, _ = fmt.Fprintln(r.out, "Note: history is in-memory per session. Restart to clear.")
+		if r.session != nil {
+			if err := r.session.ClearHistory(chatSessionKey); err != nil {
+				return true, err
+			}
+		}
+		r.println("History cleared.")
 		return true, nil
 	case "/help", "/h":
-		_, _ = fmt.Fprintln(r.out, "Commands:")
-		_, _ = fmt.Fprintln(r.out, "  /quit    Exit the REPL")
-		_, _ = fmt.Fprintln(r.out, "  /clear   Note about history")
-		_, _ = fmt.Fprintln(r.out, "  /help    Show this help")
+		r.println("Commands:")
+		r.println("  /quit    Exit the REPL")
+		r.println("  /clear   Clear conversation history")
+		r.println("  /help    Show this help")
 		return true, nil
 	}
 	return false, nil
+}
+
+func (r *Runner) start(ctx context.Context) error {
+	if err := r.manager.StartAll(ctx); err != nil {
+		return fmt.Errorf("start websocket channel: %w", err)
+	}
+
+	r.startInboundLoop(ctx)
+
+	conn, err := r.dial(ctx)
+	if err != nil {
+		_ = r.manager.StopAll(context.Background())
+		return err
+	}
+	r.conn = conn
+
+	go r.readLoop(ctx)
+	return nil
+}
+
+func (r *Runner) stop() {
+	if r.conn != nil {
+		_ = r.conn.Close()
+	}
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = r.manager.StopAll(shutdownCtx)
+	if r.bus != nil {
+		r.bus.Close()
+	}
+}
+
+func (r *Runner) startInboundLoop(ctx context.Context) {
+	cmdFilter := commandfilter.NewCommandFilter()
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{
+		ListDefinitions: reg.Definitions,
+		GetModelInfo:    r.session.GetModelInfo,
+		ListModels:      r.session.ListModels,
+		ListSkills:      r.session.ListSkills,
+		ClearHistory: func(req commands.Request) error {
+			return r.session.ClearHistory(req.SessionKey)
+		},
+		ActivateSkill: func(req commands.Request, skillName string) error {
+			return r.session.ActivateSkill(req.SessionKey, skillName)
+		},
+	}
+	executor := commands.NewExecutor(reg, rt)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-r.bus.InboundChan():
+				if !ok {
+					return
+				}
+				dec := cmdFilter.Filter(msg)
+				if dec.Result == commandfilter.Block {
+					_ = r.bus.PublishOutbound(ctx, bus.OutboundMessage{
+						Channel: msg.Channel,
+						ChatID:  msg.ChatID,
+						Content: dec.ErrMsg,
+					})
+					continue
+				}
+
+				sessionKey := msg.SessionKey
+				if sessionKey == "" {
+					sessionKey = msg.Channel + ":" + msg.ChatID
+				}
+
+				if commands.HasCommandPrefix(msg.Content) {
+					var reply string
+					result := executor.Execute(ctx, commands.Request{
+						Channel:    msg.Channel,
+						ChatID:     msg.ChatID,
+						SenderID:   msg.SenderID,
+						Text:       msg.Content,
+						SessionKey: sessionKey,
+						Reply:      func(text string) error { reply = text; return nil },
+					})
+					if result.Outcome == commands.OutcomeHandled {
+						if reply != "" {
+							_ = r.bus.PublishOutbound(ctx, bus.OutboundMessage{
+								Channel: msg.Channel,
+								ChatID:  msg.ChatID,
+								Content: reply,
+							})
+						}
+						continue
+					}
+				}
+
+				go r.session.Dispatch(ctx, msg)
+			}
+		}
+	}()
+}
+
+func (r *Runner) dial(ctx context.Context) (*websocket.Conn, error) {
+	url := fmt.Sprintf("ws://127.0.0.1:%d/websocket/ws?session_id=cli", r.port)
+	header := http.Header{"Authorization": {"Bearer " + r.token}}
+
+	var lastErr error
+	for range 50 {
+		conn, resp, err := websocket.DefaultDialer.DialContext(ctx, url, header)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	return nil, fmt.Errorf("connect websocket channel: %w", lastErr)
+}
+
+func (r *Runner) send(line string) error {
+	if r.conn == nil {
+		return errors.New("websocket is not connected")
+	}
+	msg := wschannel.WebSocketMessage{
+		Type:      wschannel.TypeMessageSend,
+		SessionID: "cli",
+		Payload: map[string]any{
+			wschannel.PayloadKeyContent: line,
+		},
+	}
+	return r.conn.WriteJSON(msg)
+}
+
+func (r *Runner) readLoop(ctx context.Context) {
+	for {
+		var msg wschannel.WebSocketMessage
+		if err := r.conn.ReadJSON(&msg); err != nil {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				r.printf("\nWebSocket closed: %v\n", err)
+				return
+			}
+		}
+
+		switch msg.Type {
+		case wschannel.TypeMessageCreate, wschannel.TypeMessageUpdate:
+			content, _ := msg.Payload[wschannel.PayloadKeyContent].(string)
+			if content != "" {
+				r.printf("\n%s\n", content)
+			}
+		case wschannel.TypeError:
+			message, _ := msg.Payload["message"].(string)
+			if message != "" {
+				r.printf("\nError: %s\n", message)
+			}
+		}
+	}
+}
+
+func (r *Runner) print(s string) {
+	r.outMu.Lock()
+	defer r.outMu.Unlock()
+	_, _ = fmt.Fprint(r.out, s)
+}
+
+func (r *Runner) println(s string) {
+	r.outMu.Lock()
+	defer r.outMu.Unlock()
+	_, _ = fmt.Fprintln(r.out, s)
+}
+
+func (r *Runner) printf(format string, args ...any) {
+	r.outMu.Lock()
+	defer r.outMu.Unlock()
+	_, _ = fmt.Fprintf(r.out, format, args...)
+}
+
+func randomToken() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+func availablePort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = ln.Close() }()
+
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("unexpected listener address %T", ln.Addr())
+	}
+	return addr.Port, nil
 }

--- a/pkg/channels/websocket/client.go
+++ b/pkg/channels/websocket/client.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/logger"
 )
 
-// WebSocketClientChannel connects to a remote Pico Protocol WebSocket server.
+// WebSocketClientChannel connects to a remote WebSocket channel server.
 type WebSocketClientChannel struct {
 	*channels.BaseChannel
 	config *config.WebSocketClientSettings
@@ -29,14 +29,14 @@ type WebSocketClientChannel struct {
 	cancel context.CancelFunc
 }
 
-// NewWebSocketClientChannel creates a new Pico Protocol client channel.
+// NewWebSocketClientChannel creates a new WebSocket client channel.
 func NewWebSocketClientChannel(
 	bc *config.Channel,
 	cfg *config.WebSocketClientSettings,
 	messageBus *bus.MessageBus,
 ) (*WebSocketClientChannel, error) {
 	if cfg.URL == "" {
-		return nil, fmt.Errorf("pico_client url is required")
+		return nil, fmt.Errorf("websocket_client url is required")
 	}
 
 	base := channels.NewBaseChannel("websocket_client", cfg, messageBus, bc.AllowFrom)
@@ -49,12 +49,12 @@ func NewWebSocketClientChannel(
 
 // Start dials the remote server and begins reading.
 func (c *WebSocketClientChannel) Start(ctx context.Context) error {
-	logger.InfoC("websocket_client", "Starting Pico Client channel")
+	logger.InfoC("websocket_client", "Starting WebSocket client channel")
 	c.ctx, c.cancel = context.WithCancel(ctx)
 
 	if err := c.dial(); err != nil {
 		c.cancel()
-		return fmt.Errorf("pico_client initial connect: %w", err)
+		return fmt.Errorf("websocket_client initial connect: %w", err)
 	}
 
 	c.SetRunning(true)
@@ -66,7 +66,7 @@ func (c *WebSocketClientChannel) Start(ctx context.Context) error {
 
 // Stop closes the connection.
 func (c *WebSocketClientChannel) Stop(ctx context.Context) error {
-	logger.InfoC("websocket_client", "Stopping Pico Client channel")
+	logger.InfoC("websocket_client", "Stopping WebSocket client channel")
 	c.SetRunning(false)
 	if c.cancel != nil {
 		c.cancel()
@@ -76,7 +76,7 @@ func (c *WebSocketClientChannel) Stop(ctx context.Context) error {
 		c.conn.close()
 	}
 	c.mu.Unlock()
-	logger.InfoC("websocket_client", "Pico Client channel stopped")
+	logger.InfoC("websocket_client", "WebSocket client channel stopped")
 	return nil
 }
 

--- a/pkg/channels/websocket/client_test.go
+++ b/pkg/channels/websocket/client_test.go
@@ -37,7 +37,7 @@ func TestNewWebSocketClientChannel_OK(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if ch.Name() != "websocket_client" {
-		t.Fatalf("name = %q, want pico_client", ch.Name())
+		t.Fatalf("name = %q, want websocket_client", ch.Name())
 	}
 }
 

--- a/pkg/channels/websocket/protocol.go
+++ b/pkg/channels/websocket/protocol.go
@@ -25,7 +25,7 @@ const (
 	MessageKindThought = "thought"
 )
 
-// WebSocketMessage is the wire format for all Pico Protocol messages.
+// WebSocketMessage is the wire format for all WebSocket channel messages.
 type WebSocketMessage struct {
 	Type      string         `json:"type"`
 	ID        string         `json:"id,omitempty"`

--- a/pkg/channels/websocket/websocket.go
+++ b/pkg/channels/websocket/websocket.go
@@ -81,7 +81,7 @@ func (pc *wsConn) close() {
 	}
 }
 
-// WebSocketChannel implements the native Pico Protocol WebSocket channel.
+// WebSocketChannel implements the native WebSocket channel.
 // It serves as the reference implementation for all optional capability interfaces.
 type WebSocketChannel struct {
 	*channels.BaseChannel
@@ -98,14 +98,14 @@ type WebSocketChannel struct {
 	httpServer         *http.Server
 }
 
-// NewWebSocketChannel creates a new Pico Protocol channel.
+// NewWebSocketChannel creates a new WebSocket channel.
 func NewWebSocketChannel(
 	bc *config.Channel,
 	cfg *config.WebSocketSettings,
 	messageBus *bus.MessageBus,
 ) (*WebSocketChannel, error) {
 	if cfg.Token.String() == "" {
-		return nil, fmt.Errorf("pico token is required")
+		return nil, fmt.Errorf("websocket token is required")
 	}
 
 	base := channels.NewBaseChannel("websocket", cfg, messageBus, bc.AllowFrom)
@@ -236,7 +236,7 @@ func (c *WebSocketChannel) currentConnCount() int {
 
 // Start implements Channel.
 func (c *WebSocketChannel) Start(ctx context.Context) error {
-	logger.InfoC("websocket", "Starting Pico Protocol channel")
+	logger.InfoC("websocket", "Starting WebSocket channel")
 	c.ctx, c.cancel = context.WithCancel(ctx)
 	c.SetRunning(true)
 
@@ -256,13 +256,13 @@ func (c *WebSocketChannel) Start(ctx context.Context) error {
 		}
 	}()
 
-	logger.InfoCF("websocket", "Pico Protocol channel started", map[string]any{"addr": addr})
+	logger.InfoCF("websocket", "WebSocket channel started", map[string]any{"addr": addr})
 	return nil
 }
 
 // Stop implements Channel.
 func (c *WebSocketChannel) Stop(ctx context.Context) error {
-	logger.InfoC("websocket", "Stopping Pico Protocol channel")
+	logger.InfoC("websocket", "Stopping WebSocket channel")
 	c.SetRunning(false)
 
 	// Close all connections
@@ -283,16 +283,16 @@ func (c *WebSocketChannel) Stop(ctx context.Context) error {
 		c.progress.StopAll()
 	}
 
-	logger.InfoC("websocket", "Pico Protocol channel stopped")
+	logger.InfoC("websocket", "WebSocket channel stopped")
 	return nil
 }
 
 // WebhookPath implements channels.WebhookHandler.
-func (c *WebSocketChannel) WebhookPath() string { return "/pico/" }
+func (c *WebSocketChannel) WebhookPath() string { return "/websocket/" }
 
 // ServeHTTP implements http.Handler for the shared HTTP server.
 func (c *WebSocketChannel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimPrefix(r.URL.Path, "/pico")
+	path := strings.TrimPrefix(r.URL.Path, "/websocket")
 
 	switch path {
 	case "/ws", "/ws/":
@@ -456,7 +456,7 @@ func (c *WebSocketChannel) StartTyping(ctx context.Context, chatID string) (func
 }
 
 // SendPlaceholder implements channels.PlaceholderCapable.
-// It sends a placeholder message via the Pico Protocol that will later be
+// It sends a placeholder message via the WebSocket protocol that will later be
 // edited to the actual response via EditMessage (channels.MessageEditor).
 func (c *WebSocketChannel) SendPlaceholder(ctx context.Context, chatID string) (string, error) {
 	if !c.bc.Placeholder.Enabled {
@@ -479,7 +479,7 @@ func (c *WebSocketChannel) SendPlaceholder(ctx context.Context, chatID string) (
 	return msgID, nil
 }
 
-// SendMedia implements channels.MediaSender for the Pico web UI.
+// SendMedia implements channels.MediaSender for WebSocket clients.
 // Media is delivered as a normal assistant message carrying structured
 // attachments plus an authenticated same-origin download URL.
 func (c *WebSocketChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaMessage) ([]string, error) {
@@ -524,10 +524,10 @@ func (c *WebSocketChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaM
 
 		attachmentType := strings.TrimSpace(part.Type)
 		if attachmentType == "" {
-			attachmentType = picoInferAttachmentType(filename, contentType)
+			attachmentType = websocketInferAttachmentType(filename, contentType)
 		}
 
-		attachmentURL, err := picoDownloadURLForRef(part.Ref)
+		attachmentURL, err := websocketDownloadURLForRef(part.Ref)
 		if err != nil {
 			logger.ErrorCF("websocket", "Failed to build media download URL", map[string]any{
 				"ref":   part.Ref,
@@ -569,15 +569,15 @@ func (c *WebSocketChannel) SendMedia(ctx context.Context, msg bus.OutboundMediaM
 	return []string{msgID}, nil
 }
 
-func picoDownloadURLForRef(ref string) (string, error) {
-	refID, err := picoMediaRefID(ref)
+func websocketDownloadURLForRef(ref string) (string, error) {
+	refID, err := websocketMediaRefID(ref)
 	if err != nil {
 		return "", err
 	}
-	return "/pico/media/" + url.PathEscape(refID), nil
+	return "/websocket/media/" + url.PathEscape(refID), nil
 }
 
-func picoMediaRefID(ref string) (string, error) {
+func websocketMediaRefID(ref string) (string, error) {
 	refID := strings.TrimSpace(strings.TrimPrefix(ref, "media://"))
 	if refID == "" || strings.Contains(refID, "/") {
 		return "", fmt.Errorf("invalid media ref %q", ref)
@@ -585,7 +585,7 @@ func picoMediaRefID(ref string) (string, error) {
 	return refID, nil
 }
 
-func picoInferAttachmentType(filename, contentType string) string {
+func websocketInferAttachmentType(filename, contentType string) string {
 	contentType = strings.ToLower(strings.TrimSpace(contentType))
 	filename = strings.ToLower(strings.TrimSpace(filename))
 
@@ -610,7 +610,7 @@ func picoInferAttachmentType(filename, contentType string) string {
 	}
 }
 
-func picoAllowsInlineDisplay(filename, contentType string) bool {
+func websocketAllowsInlineDisplay(filename, contentType string) bool {
 	contentType = strings.ToLower(strings.TrimSpace(contentType))
 	filename = strings.ToLower(strings.TrimSpace(filename))
 
@@ -618,7 +618,7 @@ func picoAllowsInlineDisplay(filename, contentType string) bool {
 		return false
 	}
 
-	return picoInferAttachmentType(filename, contentType) == "image"
+	return websocketInferAttachmentType(filename, contentType) == "image"
 }
 
 func (c *WebSocketChannel) handleMediaDownload(w http.ResponseWriter, r *http.Request) {
@@ -631,7 +631,7 @@ func (c *WebSocketChannel) handleMediaDownload(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	refID := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, "/pico/media/"), "/"))
+	refID := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, "/websocket/media/"), "/"))
 	if refID == "" {
 		http.NotFound(w, r)
 		return
@@ -672,7 +672,7 @@ func (c *WebSocketChannel) handleMediaDownload(w http.ResponseWriter, r *http.Re
 	}
 
 	dispositionType := "attachment"
-	if picoAllowsInlineDisplay(filename, contentType) {
+	if websocketAllowsInlineDisplay(filename, contentType) {
 		dispositionType = "inline"
 	}
 
@@ -898,7 +898,7 @@ func (c *WebSocketChannel) pingLoop(pc *wsConn, interval time.Duration) {
 	}
 }
 
-// handleMessage processes an inbound Pico Protocol message.
+// handleMessage processes an inbound WebSocket message.
 func (c *WebSocketChannel) handleMessage(pc *wsConn, msg WebSocketMessage) {
 	switch msg.Type {
 	case TypePing:
@@ -1085,7 +1085,7 @@ func validateInlineImageDataURL(mediaURL string) error {
 	return nil
 }
 
-// setContextUsagePayload adds context window usage stats to a pico payload.
+// setContextUsagePayload adds context window usage stats to a WebSocket payload.
 func setContextUsagePayload(payload map[string]any, u *bus.ContextUsage) {
 	if u == nil {
 		return

--- a/pkg/channels/websocket/websocket_test.go
+++ b/pkg/channels/websocket/websocket_test.go
@@ -102,7 +102,7 @@ func TestSend_ThoughtMessageDoesNotFinalizeTrackedToolFeedback(t *testing.T) {
 	}
 	defer func() { _ = ch.Stop(context.Background()) }()
 
-	clientConn, received, cleanup := newTestPicoWebSocket(t)
+	clientConn, received, cleanup := newTestWebSocket(t)
 	defer cleanup()
 	ch.addConnForTest(&wsConn{id: "conn-1", conn: clientConn, sessionID: "sess-1"})
 
@@ -340,7 +340,7 @@ func TestSendMedia_DismissesTrackedToolFeedbackMessage(t *testing.T) {
 	}
 	defer func() { _ = ch.Stop(context.Background()) }()
 
-	clientConn, received, cleanup := newTestPicoWebSocket(t)
+	clientConn, received, cleanup := newTestWebSocket(t)
 	defer cleanup()
 	ch.addConnForTest(&wsConn{id: "conn-1", conn: clientConn, sessionID: "sess-1"})
 
@@ -399,13 +399,13 @@ func TestSendMedia_DismissesTrackedToolFeedbackMessage(t *testing.T) {
 	}
 }
 
-func TestPicoDownloadURLForRef(t *testing.T) {
-	got, err := picoDownloadURLForRef("media://attachment-1")
+func TestWebSocketDownloadURLForRef(t *testing.T) {
+	got, err := websocketDownloadURLForRef("media://attachment-1")
 	if err != nil {
-		t.Fatalf("picoDownloadURLForRef() error = %v", err)
+		t.Fatalf("websocketDownloadURLForRef() error = %v", err)
 	}
-	if got != "/pico/media/attachment-1" {
-		t.Fatalf("picoDownloadURLForRef() = %q, want %q", got, "/pico/media/attachment-1")
+	if got != "/websocket/media/attachment-1" {
+		t.Fatalf("websocketDownloadURLForRef() = %q, want %q", got, "/websocket/media/attachment-1")
 	}
 }
 
@@ -433,7 +433,7 @@ func TestHandleMediaDownload_ServesStoredFile(t *testing.T) {
 	}
 
 	refID := strings.TrimPrefix(ref, "media://")
-	req := httptest.NewRequest("GET", "/pico/media/"+refID, nil)
+	req := httptest.NewRequest("GET", "/websocket/media/"+refID, nil)
 	req.Header.Set("Authorization", "Bearer test-token")
 	rec := httptest.NewRecorder()
 
@@ -471,7 +471,7 @@ func (c *WebSocketChannel) addConnForTest(pc *wsConn) {
 	bySession[pc.id] = pc
 }
 
-func newTestPicoWebSocket(t *testing.T) (*websocket.Conn, <-chan WebSocketMessage, func()) {
+func newTestWebSocket(t *testing.T) (*websocket.Conn, <-chan WebSocketMessage, func()) {
 	t.Helper()
 
 	received := make(chan WebSocketMessage, 4)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -265,7 +265,7 @@ type WhatsAppSettings struct {
 	SessionStorePath string `json:"session_store_path"`
 }
 
-// WebSocketSettings holds Pico Protocol server channel settings.
+// WebSocketSettings holds WebSocket server channel settings.
 type WebSocketSettings struct {
 	Token           SecureString `json:"token,omitzero"`
 	AllowTokenQuery bool         `json:"allow_token_query,omitempty"`
@@ -277,12 +277,12 @@ type WebSocketSettings struct {
 	Port            int          `json:"port,omitempty"`
 }
 
-// SetToken sets the Pico token.
+// SetToken sets the WebSocket token.
 func (c *WebSocketSettings) SetToken(token string) {
 	c.Token = *NewSecureString(token)
 }
 
-// WebSocketClientSettings holds Pico Protocol client channel settings.
+// WebSocketClientSettings holds WebSocket client channel settings.
 type WebSocketClientSettings struct {
 	URL          string       `json:"url"`
 	Token        SecureString `json:"token,omitzero"`
@@ -291,7 +291,7 @@ type WebSocketClientSettings struct {
 	ReadTimeout  int          `json:"read_timeout,omitempty"`
 }
 
-// SetToken sets the Pico client token.
+// SetToken sets the WebSocket client token.
 func (c *WebSocketClientSettings) SetToken(token string) {
 	c.Token = *NewSecureString(token)
 }


### PR DESCRIPTION
## Summary

Routes the local `sushiclaw chat` command through an in-process `websocket` channel instead of calling the agent directly. This keeps terminal chat on the same bus, command filter, command executor, session manager, and channel manager path used by other channels.

Also removes legacy Pico-specific wording from the WebSocket channel delivery surface:

- WebSocket endpoint paths now use `/websocket/...`.
- The example token env var is now `SUSHICLAW_WEBSOCKET_TOKEN`.
- WebSocket comments, logs, errors, helper names, and tests use standalone WebSocket terminology.

## Test plan

- `make test`
- `make lint`
- `CGO_ENABLED=0 go build -tags whatsapp_native -o /tmp/sushiclaw-build .`

