### PR TITLE
feat: add mid-turn interruption and /stop

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -44,12 +44,15 @@ type SessionManager struct {
 
 // Session represents a single isolated conversation context.
 type Session struct {
-	agent           agentRunner
-	mem             interfaces.Memory
-	activatedSkills map[string]bool
-	lastUsed        time.Time
-	mu              sync.RWMutex
-	mgr             *SessionManager
+	agent            agentRunner
+	mem              interfaces.Memory
+	activatedSkills  map[string]bool
+	activeTurnCancel context.CancelFunc
+	activeTurnDone   chan struct{}
+	activeTurnSeq    uint64
+	lastUsed         time.Time
+	mu               sync.RWMutex
+	mgr              *SessionManager
 }
 
 type agentRunner interface {
@@ -205,6 +208,7 @@ func (sm *SessionManager) Stop() {
 	stop := sm.cleanupStop
 	sm.cleanupStop = nil
 	for key, s := range sm.sessions {
+		s.stopTurn()
 		closeSessionMemory(s.mem)
 		delete(sm.sessions, key)
 	}
@@ -286,6 +290,7 @@ func (sm *SessionManager) ClearHistory(sessionKey string) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	if s, ok := sm.sessions[sessionKey]; ok {
+		s.stopTurn()
 		if err := s.mem.Clear(context.Background()); err != nil {
 			return err
 		}
@@ -451,7 +456,8 @@ func (sm *SessionManager) Dispatch(ctx context.Context, msg bus.InboundMessage) 
 		}
 		return
 	}
-	s.handleInbound(ctx, msg, key)
+	turnCtx, turnSeq, turnDone := s.startTurn(ctx)
+	s.handleInbound(turnCtx, msg, key, turnSeq, turnDone)
 }
 
 func computeSessionKey(msg bus.InboundMessage) string {
@@ -461,12 +467,17 @@ func computeSessionKey(msg bus.InboundMessage) string {
 	return msg.Channel + ":" + msg.ChatID
 }
 
-func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, sessionKey string) {
+func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, sessionKey string, turnSeq uint64, turnDone chan struct{}) {
+	defer s.finishTurn(turnSeq, turnDone)
+
 	chatID := msg.ChatID
 
 	// Transcribe audio before processing.
 	msg, hadAudio, err := s.mgr.transcribeAudioInMessage(ctx, msg)
 	if err != nil {
+		if s.turnCanceled(ctx, turnSeq, err) {
+			return
+		}
 		logger.WarnCF("agent", "Transcription failed", map[string]any{"error": err.Error()})
 		if s.mgr.bus != nil {
 			_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
@@ -479,6 +490,9 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 		return
 	}
 	if hadAudio && msg.Content == "" {
+		if s.turnCanceled(ctx, turnSeq, nil) {
+			return
+		}
 		if s.mgr.bus != nil {
 			_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
 				Channel:    msg.Channel,
@@ -528,6 +542,9 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 	elapsed := time.Since(start)
 	responseBytes := len(response)
 	if err != nil {
+		if s.turnCanceled(ctx, turnSeq, err) {
+			return
+		}
 		logger.ErrorCF("agent", "Agent run failed", map[string]any{"error": err.Error()})
 		s.logTurnSummary(msg.Channel, chatID, elapsed, usage, toolCalls, responseBytes, err)
 		if s.mgr.bus != nil {
@@ -552,6 +569,9 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 		return
 	}
 
+	if s.turnCanceled(ctx, turnSeq, nil) {
+		return
+	}
 	if response != "" {
 		if s.mgr.bus != nil {
 			_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
@@ -573,6 +593,78 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 		Duration:      elapsed,
 		ResponseBytes: responseBytes,
 	})
+}
+
+func (s *Session) startTurn(parent context.Context) (context.Context, uint64, chan struct{}) {
+	turnCtx, cancel := context.WithCancel(parent)
+	done := make(chan struct{})
+
+	s.mu.Lock()
+	prevCancel := s.activeTurnCancel
+	s.activeTurnSeq++
+	turnSeq := s.activeTurnSeq
+	s.activeTurnCancel = cancel
+	s.activeTurnDone = done
+	s.lastUsed = time.Now()
+	s.mu.Unlock()
+
+	if prevCancel != nil {
+		prevCancel()
+	}
+
+	return turnCtx, turnSeq, done
+}
+
+func (s *Session) finishTurn(turnSeq uint64, turnDone chan struct{}) {
+	if turnDone != nil {
+		close(turnDone)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.activeTurnSeq != turnSeq {
+		return
+	}
+	s.activeTurnCancel = nil
+	s.activeTurnDone = nil
+}
+
+func (s *Session) isCurrentTurn(turnSeq uint64) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.activeTurnSeq == turnSeq
+}
+
+func (s *Session) stopTurn() bool {
+	s.mu.RLock()
+	cancel := s.activeTurnCancel
+	s.mu.RUnlock()
+	if cancel == nil {
+		return false
+	}
+	cancel()
+	return true
+}
+
+func (sm *SessionManager) StopTurn(sessionKey string) bool {
+	sm.mu.RLock()
+	s := sm.sessions[sessionKey]
+	sm.mu.RUnlock()
+	if s == nil {
+		return false
+	}
+	return s.stopTurn()
+}
+
+func (s *Session) turnCanceled(ctx context.Context, turnSeq uint64, err error) bool {
+	if isExpectedCancellation(err) || ctx.Err() != nil || !s.isCurrentTurn(turnSeq) {
+		return true
+	}
+	return false
+}
+
+func isExpectedCancellation(err error) bool {
+	return errors.Is(err, context.Canceled)
 }
 
 func (s *Session) runStreamingTurn(

--- a/internal/agent/session_debug_test.go
+++ b/internal/agent/session_debug_test.go
@@ -461,10 +461,17 @@ func (s *scriptedRunner) Run(ctx context.Context, input string) (string, error) 
 }
 
 func (s *scriptedRunner) RunDetailed(ctx context.Context, input string) (*interfaces.AgentResponse, error) {
-	if s.runDetailed == nil {
-		return nil, errors.New("RunDetailed should not be called")
+	if s.runDetailed != nil {
+		return s.runDetailed(ctx, input)
 	}
-	return s.runDetailed(ctx, input)
+	if s.run != nil {
+		content, err := s.run(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		return &interfaces.AgentResponse{Content: content}, nil
+	}
+	return nil, errors.New("RunDetailed should not be called")
 }
 
 func (s *scriptedRunner) RunStream(ctx context.Context, input string) (<-chan interfaces.AgentStreamEvent, error) {

--- a/internal/agent/session_debug_test.go
+++ b/internal/agent/session_debug_test.go
@@ -249,7 +249,8 @@ func TestSessionManagerTurnSummaryLogsUsageAndDuration(t *testing.T) {
 		mgr: sm,
 	}
 
-	session.handleInbound(t.Context(), inbound("telegram", "chat1", "hi"), "telegram:chat1")
+	turnCtx, turnSeq, turnDone := session.startTurn(t.Context())
+	session.handleInbound(turnCtx, inbound("telegram", "chat1", "hi"), "telegram:chat1", turnSeq, turnDone)
 
 	data, err := os.ReadFile(logFile)
 	require.NoError(t, err)

--- a/internal/agent/session_debug_test.go
+++ b/internal/agent/session_debug_test.go
@@ -100,7 +100,8 @@ func TestSessionManagerDebugStartCompletionAndSummary(t *testing.T) {
 		mgr: sm,
 	}
 
-	session.handleInbound(t.Context(), inbound("telegram", "chat1", "hi"), "telegram:chat1")
+	turnCtx, turnSeq, turnDone := session.startTurn(t.Context())
+	session.handleInbound(turnCtx, inbound("telegram", "chat1", "hi"), "telegram:chat1", turnSeq, turnDone)
 
 	msg := requireOutboundMessage(t, extBus)
 	assert.Equal(t, "hello", msg.Content)
@@ -206,7 +207,8 @@ func TestSessionManagerRunErrorPublishesOneUserErrorAndFailureSummary(t *testing
 	sm := &SessionManager{bus: extBus, progress: progress}
 	session := &Session{agent: &mockRunner{detailedErr: runErr}, mgr: sm}
 
-	session.handleInbound(t.Context(), inbound("telegram", "chat1", "bad"), "telegram:chat1")
+	turnCtx, turnSeq, turnDone := session.startTurn(t.Context())
+	session.handleInbound(turnCtx, inbound("telegram", "chat1", "bad"), "telegram:chat1", turnSeq, turnDone)
 
 	msg := requireOutboundMessage(t, extBus)
 	assert.Equal(t, "Error: run failed", msg.Content)
@@ -288,6 +290,189 @@ func TestSessionManagerStreamingStartupFallbackUsesDetailedUsage(t *testing.T) {
 	assert.Equal(t, 15, usage.TotalTokens)
 }
 
+func TestSessionManagerStopTurnCancelsActiveWorkAndAllowsNextTurn(t *testing.T) {
+	extBus := bus.NewMessageBus()
+	progress := &collectingProgress{}
+	sm := &SessionManager{
+		bus:      extBus,
+		progress: progress,
+		sessions: map[string]*Session{},
+	}
+
+	started := make(chan struct{}, 1)
+	session := &Session{
+		agent: &scriptedRunner{
+			run: func(ctx context.Context, input string) (string, error) {
+				switch input {
+				case "first":
+					started <- struct{}{}
+					<-ctx.Done()
+					return "", ctx.Err()
+				case "second":
+					return "second reply", nil
+				default:
+					return "", errors.New("unexpected input")
+				}
+			},
+		},
+		mgr: sm,
+	}
+	sm.sessions["telegram:chat1"] = session
+
+	go sm.Dispatch(t.Context(), inbound("telegram", "chat1", "first"))
+	<-started
+
+	assert.True(t, sm.StopTurn("telegram:chat1"))
+	assertNoOutboundMessage(t, extBus)
+	assertNotHasEvent(t, progress.events, ProgressFailed)
+
+	sm.Dispatch(t.Context(), inbound("telegram", "chat1", "second"))
+
+	msg := requireOutboundMessage(t, extBus)
+	assert.Equal(t, "second reply", msg.Content)
+	assert.Equal(t, "telegram:chat1", msg.SessionKey)
+}
+
+func TestSessionManagerSecondInboundCancelsFirstAndPublishesOnlySecond(t *testing.T) {
+	extBus := bus.NewMessageBus()
+	progress := &collectingProgress{}
+	sm := &SessionManager{
+		bus:      extBus,
+		progress: progress,
+		sessions: map[string]*Session{},
+	}
+
+	firstStarted := make(chan struct{}, 1)
+	firstRelease := make(chan struct{})
+	session := &Session{
+		agent: &scriptedRunner{
+			run: func(ctx context.Context, input string) (string, error) {
+				switch input {
+				case "first":
+					firstStarted <- struct{}{}
+					<-firstRelease
+					return "stale first reply", nil
+				case "second":
+					return "second reply", nil
+				default:
+					return "", errors.New("unexpected input")
+				}
+			},
+		},
+		mgr: sm,
+	}
+	sm.sessions["telegram:chat1"] = session
+
+	go sm.Dispatch(t.Context(), inbound("telegram", "chat1", "first"))
+	<-firstStarted
+
+	sm.Dispatch(t.Context(), inbound("telegram", "chat1", "second"))
+	close(firstRelease)
+
+	msg := requireOutboundMessage(t, extBus)
+	assert.Equal(t, "second reply", msg.Content)
+	assertNoOutboundMessage(t, extBus)
+	assertNotHasEvent(t, progress.events, ProgressFailed)
+}
+
+func TestSessionManagerCanceledTurnSuppressesContextCanceledReply(t *testing.T) {
+	extBus := bus.NewMessageBus()
+	progress := &collectingProgress{}
+	sm := &SessionManager{
+		bus:      extBus,
+		progress: progress,
+		sessions: map[string]*Session{},
+	}
+
+	started := make(chan struct{}, 1)
+	session := &Session{
+		agent: &scriptedRunner{
+			run: func(ctx context.Context, input string) (string, error) {
+				started <- struct{}{}
+				<-ctx.Done()
+				return "", ctx.Err()
+			},
+		},
+		mgr: sm,
+	}
+	sm.sessions["telegram:chat1"] = session
+
+	go sm.Dispatch(t.Context(), inbound("telegram", "chat1", "first"))
+	<-started
+	assert.True(t, sm.StopTurn("telegram:chat1"))
+
+	assertNoOutboundMessage(t, extBus)
+	assertNotHasEvent(t, progress.events, ProgressFailed)
+}
+
+func TestSessionManagerStaleCanceledTurnCompletionIsIgnored(t *testing.T) {
+	extBus := bus.NewMessageBus()
+	progress := &collectingProgress{}
+	sm := &SessionManager{
+		bus:      extBus,
+		progress: progress,
+		sessions: map[string]*Session{},
+	}
+
+	firstStarted := make(chan struct{}, 1)
+	firstRelease := make(chan struct{})
+	session := &Session{
+		agent: &scriptedRunner{
+			run: func(ctx context.Context, input string) (string, error) {
+				switch input {
+				case "first":
+					firstStarted <- struct{}{}
+					<-firstRelease
+					return "stale first reply", nil
+				case "second":
+					return "fresh second reply", nil
+				default:
+					return "", errors.New("unexpected input")
+				}
+			},
+		},
+		mgr: sm,
+	}
+	sm.sessions["telegram:chat1"] = session
+
+	go sm.Dispatch(t.Context(), inbound("telegram", "chat1", "first"))
+	<-firstStarted
+
+	sm.Dispatch(t.Context(), inbound("telegram", "chat1", "second"))
+	close(firstRelease)
+
+	msg := requireOutboundMessage(t, extBus)
+	assert.Equal(t, "fresh second reply", msg.Content)
+	assertNoOutboundMessage(t, extBus)
+}
+
+type scriptedRunner struct {
+	run         func(context.Context, string) (string, error)
+	runDetailed func(context.Context, string) (*interfaces.AgentResponse, error)
+	runStream   func(context.Context, string) (<-chan interfaces.AgentStreamEvent, error)
+}
+
+func (s *scriptedRunner) Run(ctx context.Context, input string) (string, error) {
+	if s.run == nil {
+		return "", errors.New("Run should not be called")
+	}
+	return s.run(ctx, input)
+}
+
+func (s *scriptedRunner) RunDetailed(ctx context.Context, input string) (*interfaces.AgentResponse, error) {
+	if s.runDetailed == nil {
+		return nil, errors.New("RunDetailed should not be called")
+	}
+	return s.runDetailed(ctx, input)
+}
+
+func (s *scriptedRunner) RunStream(ctx context.Context, input string) (<-chan interfaces.AgentStreamEvent, error) {
+	if s.runStream == nil {
+		return nil, errors.New("RunStream should not be called")
+	}
+	return s.runStream(ctx, input)
+}
+
 func streamEvents(events ...interfaces.AgentStreamEvent) <-chan interfaces.AgentStreamEvent {
 	ch := make(chan interfaces.AgentStreamEvent, len(events))
 	for _, event := range events {
@@ -337,4 +522,13 @@ func assertHasEvent(t *testing.T, events []ProgressEvent, kind ProgressKind) {
 		}
 	}
 	t.Fatalf("expected event kind %s in %#v", kind, events)
+}
+
+func assertNotHasEvent(t *testing.T, events []ProgressEvent, kind ProgressKind) {
+	t.Helper()
+	for _, event := range events {
+		if event.Kind == kind {
+			t.Fatalf("unexpected event kind %s in %#v", kind, events)
+		}
+	}
 }

--- a/internal/agent/session_integration_test.go
+++ b/internal/agent/session_integration_test.go
@@ -366,11 +366,12 @@ func TestOutboundMessageIncludesSessionKey(t *testing.T) {
 	sm := &SessionManager{bus: extBus, progress: progress}
 	session := &Session{agent: &mockRunner{runResult: "hi"}, mgr: sm}
 
-	session.handleInbound(context.Background(), bus.InboundMessage{
+	turnCtx, turnSeq, turnDone := session.startTurn(context.Background())
+	session.handleInbound(turnCtx, bus.InboundMessage{
 		Channel: "telegram",
 		ChatID:  "chat1",
 		Content: "hello",
-	}, "telegram:chat1")
+	}, "telegram:chat1", turnSeq, turnDone)
 
 	msg := requireOutboundMessage(t, extBus)
 	assert.Equal(t, "hi", msg.Content)

--- a/internal/chat/repl.go
+++ b/internal/chat/repl.go
@@ -218,6 +218,7 @@ func (r *Runner) startInboundLoop(ctx context.Context) {
 		ClearHistory: func(req commands.Request) error {
 			return r.session.ClearHistory(req.SessionKey)
 		},
+		StopTurn: r.session.StopTurn,
 		ActivateSkill: func(req commands.Request, skillName string) error {
 			return r.session.ActivateSkill(req.SessionKey, skillName)
 		},

--- a/internal/commandfilter/commandfilter_test.go
+++ b/internal/commandfilter/commandfilter_test.go
@@ -34,7 +34,7 @@ func TestFilter_KnownCommands(t *testing.T) {
 	f := NewCommandFilter()
 	cases := []string{
 		"/start", "/help", "/show", "/list", "/use",
-		"/switch", "/check", "/clear", "/subagents", "/reload",
+		"/switch", "/check", "/clear", "/stop", "/subagents", "/reload",
 	}
 	for _, cmd := range cases {
 		t.Run(cmd, func(t *testing.T) {
@@ -57,6 +57,7 @@ func TestFilter_KnownCommandsWithArgs(t *testing.T) {
 		"/use python",
 		"/debug on",
 		"/debug off",
+		"/stop",
 		"/clear",
 	}
 	for _, cmd := range cases {

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -192,6 +192,7 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 		rt.ClearHistory = func(req commands.Request) error {
 			return sessionMgr.ClearHistory(req.SessionKey)
 		}
+		rt.StopTurn = sessionMgr.StopTurn
 		rt.GetModelInfo = sessionMgr.GetModelInfo
 		rt.ListModels = sessionMgr.ListModels
 		rt.ListSkills = sessionMgr.ListSkills

--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -68,6 +68,7 @@ type Runtime struct {
 	ListSkills      func() []SkillInfo
 	ListCronJobs    func() (string, error)
 	ClearHistory    func(req Request) error
+	StopTurn        func(sessionKey string) bool
 	SetDebug        func(ctx context.Context, channel, chatID, mode string) string
 	ActivateSkill   func(req Request, skillName string) error
 }
@@ -258,6 +259,7 @@ func BuiltinDefinitions() []Definition {
 		{Name: "start", Description: "Start the bot", Handler: startHandler},
 		{Name: "help", Description: "Show this help message", Handler: helpHandler},
 		{Name: "clear", Description: "Clear conversation history", Handler: clearHandler},
+		{Name: "stop", Description: "Stop the current turn", Handler: stopHandler},
 		{Name: "debug", Description: "Toggle debug event forwarding", Handler: debugHandler, Usage: "/debug [on|off]"},
 		{Name: "model", Description: "Show or switch model", Handler: modelHandler},
 		{Name: "show", Description: "Show current configuration"},
@@ -359,6 +361,13 @@ func clearHandler(_ context.Context, req Request, rt *Runtime) error {
 		}
 	}
 	return req.Reply("History cleared.")
+}
+
+func stopHandler(_ context.Context, req Request, rt *Runtime) error {
+	if rt != nil && rt.StopTurn != nil && rt.StopTurn(req.SessionKey) {
+		return req.Reply("Stopped current turn.")
+	}
+	return req.Reply("No active turn.")
 }
 
 func modelHandler(_ context.Context, req Request, rt *Runtime) error {

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -58,6 +58,7 @@ func TestExecuteHelp(t *testing.T) {
 	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
 	assert.Contains(t, replied, "/help")
 	assert.Contains(t, replied, "/clear")
+	assert.Contains(t, replied, "/stop")
 }
 
 func TestExecuteHelpNoRuntime(t *testing.T) {
@@ -102,6 +103,46 @@ func TestExecuteClearCallsCallback(t *testing.T) {
 	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
 	assert.True(t, cleared)
 	assert.Contains(t, replied, "cleared")
+}
+
+func TestExecuteStopActiveTurn(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	stopped := false
+	rt := &commands.Runtime{
+		StopTurn: func(sessionKey string) bool {
+			stopped = true
+			return sessionKey == "telegram:123"
+		},
+	}
+	exec := commands.NewExecutor(reg, rt)
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:       "/stop",
+		SessionKey: "telegram:123",
+		Reply:      func(s string) error { replied = s; return nil },
+	})
+
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.True(t, stopped)
+	assert.Equal(t, "Stopped current turn.", replied)
+}
+
+func TestExecuteStopIdleSession(t *testing.T) {
+	reg := commands.NewRegistry(commands.BuiltinDefinitions())
+	exec := commands.NewExecutor(reg, &commands.Runtime{
+		StopTurn: func(string) bool { return false },
+	})
+
+	var replied string
+	result := exec.Execute(context.Background(), commands.Request{
+		Text:       "/stop",
+		SessionKey: "telegram:123",
+		Reply:      func(s string) error { replied = s; return nil },
+	})
+
+	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
+	assert.Equal(t, "No active turn.", replied)
 }
 
 func TestExecuteModel(t *testing.T) {


### PR DESCRIPTION
## Summary
- add per-session active-turn cancellation so only the latest inbound message for a session can complete
- add a /stop command to cancel the active turn for the current session
- cover interruption, stale-turn suppression, and command behavior with tests

## Test plan
- make test
- make lint

## Known gaps
- None identified during implementation