### PR TITLE
Add conversation lock and OTA unlock

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -35,6 +35,16 @@
   "sessions": {
     "directory": "~/.sushiclaw/sessions"
   },
+  "conversation_lock": {
+    "enabled": false,
+    "standby_auto_lock_minutes": 30,
+    "global_auto_lock_minutes": 480,
+    "ota_expiry_minutes": 10,
+    "max_unlock_attempts": 5,
+    "resend_api_key": "env://RESEND_API_KEY",
+    "from_email": "Sushiclaw <unlock@example.com>",
+    "unlock_email": "example@example.com"
+  },
   "channels": {
     "whatsapp_native": {
       "enabled": false,

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/mdp/qrterminal/v3 v3.2.1
 	github.com/mymmrac/telego v1.8.0
+	github.com/resend/resend-go/v3 v3.6.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/zerolog v1.35.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/resend/resend-go/v3 v3.6.0 h1:T0/Bvw9YsWYbusf+LhDkAW1dmytFsMv08//r+fnSNU8=
+github.com/resend/resend-go/v3 v3.6.0/go.mod h1:iI7VA0NoGjWvsNii5iNC5Dy0llsI3HncXPejhniYzwE=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/internal/commandfilter/commandfilter_test.go
+++ b/internal/commandfilter/commandfilter_test.go
@@ -34,7 +34,7 @@ func TestFilter_KnownCommands(t *testing.T) {
 	f := NewCommandFilter()
 	cases := []string{
 		"/start", "/help", "/show", "/list", "/use",
-		"/switch", "/check", "/clear", "/stop", "/subagents", "/reload",
+		"/switch", "/check", "/clear", "/stop", "/lock", "/unlock", "/subagents", "/reload",
 	}
 	for _, cmd := range cases {
 		t.Run(cmd, func(t *testing.T) {
@@ -59,6 +59,7 @@ func TestFilter_KnownCommandsWithArgs(t *testing.T) {
 		"/debug off",
 		"/stop",
 		"/clear",
+		"/unlock 123456",
 	}
 	for _, cmd := range cases {
 		t.Run(cmd, func(t *testing.T) {

--- a/internal/conversationlock/controller.go
+++ b/internal/conversationlock/controller.go
@@ -1,0 +1,140 @@
+package conversationlock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/sushi30/sushiclaw/pkg/commands"
+	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/logger"
+)
+
+type Controller struct {
+	manager *Manager
+}
+
+func NewControllerFromConfig(cfg config.ConversationLockConfig, lockoutPath string) (*Controller, error) {
+	if !cfg.Enabled {
+		return &Controller{}, nil
+	}
+	apiKey := ""
+	if cfg.ResendAPIKey != nil {
+		apiKey = cfg.ResendAPIKey.String()
+	}
+	sender, err := NewResendSender(apiKey, cfg.FromEmail)
+	if err != nil {
+		return nil, fmt.Errorf("conversation lock email sender: %w", err)
+	}
+	opts := OptionsFromConfig(cfg)
+	opts.LockoutPath = lockoutPath
+	return &Controller{manager: NewManager(opts, sender)}, nil
+}
+
+func (c *Controller) Enabled() bool {
+	return c != nil && c.manager != nil && c.manager.Enabled()
+}
+
+func (c *Controller) Register(rt *commands.Runtime) {
+	if rt == nil {
+		return
+	}
+	rt.LockConversation = c.lockConversation
+	rt.RequestUnlock = c.requestUnlock
+	rt.VerifyUnlockCode = c.verifyUnlockCode
+}
+
+func (c *Controller) IsLocked(sessionKey string) bool {
+	return c.Enabled() && c.manager.IsLocked(sessionKey)
+}
+
+func (c *Controller) RecordActivity(sessionKey string) {
+	if c.Enabled() {
+		c.manager.RecordActivity(sessionKey)
+	}
+}
+
+func (c *Controller) LockedReply() string {
+	return "Conversation is locked. Use /unlock to request an unlock code."
+}
+
+func (c *Controller) LogEnabled(cfg config.ConversationLockConfig) {
+	if !c.Enabled() {
+		return
+	}
+	logger.InfoCF("gateway", "Conversation lock enabled", map[string]any{
+		"standby_auto_lock_minutes": cfg.StandbyAutoLockMinutes,
+		"global_auto_lock_minutes":  cfg.GlobalAutoLockMinutes,
+		"ota_expiry_minutes":        cfg.OTAExpiryMinutes,
+		"max_unlock_attempts":       c.manager.opts.MaxAttempts,
+		"lockout_path":              c.manager.opts.LockoutPath,
+	})
+}
+
+func (c *Controller) lockConversation(_ context.Context, req commands.Request) string {
+	if !c.Enabled() {
+		return "Conversation lock is disabled."
+	}
+	if err := c.manager.Lock(req.SessionKey); err != nil {
+		return replyForError(err)
+	}
+	return "Conversation locked."
+}
+
+func (c *Controller) requestUnlock(ctx context.Context, req commands.Request) string {
+	if !c.Enabled() {
+		return "Conversation lock is disabled."
+	}
+	if err := c.manager.RequestUnlock(ctx, req.SessionKey); err != nil {
+		return replyForError(err)
+	}
+	return "Unlock code sent."
+}
+
+func (c *Controller) verifyUnlockCode(_ context.Context, req commands.Request, code string) string {
+	if !c.Enabled() {
+		return "Conversation lock is disabled."
+	}
+	if err := c.manager.VerifyUnlock(req.SessionKey, code); err != nil {
+		return replyForError(err)
+	}
+	return "Conversation unlocked."
+}
+
+func replyForError(err error) string {
+	switch {
+	case errors.Is(err, ErrDisabled):
+		return "Conversation lock is disabled."
+	case errors.Is(err, ErrAlreadyUnlocked):
+		return "Conversation is already unlocked."
+	case errors.Is(err, ErrMissingUnlockEmail):
+		return "Unlock email is not configured."
+	case errors.Is(err, ErrMissingSender):
+		return "Unlock email sender is not configured."
+	case errors.Is(err, ErrInvalidCode):
+		return "Invalid unlock code."
+	case errors.Is(err, ErrExpiredCode):
+		return "Unlock code expired. Use /unlock to request a new code."
+	case errors.Is(err, ErrSupportRequired):
+		return "Too many invalid unlock attempts. Please reach out for support using the email in the bot description."
+	default:
+		return "Unlock failed: " + err.Error()
+	}
+}
+
+func IsUnlockCommand(input string) bool {
+	name, ok := commands.CommandName(input)
+	return ok && name == "unlock"
+}
+
+func RedactCommand(input string) string {
+	if !IsUnlockCommand(input) {
+		return input
+	}
+	fields := strings.Fields(input)
+	if len(fields) <= 1 {
+		return input
+	}
+	return fields[0] + " [redacted]"
+}

--- a/internal/conversationlock/controller_test.go
+++ b/internal/conversationlock/controller_test.go
@@ -1,0 +1,73 @@
+package conversationlock
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sushi30/sushiclaw/pkg/commands"
+)
+
+func TestControllerRegistersRuntimeHandlers(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	m := newTestManager(now, &fakeSender{})
+	c := &Controller{manager: m}
+	rt := &commands.Runtime{}
+
+	c.Register(rt)
+	if rt.LockConversation == nil || rt.RequestUnlock == nil || rt.VerifyUnlockCode == nil {
+		t.Fatal("expected lock runtime handlers to be registered")
+	}
+	req := commands.Request{SessionKey: "telegram:1"}
+	if got := rt.LockConversation(context.Background(), req); got != "Conversation locked." {
+		t.Fatalf("lock reply = %q", got)
+	}
+	if got := rt.RequestUnlock(context.Background(), req); got != "Unlock code sent." {
+		t.Fatalf("unlock request reply = %q", got)
+	}
+	if got := rt.VerifyUnlockCode(context.Background(), req, "123456"); got != "Conversation unlocked." {
+		t.Fatalf("verify reply = %q", got)
+	}
+}
+
+func TestReplyForSupportRequired(t *testing.T) {
+	got := replyForError(ErrSupportRequired)
+	want := "Too many invalid unlock attempts. Please reach out for support using the email in the bot description."
+	if got != want {
+		t.Fatalf("reply = %q, want %q", got, want)
+	}
+}
+
+func TestIsUnlockCommand(t *testing.T) {
+	if !IsUnlockCommand("/unlock") {
+		t.Fatal("/unlock should be unlock command")
+	}
+	if !IsUnlockCommand("!unlock 123456") {
+		t.Fatal("!unlock should be unlock command")
+	}
+	if IsUnlockCommand("/lock") {
+		t.Fatal("/lock should not be unlock command")
+	}
+}
+
+func TestRedactCommand(t *testing.T) {
+	if got := RedactCommand("/unlock 123456"); got != "/unlock [redacted]" {
+		t.Fatalf("redacted = %q", got)
+	}
+	if got := RedactCommand("/unlock"); got != "/unlock" {
+		t.Fatalf("redacted unlock request = %q", got)
+	}
+	if got := RedactCommand("/help"); got != "/help" {
+		t.Fatalf("redacted non-unlock = %q", got)
+	}
+}
+
+func TestReplyForInvalidCodeDoesNotMaskNonThresholdFailures(t *testing.T) {
+	if got := replyForError(ErrInvalidCode); got != "Invalid unlock code." {
+		t.Fatalf("reply = %q", got)
+	}
+	if got := replyForError(errors.New("boom")); got != "Unlock failed: boom" {
+		t.Fatalf("reply = %q", got)
+	}
+}

--- a/internal/conversationlock/manager.go
+++ b/internal/conversationlock/manager.go
@@ -1,0 +1,387 @@
+package conversationlock
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sushi30/sushiclaw/pkg/config"
+)
+
+var (
+	ErrDisabled           = errors.New("conversation lock is disabled")
+	ErrAlreadyUnlocked    = errors.New("conversation is already unlocked")
+	ErrMissingUnlockEmail = errors.New("unlock email is not configured")
+	ErrMissingSender      = errors.New("unlock email sender is not configured")
+	ErrInvalidCode        = errors.New("invalid unlock code")
+	ErrExpiredCode        = errors.New("unlock code expired")
+	ErrSupportRequired    = errors.New("too many unlock attempts")
+)
+
+type EmailSender interface {
+	SendUnlockCode(ctx context.Context, to, code string, expiresIn time.Duration) error
+}
+
+type Options struct {
+	Enabled         bool
+	StandbyTimeout  time.Duration
+	GlobalTimeout   time.Duration
+	OTAExpiry       time.Duration
+	MaxAttempts     int
+	LockoutDuration time.Duration
+	UnlockEmail     string
+	LockoutPath     string
+}
+
+type Manager struct {
+	mu     sync.Mutex
+	opts   Options
+	sender EmailSender
+	now    func() time.Time
+	code   func() (string, error)
+	states map[string]*sessionState
+}
+
+type sessionState struct {
+	Locked       bool
+	LastActivity time.Time
+	LastUnlock   time.Time
+	CodeHash     [32]byte
+	CodeExpiry   time.Time
+	HasCode      bool
+	Attempts     int
+	FirstAttempt time.Time
+	LockedOut    bool
+	LockedUntil  time.Time
+}
+
+func OptionsFromConfig(cfg config.ConversationLockConfig) Options {
+	expiry := time.Duration(cfg.OTAExpiryMinutes) * time.Minute
+	if cfg.Enabled && expiry <= 0 {
+		expiry = 10 * time.Minute
+	}
+	maxAttempts := cfg.MaxUnlockAttempts
+	if cfg.Enabled && maxAttempts <= 0 {
+		maxAttempts = 5
+	}
+	return Options{
+		Enabled:         cfg.Enabled,
+		StandbyTimeout:  time.Duration(cfg.StandbyAutoLockMinutes) * time.Minute,
+		GlobalTimeout:   time.Duration(cfg.GlobalAutoLockMinutes) * time.Minute,
+		OTAExpiry:       expiry,
+		MaxAttempts:     maxAttempts,
+		LockoutDuration: 24 * time.Hour,
+		UnlockEmail:     strings.TrimSpace(cfg.UnlockEmail),
+	}
+}
+
+func NewManager(opts Options, sender EmailSender) *Manager {
+	m := &Manager{
+		opts:   opts,
+		sender: sender,
+		now:    time.Now,
+		code:   generateCode,
+		states: make(map[string]*sessionState),
+	}
+	m.loadLockouts()
+	return m
+}
+
+func (m *Manager) Enabled() bool {
+	return m != nil && m.opts.Enabled
+}
+
+func (m *Manager) Lock(sessionKey string) error {
+	if !m.Enabled() {
+		return ErrDisabled
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st := m.ensureLocked(sessionKey)
+	st.Locked = true
+	return nil
+}
+
+func (m *Manager) RequestUnlock(ctx context.Context, sessionKey string) error {
+	if !m.Enabled() {
+		return ErrDisabled
+	}
+	if strings.TrimSpace(m.opts.UnlockEmail) == "" {
+		return ErrMissingUnlockEmail
+	}
+	if m.sender == nil {
+		return ErrMissingSender
+	}
+	now := m.now()
+	code, err := m.code()
+	if err != nil {
+		return err
+	}
+	codeHash := sha256.Sum256([]byte(code))
+
+	m.mu.Lock()
+	st := m.ensure(sessionKey, now)
+	m.clearExpiredLockout(st, now)
+	if st.LockedOut {
+		m.mu.Unlock()
+		return ErrSupportRequired
+	}
+	if !st.Locked && !m.shouldAutoLock(st, now) {
+		m.mu.Unlock()
+		return ErrAlreadyUnlocked
+	}
+	st.Locked = true
+	st.CodeHash = codeHash
+	st.CodeExpiry = now.Add(m.opts.OTAExpiry)
+	st.HasCode = true
+	expiresIn := m.opts.OTAExpiry
+	m.mu.Unlock()
+
+	return m.sender.SendUnlockCode(ctx, m.opts.UnlockEmail, code, expiresIn)
+}
+
+func (m *Manager) VerifyUnlock(sessionKey, code string) error {
+	if !m.Enabled() {
+		return ErrDisabled
+	}
+	now := m.now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	st := m.ensure(sessionKey, now)
+	m.clearExpiredLockout(st, now)
+	if st.LockedOut {
+		return ErrSupportRequired
+	}
+	if !st.Locked && !m.shouldAutoLock(st, now) {
+		return ErrAlreadyUnlocked
+	}
+	if !st.HasCode {
+		m.recordFailedAttempt(st)
+		if st.LockedOut {
+			return ErrSupportRequired
+		}
+		return ErrInvalidCode
+	}
+	if !st.CodeExpiry.IsZero() && !now.Before(st.CodeExpiry) {
+		st.HasCode = false
+		st.CodeHash = [32]byte{}
+		m.recordFailedAttempt(st)
+		if st.LockedOut {
+			return ErrSupportRequired
+		}
+		return ErrExpiredCode
+	}
+	codeHash := sha256.Sum256([]byte(strings.TrimSpace(code)))
+	if subtle.ConstantTimeCompare(codeHash[:], st.CodeHash[:]) != 1 {
+		m.recordFailedAttempt(st)
+		if st.LockedOut {
+			return ErrSupportRequired
+		}
+		return ErrInvalidCode
+	}
+	st.Locked = false
+	st.LastActivity = now
+	st.LastUnlock = now
+	st.HasCode = false
+	st.CodeHash = [32]byte{}
+	st.CodeExpiry = time.Time{}
+	st.Attempts = 0
+	st.FirstAttempt = time.Time{}
+	return nil
+}
+
+func (m *Manager) IsLocked(sessionKey string) bool {
+	if !m.Enabled() {
+		return false
+	}
+	now := m.now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st := m.ensure(sessionKey, now)
+	m.clearExpiredLockout(st, now)
+	if m.shouldAutoLock(st, now) {
+		st.Locked = true
+	}
+	return st.Locked
+}
+
+func (m *Manager) RecordActivity(sessionKey string) {
+	if !m.Enabled() {
+		return
+	}
+	now := m.now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st := m.ensure(sessionKey, now)
+	m.clearExpiredLockout(st, now)
+	if !st.Locked {
+		st.LastActivity = now
+		if st.LastUnlock.IsZero() {
+			st.LastUnlock = now
+		}
+	}
+}
+
+func (m *Manager) ensureLocked(sessionKey string) *sessionState {
+	now := m.now()
+	st := m.ensure(sessionKey, now)
+	if st.LastUnlock.IsZero() {
+		st.LastUnlock = now
+	}
+	return st
+}
+
+func (m *Manager) ensure(sessionKey string, now time.Time) *sessionState {
+	key := strings.TrimSpace(sessionKey)
+	st, ok := m.states[key]
+	if ok {
+		return st
+	}
+	st = &sessionState{
+		LastActivity: now,
+		LastUnlock:   now,
+	}
+	m.states[key] = st
+	return st
+}
+
+func (m *Manager) shouldAutoLock(st *sessionState, now time.Time) bool {
+	m.clearExpiredLockout(st, now)
+	if st.LockedOut {
+		return true
+	}
+	if st.Locked {
+		return false
+	}
+	if m.opts.StandbyTimeout > 0 && !st.LastActivity.IsZero() && !now.Before(st.LastActivity.Add(m.opts.StandbyTimeout)) {
+		return true
+	}
+	if m.opts.GlobalTimeout > 0 && !st.LastUnlock.IsZero() && !now.Before(st.LastUnlock.Add(m.opts.GlobalTimeout)) {
+		return true
+	}
+	return false
+}
+
+func (m *Manager) recordFailedAttempt(st *sessionState) {
+	now := m.now()
+	if !st.FirstAttempt.IsZero() && !now.Before(st.FirstAttempt.Add(m.lockoutDuration())) {
+		st.Attempts = 0
+		st.FirstAttempt = time.Time{}
+	}
+	if st.Attempts == 0 {
+		st.FirstAttempt = now
+	}
+	st.Attempts++
+	if m.opts.MaxAttempts > 0 && st.Attempts >= m.opts.MaxAttempts {
+		st.Locked = true
+		st.LockedOut = true
+		st.HasCode = false
+		st.CodeHash = [32]byte{}
+		st.CodeExpiry = time.Time{}
+		st.LockedUntil = now.Add(m.lockoutDuration())
+		_ = m.saveLockouts()
+	}
+}
+
+type lockoutFile struct {
+	Version  int                  `json:"version"`
+	Sessions map[string]time.Time `json:"sessions"`
+}
+
+func (m *Manager) loadLockouts() {
+	path := strings.TrimSpace(m.opts.LockoutPath)
+	if path == "" {
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	var file lockoutFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return
+	}
+	now := m.now()
+	for key, lockedUntil := range file.Sessions {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if !lockedUntil.IsZero() && !now.Before(lockedUntil) {
+			continue
+		}
+		m.states[key] = &sessionState{
+			Locked:       true,
+			LockedOut:    true,
+			LockedUntil:  lockedUntil,
+			LastActivity: now,
+			LastUnlock:   now,
+		}
+	}
+}
+
+func (m *Manager) saveLockouts() error {
+	path := strings.TrimSpace(m.opts.LockoutPath)
+	if path == "" {
+		return nil
+	}
+	sessions := make(map[string]time.Time)
+	now := m.now()
+	for key, st := range m.states {
+		m.clearExpiredLockout(st, now)
+		if st.LockedOut {
+			sessions[key] = st.LockedUntil
+		}
+	}
+	data, err := json.MarshalIndent(lockoutFile{Version: 1, Sessions: sessions}, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func (m *Manager) clearExpiredLockout(st *sessionState, now time.Time) {
+	if st == nil || !st.LockedOut || st.LockedUntil.IsZero() || now.Before(st.LockedUntil) {
+		return
+	}
+	st.LockedOut = false
+	st.LockedUntil = time.Time{}
+	st.Attempts = 0
+	st.FirstAttempt = time.Time{}
+	st.HasCode = false
+	st.CodeHash = [32]byte{}
+	st.CodeExpiry = time.Time{}
+}
+
+func (m *Manager) lockoutDuration() time.Duration {
+	if m.opts.LockoutDuration > 0 {
+		return m.opts.LockoutDuration
+	}
+	return 24 * time.Hour
+}
+
+func generateCode() (string, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	if err != nil {
+		return "", fmt.Errorf("generate unlock code: %w", err)
+	}
+	return fmt.Sprintf("%06d", n.Int64()), nil
+}

--- a/internal/conversationlock/manager_test.go
+++ b/internal/conversationlock/manager_test.go
@@ -1,0 +1,266 @@
+package conversationlock
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeSender struct {
+	to   string
+	code string
+	err  error
+}
+
+func (s *fakeSender) SendUnlockCode(_ context.Context, to, code string, _ time.Duration) error {
+	s.to = to
+	s.code = code
+	return s.err
+}
+
+func newTestManager(now time.Time, sender *fakeSender) *Manager {
+	m := NewManager(Options{
+		Enabled:        true,
+		StandbyTimeout: 10 * time.Minute,
+		GlobalTimeout:  time.Hour,
+		OTAExpiry:      5 * time.Minute,
+		UnlockEmail:    "user@example.com",
+	}, sender)
+	m.now = func() time.Time { return now }
+	m.code = func() (string, error) { return "123456", nil }
+	return m
+}
+
+func TestManagerLockAndUnlockWithSingleUseCode(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	sender := &fakeSender{}
+	m := newTestManager(now, sender)
+
+	if err := m.Lock("telegram:1"); err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	if !m.IsLocked("telegram:1") {
+		t.Fatal("expected session locked")
+	}
+	if err := m.RequestUnlock(context.Background(), "telegram:1"); err != nil {
+		t.Fatalf("RequestUnlock: %v", err)
+	}
+	if sender.to != "user@example.com" || sender.code != "123456" {
+		t.Fatalf("sent to/code = %q/%q", sender.to, sender.code)
+	}
+	if err := m.VerifyUnlock("telegram:1", "123456"); err != nil {
+		t.Fatalf("VerifyUnlock: %v", err)
+	}
+	if m.IsLocked("telegram:1") {
+		t.Fatal("expected session unlocked")
+	}
+	if err := m.VerifyUnlock("telegram:1", "123456"); !errors.Is(err, ErrAlreadyUnlocked) {
+		t.Fatalf("reused code error = %v, want ErrAlreadyUnlocked", err)
+	}
+}
+
+func TestManagerInvalidCodeKeepsLocked(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	m := newTestManager(now, &fakeSender{})
+
+	_ = m.Lock("telegram:1")
+	_ = m.RequestUnlock(context.Background(), "telegram:1")
+	if err := m.VerifyUnlock("telegram:1", "000000"); !errors.Is(err, ErrInvalidCode) {
+		t.Fatalf("VerifyUnlock error = %v, want ErrInvalidCode", err)
+	}
+	if !m.IsLocked("telegram:1") {
+		t.Fatal("expected session to remain locked")
+	}
+}
+
+func TestManagerExpiredCodeKeepsLocked(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	m := newTestManager(now, &fakeSender{})
+	current := now
+	m.now = func() time.Time { return current }
+
+	_ = m.Lock("telegram:1")
+	_ = m.RequestUnlock(context.Background(), "telegram:1")
+	current = now.Add(6 * time.Minute)
+	if err := m.VerifyUnlock("telegram:1", "123456"); !errors.Is(err, ErrExpiredCode) {
+		t.Fatalf("VerifyUnlock error = %v, want ErrExpiredCode", err)
+	}
+	if !m.IsLocked("telegram:1") {
+		t.Fatal("expected session to remain locked")
+	}
+}
+
+func TestManagerAutoLocksOnStandbyTimeout(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	current := now
+	m := newTestManager(now, &fakeSender{})
+	m.now = func() time.Time { return current }
+
+	m.RecordActivity("telegram:1")
+	current = now.Add(9 * time.Minute)
+	if m.IsLocked("telegram:1") {
+		t.Fatal("expected session unlocked before standby timeout")
+	}
+	current = now.Add(10 * time.Minute)
+	if !m.IsLocked("telegram:1") {
+		t.Fatal("expected session locked at standby timeout")
+	}
+}
+
+func TestManagerAutoLocksOnGlobalTimeoutDespiteActivity(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	current := now
+	m := newTestManager(now, &fakeSender{})
+	m.now = func() time.Time { return current }
+	m.opts.StandbyTimeout = 10 * time.Minute
+	m.opts.GlobalTimeout = 30 * time.Minute
+
+	m.RecordActivity("telegram:1")
+	for i := 1; i <= 3; i++ {
+		current = now.Add(time.Duration(i*9) * time.Minute)
+		m.RecordActivity("telegram:1")
+		if m.IsLocked("telegram:1") {
+			t.Fatalf("unexpected lock before global timeout at iteration %d", i)
+		}
+	}
+	current = now.Add(30 * time.Minute)
+	if !m.IsLocked("telegram:1") {
+		t.Fatal("expected session locked at global timeout")
+	}
+}
+
+func TestManagerDisabledTimers(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	current := now
+	m := newTestManager(now, &fakeSender{})
+	m.now = func() time.Time { return current }
+	m.opts.StandbyTimeout = 0
+	m.opts.GlobalTimeout = 0
+
+	m.RecordActivity("telegram:1")
+	current = now.Add(24 * time.Hour)
+	if m.IsLocked("telegram:1") {
+		t.Fatal("expected disabled timers not to lock session")
+	}
+}
+
+func TestManagerDisabledFeature(t *testing.T) {
+	m := NewManager(Options{}, &fakeSender{})
+	if m.IsLocked("telegram:1") {
+		t.Fatal("disabled manager should not lock")
+	}
+	if err := m.Lock("telegram:1"); !errors.Is(err, ErrDisabled) {
+		t.Fatalf("Lock error = %v, want ErrDisabled", err)
+	}
+}
+
+func TestManagerPersistsSupportLockout(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	path := t.TempDir() + "/.lock"
+	sender := &fakeSender{}
+	m := NewManager(Options{
+		Enabled:     true,
+		OTAExpiry:   5 * time.Minute,
+		MaxAttempts: 2,
+		UnlockEmail: "user@example.com",
+		LockoutPath: path,
+	}, sender)
+	m.now = func() time.Time { return now }
+	m.code = func() (string, error) { return "123456", nil }
+
+	_ = m.Lock("telegram:1")
+	_ = m.RequestUnlock(context.Background(), "telegram:1")
+	if err := m.VerifyUnlock("telegram:1", "000000"); !errors.Is(err, ErrInvalidCode) {
+		t.Fatalf("first VerifyUnlock error = %v, want ErrInvalidCode", err)
+	}
+	if err := m.VerifyUnlock("telegram:1", "111111"); !errors.Is(err, ErrSupportRequired) {
+		t.Fatalf("second VerifyUnlock error = %v, want ErrSupportRequired", err)
+	}
+
+	reloaded := NewManager(Options{
+		Enabled:     true,
+		OTAExpiry:   5 * time.Minute,
+		MaxAttempts: 2,
+		UnlockEmail: "user@example.com",
+		LockoutPath: path,
+	}, sender)
+	reloaded.now = func() time.Time { return now }
+	if !reloaded.IsLocked("telegram:1") {
+		t.Fatal("expected persisted lockout to be locked after reload")
+	}
+	if err := reloaded.RequestUnlock(context.Background(), "telegram:1"); !errors.Is(err, ErrSupportRequired) {
+		t.Fatalf("RequestUnlock after reload error = %v, want ErrSupportRequired", err)
+	}
+}
+
+func TestManagerLockoutExpiresAfterTwentyFourHours(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	current := now
+	path := t.TempDir() + "/.lock"
+	m := NewManager(Options{
+		Enabled:         true,
+		OTAExpiry:       5 * time.Minute,
+		MaxAttempts:     2,
+		LockoutDuration: 24 * time.Hour,
+		UnlockEmail:     "user@example.com",
+		LockoutPath:     path,
+	}, &fakeSender{})
+	m.now = func() time.Time { return current }
+	m.code = func() (string, error) { return "123456", nil }
+
+	_ = m.Lock("telegram:1")
+	_ = m.RequestUnlock(context.Background(), "telegram:1")
+	_ = m.VerifyUnlock("telegram:1", "000000")
+	if err := m.VerifyUnlock("telegram:1", "111111"); !errors.Is(err, ErrSupportRequired) {
+		t.Fatalf("VerifyUnlock error = %v, want ErrSupportRequired", err)
+	}
+
+	current = now.Add(24*time.Hour + time.Second)
+	if !m.IsLocked("telegram:1") {
+		t.Fatal("session should remain locked after support lockout expires")
+	}
+	if err := m.RequestUnlock(context.Background(), "telegram:1"); err != nil {
+		t.Fatalf("RequestUnlock after lockout expiry: %v", err)
+	}
+	if err := m.VerifyUnlock("telegram:1", "000000"); !errors.Is(err, ErrInvalidCode) {
+		t.Fatalf("VerifyUnlock after lockout expiry error = %v, want ErrInvalidCode", err)
+	}
+}
+
+func TestManagerAttemptCounterResetsAfterTwentyFourHours(t *testing.T) {
+	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	current := now
+	m := NewManager(Options{
+		Enabled:         true,
+		OTAExpiry:       5 * time.Minute,
+		MaxAttempts:     2,
+		LockoutDuration: 24 * time.Hour,
+		UnlockEmail:     "user@example.com",
+	}, &fakeSender{})
+	m.now = func() time.Time { return current }
+	m.code = func() (string, error) { return "123456", nil }
+
+	_ = m.Lock("telegram:1")
+	_ = m.RequestUnlock(context.Background(), "telegram:1")
+	if err := m.VerifyUnlock("telegram:1", "000000"); !errors.Is(err, ErrInvalidCode) {
+		t.Fatalf("first VerifyUnlock error = %v, want ErrInvalidCode", err)
+	}
+
+	current = now.Add(24*time.Hour + time.Second)
+	_ = m.RequestUnlock(context.Background(), "telegram:1")
+	if err := m.VerifyUnlock("telegram:1", "111111"); !errors.Is(err, ErrInvalidCode) {
+		t.Fatalf("second VerifyUnlock error = %v, want ErrInvalidCode", err)
+	}
+	if err := m.RequestUnlock(context.Background(), "telegram:1"); err != nil {
+		t.Fatalf("RequestUnlock after reset: %v", err)
+	}
+}
+
+func TestManagerMissingUnlockEmail(t *testing.T) {
+	m := NewManager(Options{Enabled: true, OTAExpiry: time.Minute}, &fakeSender{})
+	_ = m.Lock("telegram:1")
+	if err := m.RequestUnlock(context.Background(), "telegram:1"); !errors.Is(err, ErrMissingUnlockEmail) {
+		t.Fatalf("RequestUnlock error = %v, want ErrMissingUnlockEmail", err)
+	}
+}

--- a/internal/conversationlock/manager_test.go
+++ b/internal/conversationlock/manager_test.go
@@ -156,7 +156,7 @@ func TestManagerDisabledFeature(t *testing.T) {
 }
 
 func TestManagerPersistsSupportLockout(t *testing.T) {
-	now := time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC)
+	now := time.Now().UTC()
 	path := t.TempDir() + "/.lock"
 	sender := &fakeSender{}
 	m := NewManager(Options{

--- a/internal/conversationlock/resend.go
+++ b/internal/conversationlock/resend.go
@@ -1,0 +1,54 @@
+package conversationlock
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/resend/resend-go/v3"
+)
+
+type ResendSender struct {
+	client *resend.Client
+	from   string
+}
+
+func NewResendSender(apiKey, from string) (*ResendSender, error) {
+	if strings.TrimSpace(apiKey) == "" {
+		return nil, fmt.Errorf("resend api key is required")
+	}
+	if strings.TrimSpace(from) == "" {
+		return nil, fmt.Errorf("from email is required")
+	}
+	return &ResendSender{
+		client: resend.NewClient(apiKey),
+		from:   strings.TrimSpace(from),
+	}, nil
+}
+
+func (s *ResendSender) SendUnlockCode(ctx context.Context, to, code string, expiresIn time.Duration) error {
+	minutes := int(expiresIn.Minutes())
+	if minutes <= 0 {
+		minutes = 1
+	}
+	params := &resend.SendEmailRequest{
+		From:    s.from,
+		To:      []string{strings.TrimSpace(to)},
+		Subject: "Your sushiclaw unlock code",
+		Text: fmt.Sprintf(
+			"Your sushiclaw unlock code is %s. It expires in %d minutes. If you did not request this code, ignore this email.",
+			code,
+			minutes,
+		),
+		Html: fmt.Sprintf(
+			"<p>Your sushiclaw unlock code is <strong>%s</strong>.</p><p>It expires in %d minutes. If you did not request this code, ignore this email.</p>",
+			code,
+			minutes,
+		),
+	}
+	if _, err := s.client.Emails.SendWithContext(ctx, params); err != nil {
+		return fmt.Errorf("send unlock email: %w", err)
+	}
+	return nil
+}

--- a/internal/envresolve/envresolve.go
+++ b/internal/envresolve/envresolve.go
@@ -22,6 +22,7 @@ func Config(cfg *config.Config) {
 			resolveSecureString(model.APIKey)
 		}
 	}
+	resolveSecureString(cfg.ConversationLock.ResendAPIKey)
 }
 
 // SecureString resolves a single env://VAR_NAME reference in-place.

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sushi30/sushiclaw/internal/agent"
 	"github.com/sushi30/sushiclaw/internal/commandfilter"
+	"github.com/sushi30/sushiclaw/internal/conversationlock"
 	"github.com/sushi30/sushiclaw/internal/envresolve"
 	"github.com/sushi30/sushiclaw/pkg/audio/asr"
 	"github.com/sushi30/sushiclaw/pkg/bus"
@@ -73,6 +74,12 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	rt := &commands.Runtime{
 		ListDefinitions: reg.Definitions,
 	}
+
+	lockController, err := conversationlock.NewControllerFromConfig(cfg.ConversationLock, filepath.Join(cfg.WorkspacePath(), ".lock"))
+	if err != nil {
+		return err
+	}
+	lockController.LogEnabled(cfg.ConversationLock)
 
 	mediaStore := media.NewFileMediaStoreWithCleanup(media.MediaCleanerConfig{
 		Enabled:  cfg.Tools.MediaCleanup.Enabled,
@@ -188,6 +195,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	defer cancel()
 
 	rt.SetDebug = dm.Set
+	lockController.Register(rt)
 	if sessionMgr != nil {
 		rt.ClearHistory = func(req commands.Request) error {
 			return sessionMgr.ClearHistory(req.SessionKey)
@@ -216,7 +224,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 				dec := cmdFilter.Filter(msg)
 				logger.DebugCF("commandfilter", "Filtered message",
 					map[string]any{
-						"text":    msg.Content,
+						"text":    conversationlock.RedactCommand(msg.Content),
 						"result":  dec.Result,
 						"command": dec.Command,
 					})
@@ -240,6 +248,17 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 					sessionKey = msg.Channel + ":" + msg.ChatID
 				}
 
+				if lockController.IsLocked(sessionKey) && !conversationlock.IsUnlockCommand(msg.Content) {
+					_ = messageBus.PublishOutbound(ctx, bus.OutboundMessage{
+						Channel:    msg.Channel,
+						ChatID:     msg.ChatID,
+						Context:    bus.NewOutboundContext(msg.Channel, msg.ChatID, ""),
+						SessionKey: sessionKey,
+						Content:    lockController.LockedReply(),
+					})
+					continue
+				}
+
 				if commands.HasCommandPrefix(msg.Content) {
 					var reply string
 					result := executor.Execute(ctx, commands.Request{
@@ -252,7 +271,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 					})
 					logger.DebugCF("executor", "Command executed",
 						map[string]any{
-							"text":    msg.Content,
+							"text":    conversationlock.RedactCommand(msg.Content),
 							"command": result.Command,
 							"outcome": result.Outcome,
 							"handled": result.Outcome == commands.OutcomeHandled,
@@ -265,6 +284,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 								Content: reply,
 							}))
 						}
+						lockController.RecordActivity(sessionKey)
 						continue
 					}
 					// OutcomePassthrough: forward to agent.
@@ -272,6 +292,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 
 				// Dispatch to agent session directly (avoids bus read race).
 				if sessionMgr != nil {
+					lockController.RecordActivity(sessionKey)
 					go sessionMgr.Dispatch(ctx, msg)
 				}
 			}

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -62,15 +62,18 @@ type SkillInfo struct {
 
 // Runtime provides runtime dependencies to command handlers.
 type Runtime struct {
-	GetModelInfo    func() (name, provider string)
-	ListDefinitions func() []Definition
-	ListModels      func() []string
-	ListSkills      func() []SkillInfo
-	ListCronJobs    func() (string, error)
-	ClearHistory    func(req Request) error
-	StopTurn        func(sessionKey string) bool
-	SetDebug        func(ctx context.Context, channel, chatID, mode string) string
-	ActivateSkill   func(req Request, skillName string) error
+	GetModelInfo     func() (name, provider string)
+	ListDefinitions  func() []Definition
+	ListModels       func() []string
+	ListSkills       func() []SkillInfo
+	ListCronJobs     func() (string, error)
+	ClearHistory     func(req Request) error
+	StopTurn         func(sessionKey string) bool
+	SetDebug         func(ctx context.Context, channel, chatID, mode string) string
+	ActivateSkill    func(req Request, skillName string) error
+	LockConversation func(ctx context.Context, req Request) string
+	RequestUnlock    func(ctx context.Context, req Request) string
+	VerifyUnlockCode func(ctx context.Context, req Request, code string) string
 }
 
 // Registry stores command definitions indexed by name and alias.
@@ -260,6 +263,8 @@ func BuiltinDefinitions() []Definition {
 		{Name: "help", Description: "Show this help message", Handler: helpHandler},
 		{Name: "clear", Description: "Clear conversation history", Handler: clearHandler},
 		{Name: "stop", Description: "Stop the current turn", Handler: stopHandler},
+		{Name: "lock", Description: "Lock this conversation", Handler: lockHandler},
+		{Name: "unlock", Description: "Unlock this conversation", Handler: unlockHandler, Usage: "/unlock [code]"},
 		{Name: "debug", Description: "Toggle debug event forwarding", Handler: debugHandler, Usage: "/debug [on|off]"},
 		{Name: "model", Description: "Show or switch model", Handler: modelHandler},
 		{Name: "show", Description: "Show current configuration"},
@@ -368,6 +373,27 @@ func stopHandler(_ context.Context, req Request, rt *Runtime) error {
 		return req.Reply("Stopped current turn.")
 	}
 	return req.Reply("No active turn.")
+}
+
+func lockHandler(ctx context.Context, req Request, rt *Runtime) error {
+	if rt == nil || rt.LockConversation == nil {
+		return req.Reply("Conversation lock is not available.")
+	}
+	return req.Reply(rt.LockConversation(ctx, req))
+}
+
+func unlockHandler(ctx context.Context, req Request, rt *Runtime) error {
+	if rt == nil || rt.RequestUnlock == nil || rt.VerifyUnlockCode == nil {
+		return req.Reply("Conversation unlock is not available.")
+	}
+	code := nthToken(req.Text, 1)
+	if nthToken(req.Text, 2) != "" {
+		return req.Reply("Usage: /unlock [code]")
+	}
+	if code == "" {
+		return req.Reply(rt.RequestUnlock(ctx, req))
+	}
+	return req.Reply(rt.VerifyUnlockCode(ctx, req, code))
 }
 
 func modelHandler(_ context.Context, req Request, rt *Runtime) error {

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -145,6 +145,93 @@ func TestExecuteStopIdleSession(t *testing.T) {
 	assert.Equal(t, "No active turn.", replied)
 }
 
+func TestExecuteLockCallsCallback(t *testing.T) {
+	locked := false
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{
+		LockConversation: func(_ context.Context, _ commands.Request) string {
+			locked = true
+			return "Conversation locked."
+		},
+	}
+	exec := commands.NewExecutor(reg, rt)
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/lock",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.True(t, locked)
+	assert.Equal(t, "Conversation locked.", replied)
+}
+
+func TestExecuteUnlockRequestsCode(t *testing.T) {
+	requested := false
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{
+		RequestUnlock: func(_ context.Context, _ commands.Request) string {
+			requested = true
+			return "Unlock code sent."
+		},
+		VerifyUnlockCode: func(context.Context, commands.Request, string) string {
+			t.Fatal("VerifyUnlockCode should not be called")
+			return ""
+		},
+	}
+	exec := commands.NewExecutor(reg, rt)
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/unlock",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.True(t, requested)
+	assert.Equal(t, "Unlock code sent.", replied)
+}
+
+func TestExecuteUnlockVerifiesCode(t *testing.T) {
+	var gotCode string
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	rt := &commands.Runtime{
+		RequestUnlock: func(context.Context, commands.Request) string {
+			t.Fatal("RequestUnlock should not be called")
+			return ""
+		},
+		VerifyUnlockCode: func(_ context.Context, _ commands.Request, code string) string {
+			gotCode = code
+			return "Conversation unlocked."
+		},
+	}
+	exec := commands.NewExecutor(reg, rt)
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/unlock 123456",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Equal(t, "123456", gotCode)
+	assert.Equal(t, "Conversation unlocked.", replied)
+}
+
+func TestExecuteUnlockInvalidArgs(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{
+		RequestUnlock:    func(context.Context, commands.Request) string { return "" },
+		VerifyUnlockCode: func(context.Context, commands.Request, string) string { return "" },
+	})
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:  "/unlock 123456 extra",
+		Reply: func(s string) error { replied = s; return nil },
+	})
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Equal(t, "Usage: /unlock [code]", replied)
+}
+
 func TestExecuteModel(t *testing.T) {
 	reg := commands.NewRegistry(commands.BuiltinDefinitions())
 	rt := &commands.Runtime{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,15 +22,16 @@ const DefaultMaxMediaSize = 20 * 1024 * 1024
 
 // Config is the top-level sushiclaw configuration.
 type Config struct {
-	Version     int            `json:"version,omitempty"`
-	Agents      AgentsConfig   `json:"agents"`
-	ModelList   []ModelConfig  `json:"model_list"`
-	Channels    ChannelsConfig `json:"channels"`
-	Gateway     GatewayConfig  `json:"gateway"`
-	Tools       ToolsConfig    `json:"tools"`
-	MCP         MCPConfig      `json:"mcp,omitempty"`
-	VoiceConfig VoiceConfig    `json:"voice,omitempty"`
-	Sessions    SessionsConfig `json:"sessions,omitempty"`
+	Version          int                    `json:"version,omitempty"`
+	Agents           AgentsConfig           `json:"agents"`
+	ModelList        []ModelConfig          `json:"model_list"`
+	Channels         ChannelsConfig         `json:"channels"`
+	Gateway          GatewayConfig          `json:"gateway"`
+	Tools            ToolsConfig            `json:"tools"`
+	ConversationLock ConversationLockConfig `json:"conversation_lock,omitempty"`
+	MCP              MCPConfig              `json:"mcp,omitempty"`
+	VoiceConfig      VoiceConfig            `json:"voice,omitempty"`
+	Sessions         SessionsConfig         `json:"sessions,omitempty"`
 }
 
 // MCPConfig holds MCP server configuration.
@@ -145,6 +146,17 @@ type MediaCleanupCfg struct {
 	Enabled  bool `json:"enabled"`
 	MaxAge   int  `json:"max_age"`
 	Interval int  `json:"interval"`
+}
+
+type ConversationLockConfig struct {
+	Enabled                bool          `json:"enabled"`
+	StandbyAutoLockMinutes int           `json:"standby_auto_lock_minutes,omitempty"`
+	GlobalAutoLockMinutes  int           `json:"global_auto_lock_minutes,omitempty"`
+	OTAExpiryMinutes       int           `json:"ota_expiry_minutes,omitempty"`
+	MaxUnlockAttempts      int           `json:"max_unlock_attempts,omitempty"`
+	ResendAPIKey           *SecureString `json:"resend_api_key,omitzero"`
+	FromEmail              string        `json:"from_email,omitempty"`
+	UnlockEmail            string        `json:"unlock_email,omitempty"`
 }
 
 type WebSearchToolConfig struct {


### PR DESCRIPTION
## Summary
Add a feature-gated conversation lock for chat sessions. When a session is locked, messages stop reaching the agent and tools until it is unlocked again.

## Behavior
- Enforces the lock before agent dispatch.
- Adds `/lock` to lock the current conversation.
- Adds `/unlock` to request an unlock code, or `/unlock <code>` to verify it.
- Sends unlock codes through Resend.
- Supports standby and global auto-lock timers.
- Persists lockout state under `{workspace}/.lock` after repeated invalid codes.

## Configuration
- `conversation_lock.enabled`
- `conversation_lock.standby_auto_lock_minutes`
- `conversation_lock.global_auto_lock_minutes`
- `conversation_lock.ota_expiry_minutes`
- `conversation_lock.max_unlock_attempts`
- `conversation_lock.resend_api_key`
- `conversation_lock.from_email`
- `conversation_lock.unlock_email`

## Test Plan
- `rtk make test`
- `rtk make lint`

Closes #140.
