### PR TITLE
feat: tag system outbound messages

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -440,11 +440,11 @@ func (sm *SessionManager) Dispatch(ctx context.Context, msg bus.InboundMessage) 
 	if err != nil {
 		logger.ErrorCF("agent", "Failed to create session", map[string]any{"session_key": key, "error": err.Error()})
 		if sm.bus != nil {
-			_ = sm.bus.PublishOutbound(ctx, bus.OutboundMessage{
+			_ = sm.bus.PublishOutbound(ctx, bus.MarkSystemOutboundMessage(bus.OutboundMessage{
 				Channel: msg.Channel,
 				ChatID:  msg.ChatID,
 				Content: fmt.Sprintf("Error: %v", err),
-			})
+			}))
 		}
 		return
 	}
@@ -466,23 +466,23 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 	if err != nil {
 		logger.WarnCF("agent", "Transcription failed", map[string]any{"error": err.Error()})
 		if s.mgr.bus != nil {
-			_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
+			_ = s.mgr.bus.PublishOutbound(ctx, bus.MarkSystemOutboundMessage(bus.OutboundMessage{
 				Channel:    msg.Channel,
 				ChatID:     chatID,
 				SessionKey: sessionKey,
 				Content:    "Sorry, I couldn't transcribe that voice message.",
-			})
+			}))
 		}
 		return
 	}
 	if hadAudio && msg.Content == "" {
 		if s.mgr.bus != nil {
-			_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
+			_ = s.mgr.bus.PublishOutbound(ctx, bus.MarkSystemOutboundMessage(bus.OutboundMessage{
 				Channel:    msg.Channel,
 				ChatID:     chatID,
 				SessionKey: sessionKey,
 				Content:    "Sorry, I couldn't understand that voice message.",
-			})
+			}))
 		}
 		return
 	}
@@ -525,12 +525,12 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 	if err != nil {
 		logger.ErrorCF("agent", "Agent run failed", map[string]any{"error": err.Error()})
 		if s.mgr.bus != nil {
-			_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
+			_ = s.mgr.bus.PublishOutbound(ctx, bus.MarkSystemOutboundMessage(bus.OutboundMessage{
 				Channel:    msg.Channel,
 				ChatID:     chatID,
 				SessionKey: sessionKey,
 				Content:    fmt.Sprintf("Error: %v", err),
-			})
+			}))
 		}
 		s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressFailed, Error: err, Elapsed: time.Since(start)})
 		s.mgr.emitSummary(ctx, ProgressSummary{

--- a/internal/agent/session_debug_test.go
+++ b/internal/agent/session_debug_test.go
@@ -178,7 +178,8 @@ func TestSessionManagerRunErrorPublishesOneUserErrorAndFailureSummary(t *testing
 	session.handleInbound(t.Context(), inbound("telegram", "chat1", "bad"), "telegram:chat1")
 
 	msg := requireOutboundMessage(t, extBus)
-	assert.Equal(t, "Error: run failed", msg.Content)
+	assert.Equal(t, bus.MessageKindSystem, msg.Context.Raw["message_kind"])
+	assert.Equal(t, "[system] Error: run failed", msg.Content)
 	assertNoOutboundMessage(t, extBus)
 	require.Len(t, progress.summaries, 1)
 	assert.False(t, progress.summaries[0].Success)

--- a/internal/chat/repl.go
+++ b/internal/chat/repl.go
@@ -235,11 +235,11 @@ func (r *Runner) startInboundLoop(ctx context.Context) {
 				}
 				dec := cmdFilter.Filter(msg)
 				if dec.Result == commandfilter.Block {
-					_ = r.bus.PublishOutbound(ctx, bus.OutboundMessage{
+					_ = r.bus.PublishOutbound(ctx, bus.MarkSystemOutboundMessage(bus.OutboundMessage{
 						Channel: msg.Channel,
 						ChatID:  msg.ChatID,
 						Content: dec.ErrMsg,
-					})
+					}))
 					continue
 				}
 
@@ -260,11 +260,11 @@ func (r *Runner) startInboundLoop(ctx context.Context) {
 					})
 					if result.Outcome == commands.OutcomeHandled {
 						if reply != "" {
-							_ = r.bus.PublishOutbound(ctx, bus.OutboundMessage{
+							_ = r.bus.PublishOutbound(ctx, bus.MarkSystemOutboundMessage(bus.OutboundMessage{
 								Channel: msg.Channel,
 								ChatID:  msg.ChatID,
 								Content: reply,
-							})
+							}))
 						}
 						continue
 					}

--- a/internal/gateway/debug.go
+++ b/internal/gateway/debug.go
@@ -115,11 +115,11 @@ func (d *DebugManager) publish(ctx context.Context, channel, chatID, content str
 	if d.bus == nil || strings.TrimSpace(content) == "" {
 		return
 	}
-	if err := d.bus.PublishOutbound(ctx, bus.OutboundMessage{
+	if err := d.bus.PublishOutbound(ctx, bus.MarkSystemOutboundMessage(bus.OutboundMessage{
 		Channel: channel,
 		ChatID:  chatID,
 		Content: content,
-	}); err != nil {
+	})); err != nil {
 		logger.WarnCF("debug", "Failed to publish debug message", map[string]any{
 			"channel": channel,
 			"chat_id": chatID,

--- a/internal/gateway/debug_test.go
+++ b/internal/gateway/debug_test.go
@@ -90,6 +90,8 @@ func TestDebugManagerPublishesProgressOnlyToEnabledChat(t *testing.T) {
 	msg := requireOutbound(t, extBus)
 	assert.Equal(t, "telegram", msg.Channel)
 	assert.Equal(t, "chat1", msg.ChatID)
+	assert.Equal(t, bus.MessageKindSystem, msg.Context.Raw["message_kind"])
+	assert.Contains(t, msg.Content, "[system]")
 	assert.Contains(t, msg.Content, "exec")
 }
 
@@ -109,6 +111,8 @@ func TestDebugManagerSummaryFormatsUsage(t *testing.T) {
 	})
 
 	msg := requireOutbound(t, extBus)
+	assert.Equal(t, bus.MessageKindSystem, msg.Context.Raw["message_kind"])
+	assert.Contains(t, msg.Content, "[system]")
 	assert.Contains(t, msg.Content, "Tool calls: 2")
 	assert.Contains(t, msg.Content, "Tokens: total=8 input=3 output=5")
 	assert.True(t, strings.Contains(msg.Content, "Task time: 1s") || strings.Contains(msg.Content, "Task time: 1.2s"))

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -226,11 +226,11 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 							"chat_id": msg.ChatID,
 							"command": dec.Command,
 						})
-					_ = messageBus.PublishOutbound(ctx, bus.OutboundMessage{
+					_ = messageBus.PublishOutbound(ctx, bus.MarkSystemOutboundMessage(bus.OutboundMessage{
 						Channel: msg.Channel,
 						ChatID:  msg.ChatID,
 						Content: dec.ErrMsg,
-					})
+					}))
 					continue
 				}
 
@@ -258,11 +258,11 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 						})
 					if result.Outcome == commands.OutcomeHandled {
 						if reply != "" {
-							_ = messageBus.PublishOutbound(ctx, bus.OutboundMessage{
+							_ = messageBus.PublishOutbound(ctx, bus.MarkSystemOutboundMessage(bus.OutboundMessage{
 								Channel: msg.Channel,
 								ChatID:  msg.ChatID,
 								Content: reply,
-							})
+							}))
 						}
 						continue
 					}

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -3,6 +3,7 @@ package bus
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 )
@@ -17,6 +18,8 @@ var (
 )
 
 const defaultBusBufferSize = 64
+
+const systemContentPrefix = "[system] "
 
 // StreamDelegate is implemented by the channel Manager to provide streaming
 // capabilities without tight coupling.
@@ -97,6 +100,9 @@ func (mb *MessageBus) PublishOutbound(ctx context.Context, msg OutboundMessage) 
 	msg = NormalizeOutboundMessage(msg)
 	if msg.Context.isZero() {
 		return ErrMissingOutboundContext
+	}
+	if IsSystemOutboundMessage(msg) && !strings.HasPrefix(strings.TrimSpace(msg.Content), systemContentPrefix) {
+		msg.Content = systemContentPrefix + msg.Content
 	}
 	return publish(ctx, mb, mb.outbound, msg)
 }

--- a/pkg/bus/bus_test.go
+++ b/pkg/bus/bus_test.go
@@ -59,6 +59,31 @@ func TestPublishReceiveOutbound(t *testing.T) {
 	}
 }
 
+func TestPublishReceiveOutboundSystem(t *testing.T) {
+	mb := bus.NewMessageBus()
+	defer mb.Close()
+
+	ctx := context.Background()
+	msg := bus.MarkSystemOutboundMessage(bus.OutboundMessage{
+		Channel: "telegram",
+		ChatID:  "123",
+		Content: "reply",
+		Context: bus.NewOutboundContext("telegram", "123", ""),
+	})
+
+	err := mb.PublishOutbound(ctx, msg)
+	require.NoError(t, err)
+
+	select {
+	case got := <-mb.OutboundChan():
+		assert.Equal(t, "telegram", got.Channel)
+		assert.Equal(t, "[system] reply", got.Content)
+		assert.Equal(t, bus.MessageKindSystem, got.Context.Raw["message_kind"])
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for system outbound message")
+	}
+}
+
 func TestCloseDropsPublish(t *testing.T) {
 	mb := bus.NewMessageBus()
 	mb.Close()

--- a/pkg/bus/context.go
+++ b/pkg/bus/context.go
@@ -2,6 +2,11 @@ package bus
 
 import "strings"
 
+const (
+	// MessageKindSystem marks outbound messages that did not come from the LLM.
+	MessageKindSystem = "system"
+)
+
 func (ctx InboundContext) isZero() bool {
 	return ctx.Channel == "" &&
 		ctx.Account == "" &&
@@ -84,6 +89,35 @@ func NormalizeOutboundMessage(msg OutboundMessage) OutboundMessage {
 	}
 	msg.Scope = cloneOutboundScope(msg.Scope)
 	return msg
+}
+
+// MarkSystemOutboundMessage annotates an outbound message as non-LLM/system-generated.
+// The visible "[system]" prefix is applied when the message is published to the bus.
+func MarkSystemOutboundMessage(msg OutboundMessage) OutboundMessage {
+	msg = NormalizeOutboundMessage(msg)
+	if msg.Context.Raw == nil {
+		msg.Context.Raw = make(map[string]string, 1)
+	}
+	msg.Context.Raw["message_kind"] = MessageKindSystem
+	return msg
+}
+
+// NewSystemOutboundMessage builds a minimal system-tagged outbound message.
+func NewSystemOutboundMessage(channel, chatID, content string) OutboundMessage {
+	return MarkSystemOutboundMessage(OutboundMessage{
+		Channel: channel,
+		ChatID:  chatID,
+		Context: NewOutboundContext(channel, chatID, ""),
+		Content: content,
+	})
+}
+
+// IsSystemOutboundMessage reports whether an outbound message is marked as system-generated.
+func IsSystemOutboundMessage(msg OutboundMessage) bool {
+	if len(msg.Context.Raw) == 0 {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(msg.Context.Raw["message_kind"]), MessageKindSystem)
 }
 
 // NormalizeOutboundMediaMessage normalizes media outbound messages.

--- a/pkg/cron/scheduler.go
+++ b/pkg/cron/scheduler.go
@@ -295,6 +295,7 @@ func (s *Scheduler) deliverMessage(ctx context.Context, job Job) {
 		Context: bus.NewOutboundContext(job.Channel, job.ChatID, ""),
 		Content: job.Message,
 	}
+	msg = bus.MarkSystemOutboundMessage(msg)
 	if err := s.bus.PublishOutbound(ctx, msg); err != nil {
 		logger.ErrorCF("cron", "Failed to publish outbound cron job", map[string]any{
 			"job":   job.Name,
@@ -332,6 +333,7 @@ func (s *Scheduler) executeCommandJob(ctx context.Context, job Job) {
 		Context: bus.NewOutboundContext(job.Channel, job.ChatID, ""),
 		Content: content,
 	}
+	msg = bus.MarkSystemOutboundMessage(msg)
 	if err := s.bus.PublishOutbound(ctx, msg); err != nil {
 		logger.ErrorCF("cron", "Failed to publish command job output", map[string]any{
 			"job":   job.Name,

--- a/pkg/tools/message/message_tool.go
+++ b/pkg/tools/message/message_tool.go
@@ -95,6 +95,7 @@ func (t *Tool) Execute(ctx context.Context, args string) (string, error) {
 		Context: bus.NewOutboundContext(channel, chatID, ""),
 		Content: req.Content,
 	}
+	msg = bus.MarkSystemOutboundMessage(msg)
 
 	if err := t.bus.PublishOutbound(ctx, msg); err != nil {
 		return "", fmt.Errorf("message_tool: failed to send message: %w", err)

--- a/pkg/tools/message/message_tool_test.go
+++ b/pkg/tools/message/message_tool_test.go
@@ -49,8 +49,11 @@ func TestMessageTool_Success(t *testing.T) {
 		if msg.ChatID != "chat123" {
 			t.Errorf("expected chatID chat123, got %s", msg.ChatID)
 		}
-		if msg.Content != "Hello update" {
-			t.Errorf("expected content 'Hello update', got %s", msg.Content)
+		if msg.Context.Raw["message_kind"] != bus.MessageKindSystem {
+			t.Errorf("expected system message kind, got %q", msg.Context.Raw["message_kind"])
+		}
+		if msg.Content != "[system] Hello update" {
+			t.Errorf("expected system-prefixed content, got %s", msg.Content)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for outbound message")
@@ -127,7 +130,10 @@ func TestMessageTool_Throttling(t *testing.T) {
 
 	select {
 	case msg := <-b.OutboundChan():
-		if msg.Content != "Third" {
+		if msg.Context.Raw["message_kind"] != bus.MessageKindSystem {
+			t.Errorf("expected system message kind, got %q", msg.Context.Raw["message_kind"])
+		}
+		if msg.Content != "[system] Third" {
 			t.Errorf("expected 'Third', got %s", msg.Content)
 		}
 	case <-time.After(time.Second):


### PR DESCRIPTION
## Summary\n- Add a first-class system tag for outbound messages that do not come from the LLM.\n- Apply the tag at the bus boundary so downstream channels can distinguish system-originated replies from assistant output.\n- Tag gateway/chat command replies, debug updates, cron notices, message tool updates, and session fallback/error messages.\n\nCloses #139\n\n## Test Plan\n- go test ./...\n- git diff --check\n\n## Notes\n- The visible `[system]` prefix is applied on bus publish for tagged outbound messages.\n