### PR TITLE
feat: add tool invocation debug logging

### DIFF
--- a/internal/agent/progress.go
+++ b/internal/agent/progress.go
@@ -37,10 +37,11 @@ type ProgressSummary struct {
 	ChatID  string
 	Success bool
 
-	ToolCalls int
-	Usage     *interfaces.TokenUsage
-	Duration  time.Duration
-	Error     error
+	ToolCalls     int
+	Usage         *interfaces.TokenUsage
+	Duration      time.Duration
+	ResponseBytes int
+	Error         error
 }
 
 type ProgressSink interface {

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -429,7 +429,10 @@ func (sm *SessionManager) Chat(ctx context.Context, input string) (string, error
 	if err != nil {
 		return "", err
 	}
-	return s.agent.Run(actx, input)
+	start := time.Now()
+	response, usage, toolCalls, err := s.runDetailedTurn(actx, input)
+	s.logTurnSummary("cli", "cli", time.Since(start), usage, toolCalls, len(response), err)
+	return response, err
 }
 
 // Dispatch processes a single inbound message through the agent.
@@ -521,9 +524,12 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 	start := time.Now()
 	s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressTurnStarted})
 
-	response, err := s.agent.Run(actx, input)
+	response, usage, toolCalls, err := s.runDetailedTurn(actx, input)
+	elapsed := time.Since(start)
+	responseBytes := len(response)
 	if err != nil {
 		logger.ErrorCF("agent", "Agent run failed", map[string]any{"error": err.Error()})
+		s.logTurnSummary(msg.Channel, chatID, elapsed, usage, toolCalls, responseBytes, err)
 		if s.mgr.bus != nil {
 			_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
 				Channel:    msg.Channel,
@@ -532,13 +538,16 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 				Content:    fmt.Sprintf("Error: %v", err),
 			})
 		}
-		s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressFailed, Error: err, Elapsed: time.Since(start)})
+		s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressFailed, Error: err, Elapsed: elapsed})
 		s.mgr.emitSummary(ctx, ProgressSummary{
-			Channel:  msg.Channel,
-			ChatID:   chatID,
-			Success:  false,
-			Duration: time.Since(start),
-			Error:    err,
+			Channel:       msg.Channel,
+			ChatID:        chatID,
+			Success:       false,
+			ToolCalls:     toolCalls,
+			Usage:         usage,
+			Duration:      elapsed,
+			ResponseBytes: responseBytes,
+			Error:         err,
 		})
 		return
 	}
@@ -553,12 +562,16 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 			})
 		}
 	}
-	s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressCompleted, Elapsed: time.Since(start)})
+	s.logTurnSummary(msg.Channel, chatID, elapsed, usage, toolCalls, responseBytes, nil)
+	s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressCompleted, Elapsed: elapsed})
 	s.mgr.emitSummary(ctx, ProgressSummary{
-		Channel:  msg.Channel,
-		ChatID:   chatID,
-		Success:  true,
-		Duration: time.Since(start),
+		Channel:       msg.Channel,
+		ChatID:        chatID,
+		Success:       true,
+		ToolCalls:     toolCalls,
+		Usage:         usage,
+		Duration:      elapsed,
+		ResponseBytes: responseBytes,
 	})
 }
 
@@ -699,6 +712,29 @@ func (sm *SessionManager) emitSummary(ctx context.Context, summary ProgressSumma
 	if sm.progress != nil {
 		sm.progress.Summary(ctx, summary)
 	}
+}
+
+func (s *Session) logTurnSummary(channel, chatID string, elapsed time.Duration, usage *interfaces.TokenUsage, toolCalls, responseBytes int, err error) {
+	fields := map[string]any{
+		"channel":        channel,
+		"chat_id":        chatID,
+		"duration":       elapsed.Round(time.Millisecond).String(),
+		"tool_calls":     toolCalls,
+		"response_bytes": responseBytes,
+	}
+	if usage != nil {
+		fields["input_tokens"] = usage.InputTokens
+		fields["output_tokens"] = usage.OutputTokens
+		fields["total_tokens"] = usage.TotalTokens
+	} else {
+		fields["tokens"] = "unavailable"
+	}
+	if err != nil {
+		fields["error"] = err.Error()
+		logger.DebugCF("agent", "Turn summary failed", fields)
+		return
+	}
+	logger.DebugCF("agent", "Turn summary", fields)
 }
 
 func resetTimer(timer *time.Timer, d time.Duration) {

--- a/internal/agent/session_debug_test.go
+++ b/internal/agent/session_debug_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/logger"
 )
 
 type mockRunner struct {
@@ -38,6 +41,18 @@ func (m *mockRunner) RunStream(context.Context, string) (<-chan interfaces.Agent
 }
 
 func (m *mockRunner) RunDetailed(context.Context, string) (*interfaces.AgentResponse, error) {
+	if m.detailedErr != nil {
+		return nil, m.detailedErr
+	}
+	if m.detailed != nil {
+		return m.detailed, nil
+	}
+	if m.runErr != nil {
+		return nil, m.runErr
+	}
+	if m.runResult != "" {
+		return &interfaces.AgentResponse{Content: m.runResult}, nil
+	}
 	return m.detailed, m.detailedErr
 }
 
@@ -71,7 +86,19 @@ func TestSessionManagerDebugStartCompletionAndSummary(t *testing.T) {
 	extBus := bus.NewMessageBus()
 	progress := &collectingProgress{}
 	sm := &SessionManager{bus: extBus, progress: progress}
-	session := &Session{agent: &mockRunner{runResult: "hello"}, mgr: sm}
+	session := &Session{
+		agent: &mockRunner{
+			detailed: &interfaces.AgentResponse{
+				Content: "hello",
+				Usage:   &interfaces.TokenUsage{InputTokens: 7, OutputTokens: 8, TotalTokens: 15},
+				ExecutionSummary: interfaces.ExecutionSummary{
+					LLMCalls:  1,
+					ToolCalls: 2,
+				},
+			},
+		},
+		mgr: sm,
+	}
 
 	session.handleInbound(t.Context(), inbound("telegram", "chat1", "hi"), "telegram:chat1")
 
@@ -80,6 +107,10 @@ func TestSessionManagerDebugStartCompletionAndSummary(t *testing.T) {
 	assertEventKinds(t, progress.events, ProgressTurnStarted, ProgressCompleted)
 	require.Len(t, progress.summaries, 1)
 	assert.True(t, progress.summaries[0].Success)
+	assert.Equal(t, 2, progress.summaries[0].ToolCalls)
+	require.NotNil(t, progress.summaries[0].Usage)
+	assert.Equal(t, 15, progress.summaries[0].Usage.TotalTokens)
+	assert.Equal(t, len("hello"), progress.summaries[0].ResponseBytes)
 	assert.GreaterOrEqual(t, progress.summaries[0].Duration, time.Duration(0))
 }
 
@@ -173,7 +204,7 @@ func TestSessionManagerRunErrorPublishesOneUserErrorAndFailureSummary(t *testing
 	extBus := bus.NewMessageBus()
 	progress := &collectingProgress{}
 	sm := &SessionManager{bus: extBus, progress: progress}
-	session := &Session{agent: &mockRunner{runErr: runErr}, mgr: sm}
+	session := &Session{agent: &mockRunner{detailedErr: runErr}, mgr: sm}
 
 	session.handleInbound(t.Context(), inbound("telegram", "chat1", "bad"), "telegram:chat1")
 
@@ -183,7 +214,49 @@ func TestSessionManagerRunErrorPublishesOneUserErrorAndFailureSummary(t *testing
 	require.Len(t, progress.summaries, 1)
 	assert.False(t, progress.summaries[0].Success)
 	assert.ErrorIs(t, progress.summaries[0].Error, runErr)
+	assert.Equal(t, 0, progress.summaries[0].ResponseBytes)
 	assertHasEvent(t, progress.events, ProgressFailed)
+}
+
+func TestSessionManagerTurnSummaryLogsUsageAndDuration(t *testing.T) {
+	tmpDir := t.TempDir()
+	logFile := filepath.Join(tmpDir, "debug.log")
+
+	prevLevel := logger.GetLevel()
+	logger.SetLevel(logger.DEBUG)
+	require.NoError(t, logger.EnableFileLogging(logFile))
+	t.Cleanup(func() {
+		logger.DisableFileLogging()
+		logger.SetLevel(prevLevel)
+	})
+
+	extBus := bus.NewMessageBus()
+	progress := &collectingProgress{}
+	sm := &SessionManager{bus: extBus, progress: progress}
+	session := &Session{
+		agent: &mockRunner{
+			detailed: &interfaces.AgentResponse{
+				Content: "hello",
+				Usage:   &interfaces.TokenUsage{InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
+				ExecutionSummary: interfaces.ExecutionSummary{
+					LLMCalls:  1,
+					ToolCalls: 1,
+				},
+			},
+		},
+		mgr: sm,
+	}
+
+	session.handleInbound(t.Context(), inbound("telegram", "chat1", "hi"), "telegram:chat1")
+
+	data, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	logs := string(data)
+	assert.Contains(t, logs, "Turn summary")
+	assert.Contains(t, logs, "total_tokens")
+	assert.Contains(t, logs, "duration")
+	assert.Contains(t, logs, "tool_calls")
+	assert.Contains(t, logs, "response_bytes")
 }
 
 func TestSessionManagerStreamingStartupFallbackUsesDetailedUsage(t *testing.T) {

--- a/internal/gateway/debug.go
+++ b/internal/gateway/debug.go
@@ -184,6 +184,7 @@ func debugSummaryText(summary agent.ProgressSummary) string {
 	}
 	sb.WriteString("\nTask time: ")
 	sb.WriteString(formatDuration(summary.Duration))
+	fmt.Fprintf(&sb, "\nResponse size: %d bytes", summary.ResponseBytes)
 	return sb.String()
 }
 

--- a/internal/gateway/debug_test.go
+++ b/internal/gateway/debug_test.go
@@ -100,18 +100,20 @@ func TestDebugManagerSummaryFormatsUsage(t *testing.T) {
 	mgr.Set(ctx, "telegram", "chat1", "on")
 
 	mgr.Summary(ctx, agent.ProgressSummary{
-		Channel:   "telegram",
-		ChatID:    "chat1",
-		Success:   true,
-		ToolCalls: 2,
-		Usage:     &interfaces.TokenUsage{InputTokens: 3, OutputTokens: 5, TotalTokens: 8},
-		Duration:  1200 * time.Millisecond,
+		Channel:       "telegram",
+		ChatID:        "chat1",
+		Success:       true,
+		ToolCalls:     2,
+		Usage:         &interfaces.TokenUsage{InputTokens: 3, OutputTokens: 5, TotalTokens: 8},
+		Duration:      1200 * time.Millisecond,
+		ResponseBytes: 42,
 	})
 
 	msg := requireOutbound(t, extBus)
 	assert.Contains(t, msg.Content, "Tool calls: 2")
 	assert.Contains(t, msg.Content, "Tokens: total=8 input=3 output=5")
 	assert.True(t, strings.Contains(msg.Content, "Task time: 1s") || strings.Contains(msg.Content, "Task time: 1.2s"))
+	assert.Contains(t, msg.Content, "Response size: 42 bytes")
 }
 
 func requireOutbound(t *testing.T, extBus *bus.MessageBus) bus.OutboundMessage {

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -99,7 +99,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 			logger.WarnCF("gateway", "Failed to init web search tool",
 				map[string]any{"error": err.Error()})
 		} else {
-			tools = append(tools, wsTool)
+			tools = append(tools, sushitools.WithDebugLogging(wsTool))
 			logger.InfoCF("gateway", "Web search tool registered",
 				map[string]any{"provider": cfg.Tools.WebSearch.Provider})
 		}
@@ -115,7 +115,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 		}
 	}
 	if cronScheduler != nil && cfg.Tools.IsToolEnabled("cron") {
-		tools = append(tools, cron.NewCronTool(cronScheduler, cfg))
+		tools = append(tools, sushitools.WithDebugLogging(cron.NewCronTool(cronScheduler, cfg)))
 		rt.ListCronJobs = func() (string, error) {
 			jobs, err := cronScheduler.ListJobs()
 			if err != nil {

--- a/pkg/cron/scheduler.go
+++ b/pkg/cron/scheduler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/bus"
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/logger"
+	"github.com/sushi30/sushiclaw/pkg/tools"
 	"github.com/sushi30/sushiclaw/pkg/tools/exec"
 )
 
@@ -318,7 +319,7 @@ func (s *Scheduler) executeCommandJob(ctx context.Context, job Job) {
 	execCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	execTool := exec.NewExecTool(s.cfg.WorkspacePath(), s.cfg.Agents.Defaults.RestrictToWorkspace, true)
+	execTool := tools.WithDebugLogging(exec.NewExecTool(s.cfg.WorkspacePath(), s.cfg.Agents.Defaults.RestrictToWorkspace, true))
 	output, err := execTool.Run(execCtx, job.Command)
 
 	content := output

--- a/pkg/tools/builder.go
+++ b/pkg/tools/builder.go
@@ -16,16 +16,16 @@ import (
 func NewChatTools(cfg *config.Config) []interfaces.Tool {
 	out := newFileTools(cfg)
 	if cfg.Tools.IsToolEnabled("exec") {
-		out = append(out, exec.NewExecTool(workspacePath(cfg), restrictToWorkspace(cfg), true))
+		out = append(out, withDebugLogging(exec.NewExecTool(workspacePath(cfg), restrictToWorkspace(cfg), true)))
 	}
 	if cfg.Tools.IsToolEnabled("web_search") {
 		if tool, err := websearch.NewTool(cfg.Tools.WebSearch); err == nil {
-			out = append(out, tool)
+			out = append(out, withDebugLogging(tool))
 		}
 	}
 	if cfg.Tools.IsToolEnabled("vision") {
 		if tool, err := vision.NewTool(cfg.Tools.Vision, visionModel(cfg), nil); err == nil {
-			out = append(out, tool)
+			out = append(out, withDebugLogging(tool))
 		}
 	}
 	return out
@@ -39,15 +39,15 @@ func NewGatewayTools(cfg *config.Config, execAllowedSenders []string, store medi
 		if err != nil {
 			return out, err
 		}
-		out = append(out, trustedExec)
+		out = append(out, withDebugLogging(trustedExec))
 	}
 	if cfg.Tools.IsToolEnabled("vision") {
 		if tool, err := vision.NewTool(cfg.Tools.Vision, visionModel(cfg), store); err == nil {
-			out = append(out, tool)
+			out = append(out, withDebugLogging(tool))
 		}
 	}
 	if cfg.Tools.IsToolEnabled("message") && messageBus != nil {
-		out = append(out, message.NewTool(messageBus, cfg.Tools.Message.MinInterval))
+		out = append(out, withDebugLogging(message.NewTool(messageBus, cfg.Tools.Message.MinInterval)))
 	}
 	return out, nil
 }
@@ -58,13 +58,13 @@ func newFileTools(cfg *config.Config) []interfaces.Tool {
 
 	var out []interfaces.Tool
 	if cfg.Tools.IsToolEnabled("read_file") {
-		out = append(out, fstools.NewReadFileTool(workspace, restrict, 0))
+		out = append(out, withDebugLogging(fstools.NewReadFileTool(workspace, restrict, 0)))
 	}
 	if cfg.Tools.IsToolEnabled("write_file") {
-		out = append(out, fstools.NewWriteFileTool(workspace, restrict))
+		out = append(out, withDebugLogging(fstools.NewWriteFileTool(workspace, restrict)))
 	}
 	if cfg.Tools.IsToolEnabled("list_dir") {
-		out = append(out, fstools.NewListDirTool(workspace, restrict))
+		out = append(out, withDebugLogging(fstools.NewListDirTool(workspace, restrict)))
 	}
 	return out
 }

--- a/pkg/tools/debug_logging.go
+++ b/pkg/tools/debug_logging.go
@@ -1,0 +1,65 @@
+package tools
+
+import (
+	"context"
+	"time"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/sushi30/sushiclaw/pkg/logger"
+	"github.com/sushi30/sushiclaw/pkg/tools/toolctx"
+)
+
+type debugLoggingTool struct {
+	tool interfaces.Tool
+}
+
+// WithDebugLogging wraps a tool with debug logging for tool invocations.
+func WithDebugLogging(tool interfaces.Tool) interfaces.Tool {
+	if tool == nil {
+		return nil
+	}
+	return debugLoggingTool{tool: tool}
+}
+
+func withDebugLogging(tool interfaces.Tool) interfaces.Tool {
+	return WithDebugLogging(tool)
+}
+
+func (t debugLoggingTool) Name() string { return t.tool.Name() }
+
+func (t debugLoggingTool) Description() string { return t.tool.Description() }
+
+func (t debugLoggingTool) Parameters() map[string]interfaces.ParameterSpec {
+	return t.tool.Parameters()
+}
+
+func (t debugLoggingTool) Run(ctx context.Context, input string) (string, error) {
+	return t.logAndRun(ctx, input)
+}
+
+func (t debugLoggingTool) Execute(ctx context.Context, input string) (string, error) {
+	return t.logAndRun(ctx, input)
+}
+
+func (t debugLoggingTool) logAndRun(ctx context.Context, input string) (string, error) {
+	start := time.Now()
+	fields := map[string]any{
+		"tool":      t.tool.Name(),
+		"params":    input,
+		"channel":   toolctx.ChannelFromContext(ctx),
+		"chat_id":   toolctx.ChatIDFromContext(ctx),
+		"sender_id": toolctx.SenderIDFromContext(ctx),
+	}
+	logger.DebugCF("tool", "Tool invoked", fields)
+
+	output, err := t.tool.Run(ctx, input)
+	fields["duration"] = time.Since(start).Round(time.Millisecond).String()
+	fields["output_bytes"] = len(output)
+	if err != nil {
+		fields["error"] = err.Error()
+		logger.DebugCF("tool", "Tool failed", fields)
+		return output, err
+	}
+	logger.DebugCF("tool", "Tool completed", fields)
+	return output, nil
+}

--- a/pkg/tools/debug_logging_test.go
+++ b/pkg/tools/debug_logging_test.go
@@ -1,0 +1,99 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/sushi30/sushiclaw/pkg/logger"
+)
+
+type stubTool struct {
+	name    string
+	runFunc func(context.Context, string) (string, error)
+}
+
+func (s stubTool) Name() string { return s.name }
+
+func (s stubTool) Description() string { return "stub" }
+
+func (s stubTool) Parameters() map[string]interfaces.ParameterSpec {
+	return map[string]interfaces.ParameterSpec{
+		"input": {Type: "string", Required: true},
+	}
+}
+
+func (s stubTool) Run(ctx context.Context, input string) (string, error) {
+	if s.runFunc != nil {
+		return s.runFunc(ctx, input)
+	}
+	return "ok", nil
+}
+
+func (s stubTool) Execute(ctx context.Context, input string) (string, error) {
+	return s.Run(ctx, input)
+}
+
+func TestWithDebugLoggingPreservesToolIdentity(t *testing.T) {
+	wrapped := WithDebugLogging(stubTool{name: "read_file"})
+	if wrapped.Name() != "read_file" {
+		t.Fatalf("Name() = %q, want read_file", wrapped.Name())
+	}
+	if wrapped.Description() != "stub" {
+		t.Fatalf("Description() = %q, want stub", wrapped.Description())
+	}
+	if _, ok := wrapped.Parameters()["input"]; !ok {
+		t.Fatal("expected parameters to be forwarded")
+	}
+}
+
+func TestWithDebugLoggingLogsParamsAndDuration(t *testing.T) {
+	tmpDir := t.TempDir()
+	logFile := filepath.Join(tmpDir, "debug.log")
+
+	prevLevel := logger.GetLevel()
+	logger.SetLevel(logger.DEBUG)
+	if err := logger.EnableFileLogging(logFile); err != nil {
+		t.Fatalf("EnableFileLogging: %v", err)
+	}
+	t.Cleanup(func() {
+		logger.DisableFileLogging()
+		logger.SetLevel(prevLevel)
+	})
+
+	wrapped := WithDebugLogging(stubTool{
+		name: "read_file",
+		runFunc: func(context.Context, string) (string, error) {
+			return "file contents", nil
+		},
+	})
+
+	out, err := wrapped.Run(context.Background(), `{"path":"README.md"}`)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out != "file contents" {
+		t.Fatalf("Run output = %q, want file contents", out)
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	logs := string(data)
+	if !strings.Contains(logs, "Tool invoked") {
+		t.Fatalf("logs = %q, want invocation log", logs)
+	}
+	if !strings.Contains(logs, "README.md") {
+		t.Fatalf("logs = %q, want params", logs)
+	}
+	if !strings.Contains(logs, "Tool completed") {
+		t.Fatalf("logs = %q, want completion log", logs)
+	}
+	if !strings.Contains(logs, "output_bytes") {
+		t.Fatalf("logs = %q, want output size", logs)
+	}
+}

--- a/pkg/tools/exec/exec_tool.go
+++ b/pkg/tools/exec/exec_tool.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/sushi30/sushiclaw/pkg/logger"
 	"github.com/sushi30/sushiclaw/pkg/tools/toolctx"
 )
 
@@ -84,15 +85,34 @@ func (e *ExecTool) Execute(ctx context.Context, args string) (string, error) {
 		cmdStr = restrictCommand(cmdStr, wd)
 	}
 
+	start := time.Now()
+	logger.DebugCF("exec", "Executing command", map[string]any{
+		"chat_id":               ChatIDFromContext(ctx),
+		"working_dir":           wd,
+		"restrict_to_workspace": e.restrictToWorkspace,
+		"allow_remote":          e.allowRemote,
+		"command":               cmdStr,
+	})
+
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", cmdStr)
 	cmd.Dir = wd
 	out, err := cmd.CombinedOutput()
+	fields := map[string]any{
+		"chat_id":     ChatIDFromContext(ctx),
+		"working_dir": wd,
+		"command":     cmdStr,
+		"duration":    time.Since(start).Round(time.Millisecond).String(),
+		"output_size": len(out),
+	}
 	if err != nil {
+		fields["error"] = err.Error()
+		logger.DebugCF("exec", "Command failed", fields)
 		return string(out), fmt.Errorf("exec error: %w", err)
 	}
+	logger.DebugCF("exec", "Command completed", fields)
 	return string(out), nil
 }
 

--- a/pkg/tools/exec/exec_tool_test.go
+++ b/pkg/tools/exec/exec_tool_test.go
@@ -2,8 +2,12 @@ package exec
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/sushi30/sushiclaw/pkg/logger"
 )
 
 func TestWithChatID(t *testing.T) {
@@ -159,6 +163,44 @@ func TestExecTool_Run(t *testing.T) {
 	}
 	if !strings.Contains(out, "run-test") {
 		t.Errorf("output = %q, want to contain 'run-test'", out)
+	}
+}
+
+func TestExecTool_LogsExecutedCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+	logFile := filepath.Join(tmpDir, "debug.log")
+
+	prevLevel := logger.GetLevel()
+	logger.SetLevel(logger.DEBUG)
+	if err := logger.EnableFileLogging(logFile); err != nil {
+		t.Fatalf("EnableFileLogging: %v", err)
+	}
+	t.Cleanup(func() {
+		logger.DisableFileLogging()
+		logger.SetLevel(prevLevel)
+	})
+
+	tool := NewExecTool("", false, true)
+	ctx := WithChatID(context.Background(), "cli")
+
+	_, err := tool.Execute(ctx, `{"command":"echo log-me"}`)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	logs := string(data)
+	if !strings.Contains(logs, "Executing command") {
+		t.Fatalf("logs = %q, want to contain executing command entry", logs)
+	}
+	if !strings.Contains(logs, "log-me") {
+		t.Fatalf("logs = %q, want to contain the command", logs)
+	}
+	if !strings.Contains(logs, "duration") {
+		t.Fatalf("logs = %q, want to contain duration", logs)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Add a shared debug wrapper for tools that logs raw parameters, context, duration, and output size.
- Wrap file, exec, web search, message, cron, and vision tool construction paths with the decorator.
- Extend turn summaries with duration, token usage, and response size.

Test plan:
- go test ./...
