### PR TITLE
feat: support MCP HTTP transport mode config

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ Connect the agent to [Model Context Protocol (MCP)](https://modelcontextprotocol
         "command": "npx",
         "args": ["-y", "@modelcontextprotocol/server-github"],
         "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": "env://GITHUB_TOKEN" }
+      },
+      "browserbase": {
+        "url": "https://mcp.browserbase.com/mcp",
+        "token": "env://BROWSERBASE_API_KEY",
+        "httpTransportMode": "streamable"
       }
     }
   }

--- a/config.example.json
+++ b/config.example.json
@@ -165,6 +165,11 @@
       "filesystem": {
         "command": "npx",
         "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/workspace"]
+      },
+      "browserbase": {
+        "url": "https://mcp.browserbase.com/mcp",
+        "token": "env://BROWSERBASE_API_KEY",
+        "httpTransportMode": "streamable"
       }
     }
   }

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -74,6 +74,7 @@ Remote MCP servers exposed over HTTP.
 {
   "url": "http://localhost:3000/mcp",
   "token": "env://MCP_REMOTE_TOKEN",
+  "httpTransportMode": "streamable",
   "allowedTools": ["query_database"]
 }
 ```
@@ -82,7 +83,10 @@ Remote MCP servers exposed over HTTP.
 |-------|------|-------------|
 | `url` | string | HTTP(S) endpoint of the MCP server |
 | `token` | string | Bearer token for authentication |
+| `httpTransportMode` | string | *(Optional)* HTTP MCP transport mode: `sse` or `streamable` |
 | `allowedTools` | string[] | *(Optional)* Whitelist tools from this server |
+
+If `httpTransportMode` is omitted, the underlying SDK keeps its current default behavior. Use `"streamable"` for hosted MCP endpoints that require Streamable HTTP.
 
 ## Environment Variables
 
@@ -132,6 +136,7 @@ See [`examples/config/mcp.json`](../examples/config/mcp.json) for a complete exa
 **Tools from MCP server are not available**
 - Ensure the server process starts successfully (stdio servers).
 - Verify the HTTP endpoint is reachable.
+- For hosted HTTP MCP endpoints, verify `httpTransportMode` matches the server expectation (`streamable` vs `sse`).
 - Check `allowedTools` is not accidentally filtering out the tool you need.
 
 **Secrets exposed in logs**

--- a/examples/config/mcp.json
+++ b/examples/config/mcp.json
@@ -13,7 +13,8 @@
     },
     "remote": {
       "url": "http://localhost:3000/mcp",
-      "token": "env://MCP_REMOTE_TOKEN"
+      "token": "env://MCP_REMOTE_TOKEN",
+      "httpTransportMode": "streamable"
     }
   }
 }

--- a/internal/agent/mcp_config_test.go
+++ b/internal/agent/mcp_config_test.go
@@ -25,9 +25,10 @@ func TestToAgentSDKMCPConfig(t *testing.T) {
 					AllowedTools: []string{"read_file"},
 				},
 				"http-server": {
-					URL:          "http://localhost:3000/mcp",
-					Token:        config.NewSecureString("bearer-token"),
-					AllowedTools: []string{"query"},
+					URL:               "http://localhost:3000/mcp",
+					Token:             config.NewSecureString("bearer-token"),
+					HttpTransportMode: "streamable",
+					AllowedTools:      []string{"query"},
 				},
 			},
 		}
@@ -48,6 +49,7 @@ func TestToAgentSDKMCPConfig(t *testing.T) {
 		assert.Equal(t, "", http.Command)
 		assert.Equal(t, "http://localhost:3000/mcp", http.URL)
 		assert.Equal(t, "bearer-token", http.Token)
+		assert.Equal(t, "streamable", http.HttpTransportMode)
 		assert.Equal(t, []string{"query"}, http.AllowedTools)
 	})
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -152,12 +152,13 @@ func toAgentSDKMCPConfig(cfg config.MCPConfig) *agentsdk.MCPConfiguration {
 			token = s.Token.String()
 		}
 		servers[name] = agentsdk.MCPServerConfig{
-			Command:      s.Command,
-			Args:         s.Args,
-			Env:          s.Env,
-			URL:          s.URL,
-			Token:        token,
-			AllowedTools: s.AllowedTools,
+			Command:           s.Command,
+			Args:              s.Args,
+			Env:               s.Env,
+			URL:               s.URL,
+			Token:             token,
+			HttpTransportMode: s.HttpTransportMode,
+			AllowedTools:      s.AllowedTools,
 		}
 	}
 	return &agentsdk.MCPConfiguration{

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -266,8 +266,9 @@ func TestBuildAgent_WithMCPConfig(t *testing.T) {
 					Args:    []string{"-y", "@modelcontextprotocol/server-filesystem", "/tmp"},
 				},
 				"remote": {
-					URL:   "http://localhost:3000/mcp",
-					Token: config.NewSecureString("secret-token"),
+					URL:               "http://localhost:3000/mcp",
+					Token:             config.NewSecureString("secret-token"),
+					HttpTransportMode: "streamable",
 				},
 			},
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,12 +40,13 @@ type MCPConfig struct {
 
 // MCPServerConfig represents a single MCP server configuration.
 type MCPServerConfig struct {
-	Command      string            `json:"command,omitempty"`
-	Args         []string          `json:"args,omitempty"`
-	Env          map[string]string `json:"env,omitempty"`
-	URL          string            `json:"url,omitempty"`
-	Token        *SecureString     `json:"token,omitzero"`
-	AllowedTools []string          `json:"allowedTools,omitempty"`
+	Command           string            `json:"command,omitempty"`
+	Args              []string          `json:"args,omitempty"`
+	Env               map[string]string `json:"env,omitempty"`
+	URL               string            `json:"url,omitempty"`
+	Token             *SecureString     `json:"token,omitzero"`
+	HttpTransportMode string            `json:"httpTransportMode,omitempty"`
+	AllowedTools      []string          `json:"allowedTools,omitempty"`
 }
 
 type AgentsConfig struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -83,7 +83,8 @@ func TestMCPConfigTokenEnvResolve(t *testing.T) {
 			"mcpServers": {
 				"remote": {
 					"url": "http://localhost:3000/mcp",
-					"token": "env://MCP_TEST_TOKEN"
+					"token": "env://MCP_TEST_TOKEN",
+					"httpTransportMode": "streamable"
 				}
 			}
 		}
@@ -96,6 +97,7 @@ func TestMCPConfigTokenEnvResolve(t *testing.T) {
 	remote := cfg.MCP.MCPServers["remote"]
 	require.NotNil(t, remote.Token)
 	assert.Equal(t, "resolved-token", remote.Token.String())
+	assert.Equal(t, "streamable", remote.HttpTransportMode)
 }
 
 func TestWebSearchConfigParsing(t *testing.T) {


### PR DESCRIPTION
## Summary
- add  to sushiclaw MCP server config
- pass the field through to  for HTTP MCP servers
- document  usage in the MCP docs and example configs

## Test plan
- go test ./...
ok  	github.com/sushi30/sushiclaw	(cached)
ok  	github.com/sushi30/sushiclaw/internal/agent	(cached)
ok  	github.com/sushi30/sushiclaw/internal/chat	(cached)
ok  	github.com/sushi30/sushiclaw/internal/commandfilter	(cached)
ok  	github.com/sushi30/sushiclaw/internal/envresolve	(cached)
ok  	github.com/sushi30/sushiclaw/internal/gateway	(cached)
?   	github.com/sushi30/sushiclaw/internal/version	[no test files]
ok  	github.com/sushi30/sushiclaw/pkg/audio/asr	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/bus	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/channels	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/channels/email	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/channels/telegram	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/channels/websocket	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/channels/whatsapp_native	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/commands	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/config	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/cron	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/identity	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/llm/openrouter	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/logger	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/media	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/steering	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/tools	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/tools/exec	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/tools/fs	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/tools/message	(cached)
?   	github.com/sushi30/sushiclaw/pkg/tools/toolctx	[no test files]
?   	github.com/sushi30/sushiclaw/pkg/tools/vision	[no test files]
ok  	github.com/sushi30/sushiclaw/pkg/tools/websearch	(cached)
ok  	github.com/sushi30/sushiclaw/pkg/utils	(cached)
- golangci-lint run ./...
0 issues.

Closes #155