### PR TITLE
Persist sessions in SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Copy `config.example.json` to `~/.picoclaw/config.json`. Key sections:
     }
   },
   "model_list": [{ "model_name": "gpt-4o-mini", "api_key": "env://OPENAI_API_KEY" }],
+  "sessions": {
+    "directory": "~/.sushiclaw/sessions"
+  },
   "channels": {
     "email": { "enabled": false, "type": "email", "...": "..." }
   },
@@ -98,6 +101,11 @@ Copy `config.example.json` to `~/.picoclaw/config.json`. Key sections:
 ```
 
 Override config path with `$SUSHICLAW_CONFIG`.
+
+Conversation sessions are persisted in a single SQLite database at
+`<sessions.directory>/sessions.db`. The default session directory is
+`~/.sushiclaw/sessions`, separate from the legacy `~/.picoclaw` config and workspace
+defaults. The `/clear` command removes the current session's persisted history.
 
 ---
 

--- a/config.example.json
+++ b/config.example.json
@@ -32,6 +32,9 @@
     "model_name": "whisper-1",
     "echo_transcription": false
   },
+  "sessions": {
+    "directory": "~/.sushiclaw/sessions"
+  },
   "channels": {
     "whatsapp_native": {
       "enabled": false,

--- a/internal/agent/memory.go
+++ b/internal/agent/memory.go
@@ -33,13 +33,17 @@ func (m *InMemoryMemory) GetMessages(_ context.Context, options ...interfaces.Ge
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	return filterMessages(m.messages, options...), nil
+}
+
+func filterMessages(messages []interfaces.Message, options ...interfaces.GetMessagesOption) []interfaces.Message {
 	opts := &interfaces.GetMessagesOptions{}
 	for _, o := range options {
 		o(opts)
 	}
 
-	result := make([]interfaces.Message, len(m.messages))
-	copy(result, m.messages)
+	result := make([]interfaces.Message, len(messages))
+	copy(result, messages)
 
 	// Apply role filter
 	if len(opts.Roles) > 0 {
@@ -61,7 +65,7 @@ func (m *InMemoryMemory) GetMessages(_ context.Context, options ...interfaces.Ge
 		result = result[len(result)-opts.Limit:]
 	}
 
-	return result, nil
+	return result
 }
 
 // Clear removes all messages from memory.

--- a/internal/agent/memory_test.go
+++ b/internal/agent/memory_test.go
@@ -2,6 +2,7 @@ package agent_test
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
@@ -64,4 +65,95 @@ func TestInMemoryMemory_Clear(t *testing.T) {
 	msgs, err := mem.GetMessages(ctx)
 	require.NoError(t, err)
 	assert.Len(t, msgs, 0)
+}
+
+func TestSQLiteMemory_PersistsAcrossReopen(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+
+	mem, err := agent.NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
+	require.NoError(t, err)
+	defer swallowError(mem.Close)
+
+	err = mem.AddMessage(ctx, interfaces.Message{
+		Role:       interfaces.MessageRoleAssistant,
+		Content:    "using a tool",
+		Metadata:   map[string]interface{}{"retry_count": 1},
+		ToolCallID: "tool-call-result",
+		ToolCalls: []interfaces.ToolCall{{
+			ID:        "call-1",
+			Name:      "exec",
+			Arguments: `{"cmd":"date"}`,
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, mem.Close())
+
+	reopened, err := agent.NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
+	require.NoError(t, err)
+	defer swallowError(reopened.Close)
+
+	msgs, err := reopened.GetMessages(ctx)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, interfaces.MessageRoleAssistant, msgs[0].Role)
+	assert.Equal(t, "using a tool", msgs[0].Content)
+	assert.Equal(t, "tool-call-result", msgs[0].ToolCallID)
+	require.Len(t, msgs[0].ToolCalls, 1)
+	assert.Equal(t, "call-1", msgs[0].ToolCalls[0].ID)
+	assert.Equal(t, float64(1), msgs[0].Metadata["retry_count"])
+}
+
+func TestSQLiteMemory_IsolatesSessionsAndFilters(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+
+	sessionA, err := agent.NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat-a")
+	require.NoError(t, err)
+	defer swallowError(sessionA.Close)
+	sessionB, err := agent.NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat-b")
+	require.NoError(t, err)
+	defer swallowError(sessionB.Close)
+
+	require.NoError(t, sessionA.AddMessage(ctx, interfaces.Message{Role: interfaces.MessageRoleUser, Content: "a1"}))
+	require.NoError(t, sessionA.AddMessage(ctx, interfaces.Message{Role: interfaces.MessageRoleAssistant, Content: "a2"}))
+	require.NoError(t, sessionB.AddMessage(ctx, interfaces.Message{Role: interfaces.MessageRoleUser, Content: "b1"}))
+
+	userMsgs, err := sessionA.GetMessages(ctx, interfaces.WithRoles(string(interfaces.MessageRoleUser)))
+	require.NoError(t, err)
+	require.Len(t, userMsgs, 1)
+	assert.Equal(t, "a1", userMsgs[0].Content)
+
+	limited, err := sessionA.GetMessages(ctx, interfaces.WithLimit(1))
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+	assert.Equal(t, "a2", limited[0].Content)
+
+	msgsB, err := sessionB.GetMessages(ctx)
+	require.NoError(t, err)
+	require.Len(t, msgsB, 1)
+	assert.Equal(t, "b1", msgsB[0].Content)
+}
+
+func TestSQLiteMemory_ClearDeletesPersistedRows(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+
+	mem, err := agent.NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
+	require.NoError(t, err)
+	require.NoError(t, mem.AddMessage(ctx, interfaces.Message{Role: interfaces.MessageRoleUser, Content: "hello"}))
+	require.NoError(t, mem.Clear(ctx))
+	require.NoError(t, mem.Close())
+
+	reopened, err := agent.NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
+	require.NoError(t, err)
+	defer swallowError(reopened.Close)
+
+	msgs, err := reopened.GetMessages(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, msgs)
+}
+
+func swallowError(fn func() error) {
+	_ = fn()
 }

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -45,7 +45,7 @@ type SessionManager struct {
 // Session represents a single isolated conversation context.
 type Session struct {
 	agent           agentRunner
-	mem             *InMemoryMemory
+	mem             interfaces.Memory
 	activatedSkills map[string]bool
 	lastUsed        time.Time
 	mu              sync.RWMutex
@@ -71,7 +71,7 @@ func BuildAgent(cfg *config.Config, tools []interfaces.Tool) (*agentsdk.Agent, e
 	return buildAgentWithMemory(cfg, tools, NewInMemoryMemory())
 }
 
-func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem *InMemoryMemory) (*agentsdk.Agent, error) {
+func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem interfaces.Memory) (*agentsdk.Agent, error) {
 	maxToolIterations := cfg.Agents.Defaults.MaxToolIterations
 	if maxToolIterations < 0 {
 		return nil, fmt.Errorf("invalid max_tool_iterations %d: must be >= 0", maxToolIterations)
@@ -204,6 +204,10 @@ func (sm *SessionManager) Stop() {
 	sm.mu.Lock()
 	stop := sm.cleanupStop
 	sm.cleanupStop = nil
+	for key, s := range sm.sessions {
+		closeSessionMemory(s.mem)
+		delete(sm.sessions, key)
+	}
 	sm.mu.Unlock()
 	if stop != nil {
 		close(stop)
@@ -232,6 +236,7 @@ func (sm *SessionManager) evictStaleSessions() {
 		lastUsed := s.lastUsed
 		s.mu.RUnlock()
 		if lastUsed.Before(cutoff) {
+			closeSessionMemory(s.mem)
 			delete(sm.sessions, key)
 		}
 	}
@@ -255,9 +260,13 @@ func (sm *SessionManager) getOrCreateSession(key string) (*Session, error) {
 		return s, nil
 	}
 
-	mem := NewInMemoryMemory()
+	mem, err := NewSQLiteSessionMemory(context.Background(), sessionDBPath(sm.cfg), key)
+	if err != nil {
+		return nil, err
+	}
 	a, err := buildAgentWithMemory(sm.cfg, sm.tools, mem)
 	if err != nil {
+		closeSessionMemory(mem)
 		return nil, err
 	}
 
@@ -272,12 +281,34 @@ func (sm *SessionManager) getOrCreateSession(key string) (*Session, error) {
 	return s, nil
 }
 
-// ClearHistory evicts the session from the registry entirely.
+// ClearHistory removes persisted history and evicts the session from the registry.
 func (sm *SessionManager) ClearHistory(sessionKey string) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	delete(sm.sessions, sessionKey)
-	return nil
+	if s, ok := sm.sessions[sessionKey]; ok {
+		if err := s.mem.Clear(context.Background()); err != nil {
+			return err
+		}
+		closeSessionMemory(s.mem)
+		delete(sm.sessions, sessionKey)
+		return nil
+	}
+	mem, err := NewSQLiteSessionMemory(context.Background(), sessionDBPath(sm.cfg), sessionKey)
+	if err != nil {
+		return err
+	}
+	defer closeSessionMemory(mem)
+	return mem.Clear(context.Background())
+}
+
+func sessionDBPath(cfg *config.Config) string {
+	return filepath.Join(cfg.SessionsPath(), "sessions.db")
+}
+
+func closeSessionMemory(mem interfaces.Memory) {
+	if closer, ok := mem.(interface{ Close() error }); ok {
+		_ = closer.Close()
+	}
 }
 
 // SetMediaStore injects a MediaStore for resolving media refs (e.g. voice messages).

--- a/internal/agent/session_integration_test.go
+++ b/internal/agent/session_integration_test.go
@@ -35,6 +35,7 @@ func TestSessionIsolation(t *testing.T) {
 		},
 	}
 	cfg.Agents.Defaults.Workspace = ws
+	cfg.Sessions.Directory = t.TempDir()
 
 	sm, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
 	require.NoError(t, err)
@@ -90,6 +91,7 @@ func TestClearHistoryEvictsSession(t *testing.T) {
 		},
 	}
 	cfg.Agents.Defaults.Workspace = ws
+	cfg.Sessions.Directory = t.TempDir()
 
 	sm, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
 	require.NoError(t, err)
@@ -119,8 +121,88 @@ func TestClearHistoryEvictsSession(t *testing.T) {
 	require.Len(t, msgs, 1)
 }
 
+func TestSessionManagerPersistsSessionAcrossManagers(t *testing.T) {
+	ws := t.TempDir()
+	sessionsDir := t.TempDir()
+	skillsDir := filepath.Join(ws, "skills", "python")
+	require.NoError(t, os.MkdirAll(skillsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillsDir, "SKILL.md"), []byte("Persistent skill."), 0644))
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{ModelName: "test-model", Workspace: ws},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+		Sessions: config.SessionsConfig{Directory: sessionsDir},
+	}
+
+	sm, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, sm.ActivateSkill("telegram:chat1", "python"))
+	sm.Stop()
+
+	reopened, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
+	require.NoError(t, err)
+	defer reopened.Stop()
+
+	session, err := reopened.getOrCreateSession("telegram:chat1")
+	require.NoError(t, err)
+	msgs, err := session.mem.GetMessages(context.Background())
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "Persistent skill.", msgs[0].Content)
+}
+
+func TestClearHistoryDeletesPersistedSession(t *testing.T) {
+	ws := t.TempDir()
+	sessionsDir := t.TempDir()
+	skillsDir := filepath.Join(ws, "skills", "python")
+	require.NoError(t, os.MkdirAll(skillsDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillsDir, "SKILL.md"), []byte("Clear me."), 0644))
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{ModelName: "test-model", Workspace: ws},
+		},
+		ModelList: []config.ModelConfig{
+			{
+				ModelName: "test-model",
+				Model:     "gpt-4o",
+				APIKey:    config.NewSecureString("test-key"),
+			},
+		},
+		Sessions: config.SessionsConfig{Directory: sessionsDir},
+	}
+
+	sm, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, sm.ActivateSkill("telegram:chat1", "python"))
+	sm.Stop()
+
+	clearer, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, clearer.ClearHistory("telegram:chat1"))
+	clearer.Stop()
+
+	reopened, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
+	require.NoError(t, err)
+	defer reopened.Stop()
+
+	session, err := reopened.getOrCreateSession("telegram:chat1")
+	require.NoError(t, err)
+	msgs, err := session.mem.GetMessages(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, msgs)
+}
+
 // TestSessionManagerEviction verifies that stale sessions are evicted by the
-// background cleanup goroutine.
+// background cleanup goroutine without deleting persisted history.
 func TestSessionManagerEviction(t *testing.T) {
 	cfg := &config.Config{
 		Agents: config.AgentsConfig{
@@ -134,6 +216,7 @@ func TestSessionManagerEviction(t *testing.T) {
 			},
 		},
 	}
+	cfg.Sessions.Directory = t.TempDir()
 
 	sm, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
 	require.NoError(t, err)
@@ -165,6 +248,13 @@ func TestSessionManagerEviction(t *testing.T) {
 	msgs, err = sm.GetMessages("old-session", context.Background())
 	require.NoError(t, err)
 	assert.Empty(t, msgs)
+
+	session, err := sm.getOrCreateSession("old-session")
+	require.NoError(t, err)
+	msgs, err = session.mem.GetMessages(context.Background())
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "Skill content.", msgs[0].Content)
 }
 
 // TestDispatchUsesSessionKey verifies that Dispatch routes to the correct
@@ -185,6 +275,7 @@ func TestDispatchUsesSessionKey(t *testing.T) {
 			},
 		},
 	}
+	cfg.Sessions.Directory = t.TempDir()
 
 	sm, err := NewSessionManager(cfg, extBus, nil, nil, WithProgressSink(progress))
 	require.NoError(t, err)

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -298,6 +298,7 @@ func TestSessionManager_ActivateSkill(t *testing.T) {
 		},
 	}
 	cfg.Agents.Defaults.Workspace = ws
+	cfg.Sessions.Directory = t.TempDir()
 
 	sm, err := agent.NewSessionManager(cfg, nil, nil, nil)
 	require.NoError(t, err)
@@ -333,6 +334,7 @@ func TestSessionManager_ActivateSkill_AlreadyLoaded(t *testing.T) {
 		},
 	}
 	cfg.Agents.Defaults.Workspace = ws
+	cfg.Sessions.Directory = t.TempDir()
 
 	sm, err := agent.NewSessionManager(cfg, nil, nil, nil)
 	require.NoError(t, err)
@@ -359,6 +361,7 @@ func TestSessionManager_ActivateSkill_NotFound(t *testing.T) {
 		},
 	}
 	cfg.Agents.Defaults.Workspace = ws
+	cfg.Sessions.Directory = t.TempDir()
 
 	sm, err := agent.NewSessionManager(cfg, nil, nil, nil)
 	require.NoError(t, err)

--- a/internal/agent/sqlite_memory.go
+++ b/internal/agent/sqlite_memory.go
@@ -1,0 +1,191 @@
+package agent
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	_ "modernc.org/sqlite"
+)
+
+const sqliteSessionSchema = `
+CREATE TABLE IF NOT EXISTS messages (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	session_key TEXT NOT NULL,
+	role TEXT NOT NULL,
+	content TEXT NOT NULL,
+	metadata_json TEXT,
+	tool_call_id TEXT,
+	tool_calls_json TEXT,
+	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_key, id);
+`
+
+// SQLiteSessionMemory stores one session's conversation in a shared SQLite DB.
+type SQLiteSessionMemory struct {
+	mu         sync.RWMutex
+	db         *sql.DB
+	sessionKey string
+	messages   []interfaces.Message
+}
+
+// NewSQLiteSessionMemory opens dbPath and returns memory scoped to sessionKey.
+func NewSQLiteSessionMemory(ctx context.Context, dbPath, sessionKey string) (*SQLiteSessionMemory, error) {
+	if err := os.MkdirAll(filepath.Dir(dbPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create sessions directory: %w", err)
+	}
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)")
+	if err != nil {
+		return nil, fmt.Errorf("open sessions database: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	mem := &SQLiteSessionMemory{db: db, sessionKey: sessionKey}
+	if err := mem.init(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := mem.load(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return mem, nil
+}
+
+func (m *SQLiteSessionMemory) init(ctx context.Context) error {
+	if _, err := m.db.ExecContext(ctx, sqliteSessionSchema); err != nil {
+		return fmt.Errorf("initialize sessions database: %w", err)
+	}
+	return nil
+}
+
+func (m *SQLiteSessionMemory) load(ctx context.Context) error {
+	rows, err := m.db.QueryContext(ctx, `
+SELECT role, content, metadata_json, tool_call_id, tool_calls_json
+FROM messages
+WHERE session_key = ?
+ORDER BY id`, m.sessionKey)
+	if err != nil {
+		return fmt.Errorf("load session messages: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	var messages []interfaces.Message
+	for rows.Next() {
+		var role, content, toolCallID string
+		var metadataJSON, toolCallsJSON sql.NullString
+		if err := rows.Scan(&role, &content, &metadataJSON, &toolCallID, &toolCallsJSON); err != nil {
+			return fmt.Errorf("scan session message: %w", err)
+		}
+		msg, err := messageFromSQLite(role, content, metadataJSON.String, toolCallID, toolCallsJSON.String)
+		if err != nil {
+			return err
+		}
+		messages = append(messages, msg)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("load session messages: %w", err)
+	}
+
+	m.mu.Lock()
+	m.messages = messages
+	m.mu.Unlock()
+	return nil
+}
+
+// AddMessage appends a message to this session.
+func (m *SQLiteSessionMemory) AddMessage(ctx context.Context, message interfaces.Message) error {
+	metadataJSON, toolCallsJSON, err := messageJSON(message)
+	if err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, err = m.db.ExecContext(ctx, `
+INSERT INTO messages (session_key, role, content, metadata_json, tool_call_id, tool_calls_json)
+VALUES (?, ?, ?, ?, ?, ?)`,
+		m.sessionKey,
+		string(message.Role),
+		message.Content,
+		metadataJSON,
+		message.ToolCallID,
+		toolCallsJSON,
+	)
+	if err != nil {
+		return fmt.Errorf("append session message: %w", err)
+	}
+	m.messages = append(m.messages, message)
+	return nil
+}
+
+// GetMessages returns all messages or filters by supported options.
+func (m *SQLiteSessionMemory) GetMessages(_ context.Context, options ...interfaces.GetMessagesOption) ([]interfaces.Message, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return filterMessages(m.messages, options...), nil
+}
+
+// Clear removes all messages from this session.
+func (m *SQLiteSessionMemory) Clear(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err := clearSQLiteSession(ctx, m.db, m.sessionKey); err != nil {
+		return err
+	}
+	m.messages = m.messages[:0]
+	return nil
+}
+
+// Close closes the underlying SQLite handle.
+func (m *SQLiteSessionMemory) Close() error {
+	return m.db.Close()
+}
+
+func clearSQLiteSession(ctx context.Context, db *sql.DB, sessionKey string) error {
+	if _, err := db.ExecContext(ctx, `DELETE FROM messages WHERE session_key = ?`, sessionKey); err != nil {
+		return fmt.Errorf("clear session messages: %w", err)
+	}
+	return nil
+}
+
+func messageJSON(message interfaces.Message) (string, string, error) {
+	metadata, err := json.Marshal(message.Metadata)
+	if err != nil {
+		return "", "", fmt.Errorf("marshal message metadata: %w", err)
+	}
+	toolCalls, err := json.Marshal(message.ToolCalls)
+	if err != nil {
+		return "", "", fmt.Errorf("marshal message tool calls: %w", err)
+	}
+	return string(metadata), string(toolCalls), nil
+}
+
+func messageFromSQLite(role, content, metadataJSON, toolCallID, toolCallsJSON string) (interfaces.Message, error) {
+	msg := interfaces.Message{
+		Role:       interfaces.MessageRole(role),
+		Content:    content,
+		ToolCallID: toolCallID,
+	}
+	if metadataJSON != "" {
+		if err := json.Unmarshal([]byte(metadataJSON), &msg.Metadata); err != nil {
+			return msg, fmt.Errorf("decode message metadata: %w", err)
+		}
+	}
+	if toolCallsJSON != "" {
+		if err := json.Unmarshal([]byte(toolCallsJSON), &msg.ToolCalls); err != nil {
+			return msg, fmt.Errorf("decode message tool calls: %w", err)
+		}
+	}
+	return msg, nil
+}

--- a/internal/chat/repl_test.go
+++ b/internal/chat/repl_test.go
@@ -24,6 +24,7 @@ func TestRunner_HelpCommand(t *testing.T) {
 		ModelList: []config.ModelConfig{
 			{ModelName: "test-model", Model: "gpt-4", APIKey: config.NewSecureString("test-key")},
 		},
+		Sessions: config.SessionsConfig{Directory: t.TempDir()},
 	}
 
 	// Build agent will fail without a real API key — this test just verifies
@@ -63,6 +64,7 @@ func TestRunner_EmptyInput(t *testing.T) {
 		ModelList: []config.ModelConfig{
 			{ModelName: "test-model", Model: "gpt-4", APIKey: config.NewSecureString("test-key")},
 		},
+		Sessions: config.SessionsConfig{Directory: t.TempDir()},
 	}
 
 	runner, err := chat.NewRunner(cfg)
@@ -84,4 +86,30 @@ func TestRunner_EmptyInput(t *testing.T) {
 
 	// Should show prompts but no responses for empty lines
 	assert.Contains(t, out.String(), "> ")
+}
+
+func TestRunner_ClearCommand(t *testing.T) {
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				ModelName: "test-model",
+				Workspace: "/tmp",
+			},
+		},
+		ModelList: []config.ModelConfig{
+			{ModelName: "test-model", Model: "gpt-4", APIKey: config.NewSecureString("test-key")},
+		},
+		Sessions: config.SessionsConfig{Directory: t.TempDir()},
+	}
+
+	runner, err := chat.NewRunner(cfg)
+	require.NoError(t, err)
+
+	var out bytes.Buffer
+	runner.SetOutput(&out)
+	runner.SetInput(strings.NewReader("/clear\n/quit\n"))
+
+	err = runner.Run(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, out.String(), "History cleared.")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	Tools       ToolsConfig    `json:"tools"`
 	MCP         MCPConfig      `json:"mcp,omitempty"`
 	VoiceConfig VoiceConfig    `json:"voice,omitempty"`
+	Sessions    SessionsConfig `json:"sessions,omitempty"`
 }
 
 // MCPConfig holds MCP server configuration.
@@ -86,6 +87,10 @@ type GatewayConfig struct {
 	Port                  int    `json:"port"`
 	LogLevel              string `json:"log_level"`
 	DebugHeartbeatSeconds int    `json:"debug_heartbeat_seconds,omitempty"`
+}
+
+type SessionsConfig struct {
+	Directory string `json:"directory,omitempty"`
 }
 
 type ToolsConfig struct {
@@ -368,6 +373,15 @@ func (c *Config) WorkspacePath() string {
 	p := c.Agents.Defaults.Workspace
 	if p == "" {
 		p = GetHome() + "/workspace"
+	}
+	return expandHome(p)
+}
+
+// SessionsPath returns the agent session storage directory with ~ expanded.
+func (c *Config) SessionsPath() string {
+	p := c.Sessions.Directory
+	if p == "" {
+		p = "~/.sushiclaw/sessions"
 	}
 	return expandHome(p)
 }

--- a/pkg/config/config_extra_test.go
+++ b/pkg/config/config_extra_test.go
@@ -78,6 +78,20 @@ func TestConfig_WorkspacePath(t *testing.T) {
 	assert.Equal(t, "/tmp/workspace", cfg.WorkspacePath())
 }
 
+func TestConfig_SessionsPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := &config.Config{}
+	assert.Equal(t, filepath.Join(home, ".sushiclaw", "sessions"), cfg.SessionsPath())
+
+	cfg.Sessions.Directory = "~/custom-sessions"
+	assert.Equal(t, filepath.Join(home, "custom-sessions"), cfg.SessionsPath())
+
+	cfg.Sessions.Directory = "/tmp/sessions"
+	assert.Equal(t, "/tmp/sessions", cfg.SessionsPath())
+}
+
 func TestConfig_Voice(t *testing.T) {
 	cfg := &config.Config{}
 	voice := cfg.Voice()


### PR DESCRIPTION
## Summary
- persist agent session memory in a single SQLite database under sessions.directory
- add sessions.directory config with ~/.sushiclaw/sessions default
- route terminal chat through SessionManager so /clear clears persisted cli:local history

Fixes #146

## Test plan
- make test
- make lint

## Known gaps
- #147 Add in-memory cache for SQLite session storage