### PR TITLE
Guard publish release against stale origin/main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ LDFLAGS     := -X $(VERSION_PKG).Version=$(VERSION) \
                -X $(VERSION_PKG).BuildTime=$(BUILDTIME) \
                -X $(VERSION_PKG).GoVersion=$(GOVER)
 
-.PHONY: build test install lint fmt vet deps test-integration release-check publish-version publish-version-dry-run air
+.PHONY: build test install lint fmt vet deps test-integration release-check publish-release publish-version publish-version-dry-run air
 
 build:
 	CGO_ENABLED=0 go build -tags whatsapp_native -ldflags "$(LDFLAGS)" -o $(BINARY) .
@@ -51,6 +51,8 @@ test-integration:
 release-check:
 	@test "$(VERSION)" != "dev" || (echo "ERROR: no git tag found, set VERSION= explicitly" && exit 1)
 	@echo "Releasing $(VERSION) from commit $(COMMIT)"
+
+publish-release: publish-version
 
 publish-version:
 	./scripts/publish-version.sh

--- a/scripts/publish-version.sh
+++ b/scripts/publish-version.sh
@@ -31,6 +31,16 @@ echo "Next release tag: ${version}"
 echo "Current commit:   ${head}"
 echo "origin/main:      ${remote_head}"
 
+if [[ "${FORCE:-}" != "1" && "${head}" != "${remote_head}" ]]; then
+	echo "ERROR: local HEAD (${head}) does not match origin/main (${remote_head})." >&2
+	echo "Run with FORCE=1 to publish anyway." >&2
+	exit 1
+fi
+
+if [[ "${FORCE:-}" == "1" && "${head}" != "${remote_head}" ]]; then
+	echo "WARNING: FORCE=1 set; publishing even though local HEAD differs from origin/main." >&2
+fi
+
 if [[ "${dry_run}" == true ]]; then
 	echo "Dry run: would create annotated tag ${version} and push it to origin."
 	echo "Command: git tag -a ${version} -m \"Release ${version}\""


### PR DESCRIPTION
Add a guard to make publish-release and scripts/publish-version.sh so it fails when local HEAD does not match origin/main, with FORCE=1 as an override. Also add publish-release as a Makefile alias for the existing publish script.\n\nVerification: make publish-version-dry-run