### PR TITLE
feat: auto summarize long sessions

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -33,6 +33,8 @@ type SessionManager struct {
 	bus             *bus.MessageBus
 	tools           []interfaces.Tool
 	progress        ProgressSink
+	agentFactory    func(mem interfaces.Memory) (agentRunner, error)
+	summaryFactory  func() (agentRunner, error)
 	mediaStore      media.MediaStore
 	transcriber     asr.Transcriber
 	sessions        map[string]*Session
@@ -50,6 +52,8 @@ type Session struct {
 	activeTurnCancel context.CancelFunc
 	activeTurnDone   chan struct{}
 	activeTurnSeq    uint64
+	stableKey        string
+	backingKey       string
 	lastUsed         time.Time
 	mu               sync.RWMutex
 	mgr              *SessionManager
@@ -143,6 +147,10 @@ func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem inter
 	return a, nil
 }
 
+func buildSummaryAgent(cfg *config.Config) (agentRunner, error) {
+	return buildAgentWithMemory(cfg, nil, NewInMemoryMemory())
+}
+
 // toAgentSDKMCPConfig converts sushiclaw MCPConfig to agent-sdk-go MCPConfiguration.
 func toAgentSDKMCPConfig(cfg config.MCPConfig) *agentsdk.MCPConfiguration {
 	if len(cfg.MCPServers) == 0 {
@@ -179,6 +187,8 @@ func NewSessionManager(cfg *config.Config, messageBus *bus.MessageBus, tools []i
 		cfg:             cfg,
 		bus:             messageBus,
 		tools:           tools,
+		agentFactory:    func(mem interfaces.Memory) (agentRunner, error) { return buildAgentWithMemory(cfg, tools, mem) },
+		summaryFactory:  func() (agentRunner, error) { return buildSummaryAgent(cfg) },
 		mediaStore:      store,
 		sessions:        make(map[string]*Session),
 		ttl:             30 * 24 * time.Hour,
@@ -269,7 +279,23 @@ func (sm *SessionManager) getOrCreateSession(key string) (*Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	a, err := buildAgentWithMemory(sm.cfg, sm.tools, mem)
+	activeKey, err := resolveActiveSessionKey(context.Background(), mem.db, key)
+	if err != nil {
+		closeSessionMemory(mem)
+		return nil, err
+	}
+	if activeKey != key {
+		closeSessionMemory(mem)
+		mem, err = NewSQLiteSessionMemory(context.Background(), sessionDBPath(sm.cfg), activeKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err := ensureSessionLineage(context.Background(), mem.db, key, activeKey); err != nil {
+		closeSessionMemory(mem)
+		return nil, err
+	}
+	a, err := sm.buildSessionAgent(mem)
 	if err != nil {
 		closeSessionMemory(mem)
 		return nil, err
@@ -279,6 +305,8 @@ func (sm *SessionManager) getOrCreateSession(key string) (*Session, error) {
 		agent:           a,
 		mem:             mem,
 		activatedSkills: make(map[string]bool),
+		stableKey:       key,
+		backingKey:      activeKey,
 		lastUsed:        time.Now(),
 		mgr:             sm,
 	}
@@ -292,7 +320,24 @@ func (sm *SessionManager) ClearHistory(sessionKey string) error {
 	defer sm.mu.Unlock()
 	if s, ok := sm.sessions[sessionKey]; ok {
 		s.stopTurn()
-		if err := s.mem.Clear(context.Background()); err != nil {
+		mem, ok := s.mem.(*SQLiteSessionMemory)
+		if !ok {
+			if err := s.mem.Clear(context.Background()); err != nil {
+				return err
+			}
+			delete(sm.sessions, sessionKey)
+			return nil
+		}
+		lineageKeys, err := listSessionLineageKeys(context.Background(), mem.db, sessionKey)
+		if err != nil {
+			return err
+		}
+		for _, backingKey := range lineageKeys {
+			if err := clearSQLiteSession(context.Background(), mem.db, backingKey); err != nil {
+				return err
+			}
+		}
+		if err := clearSessionLineage(context.Background(), mem.db, sessionKey); err != nil {
 			return err
 		}
 		closeSessionMemory(s.mem)
@@ -304,7 +349,16 @@ func (sm *SessionManager) ClearHistory(sessionKey string) error {
 		return err
 	}
 	defer closeSessionMemory(mem)
-	return mem.Clear(context.Background())
+	lineageKeys, err := listSessionLineageKeys(context.Background(), mem.db, sessionKey)
+	if err != nil {
+		return err
+	}
+	for _, backingKey := range lineageKeys {
+		if err := clearSQLiteSession(context.Background(), mem.db, backingKey); err != nil {
+			return err
+		}
+	}
+	return clearSessionLineage(context.Background(), mem.db, sessionKey)
 }
 
 func sessionDBPath(cfg *config.Config) string {
@@ -540,6 +594,11 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 	s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressTurnStarted})
 
 	response, usage, toolCalls, err := s.runDetailedTurn(actx, input)
+	if err != nil && isContextOverflowError(err) {
+		response, err = s.handoffToSummarySession(actx, msg.Channel, chatID, input)
+		usage = nil
+		toolCalls = 0
+	}
 	elapsed := time.Since(start)
 	responseBytes := len(response)
 	if err != nil {
@@ -666,6 +725,13 @@ func (s *Session) turnCanceled(ctx context.Context, turnSeq uint64, err error) b
 
 func isExpectedCancellation(err error) bool {
 	return errors.Is(err, context.Canceled)
+}
+
+func (sm *SessionManager) buildSessionAgent(mem interfaces.Memory) (agentRunner, error) {
+	if sm.agentFactory != nil {
+		return sm.agentFactory(mem)
+	}
+	return buildAgentWithMemory(sm.cfg, sm.tools, mem)
 }
 
 func (s *Session) runStreamingTurn(
@@ -914,6 +980,123 @@ func firstInt(m map[string]interface{}, keys ...string) (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+func (s *Session) handoffToSummarySession(ctx context.Context, channel, chatID, input string) (string, error) {
+	messages, err := s.mem.GetMessages(ctx)
+	if err != nil {
+		return "", fmt.Errorf("load session history: %w", err)
+	}
+
+	summary, err := s.generateSummary(ctx, buildSummaryInput(messages))
+	if err != nil {
+		return "", err
+	}
+
+	if s.mgr.bus != nil {
+		_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
+			Channel:    channel,
+			ChatID:     chatID,
+			SessionKey: s.stableKey,
+			Content:    "Summarizing the conversation to keep going...",
+		})
+	}
+
+	newBackingKey := nextSummarySessionKey(s.stableKey)
+	newMem, err := NewSQLiteSessionMemory(ctx, sessionDBPath(s.mgr.cfg), newBackingKey)
+	if err != nil {
+		return "", fmt.Errorf("create summary session: %w", err)
+	}
+	if err := newMem.AddMessage(ctx, interfaces.Message{
+		Role:    interfaces.MessageRoleAssistant,
+		Content: "Conversation summary:\n" + summary,
+	}); err != nil {
+		closeSessionMemory(newMem)
+		return "", fmt.Errorf("seed summary session: %w", err)
+	}
+
+	newAgent, err := s.mgr.buildSessionAgent(newMem)
+	if err != nil {
+		closeSessionMemory(newMem)
+		return "", fmt.Errorf("build summary session agent: %w", err)
+	}
+	if err := setActiveSessionKey(ctx, newMem.db, s.stableKey, newBackingKey); err != nil {
+		closeSessionMemory(newMem)
+		return "", err
+	}
+
+	oldMem := s.mem
+	s.mu.Lock()
+	s.mem = newMem
+	s.agent = newAgent
+	s.backingKey = newBackingKey
+	s.activatedSkills = make(map[string]bool)
+	s.mu.Unlock()
+	closeSessionMemory(oldMem)
+
+	response, err := newAgent.Run(ctx, input)
+	if err != nil {
+		return "", err
+	}
+	return response, nil
+}
+
+func (s *Session) generateSummary(ctx context.Context, transcript string) (string, error) {
+	factory := s.mgr.summaryFactory
+	if factory == nil {
+		factory = func() (agentRunner, error) { return buildSummaryAgent(s.mgr.cfg) }
+	}
+	summarizer, err := factory()
+	if err != nil {
+		return "", fmt.Errorf("build summary agent: %w", err)
+	}
+
+	prompt := "Summarize this prior conversation for future turns.\n" +
+		"Preserve user goals, decisions, constraints, facts, unfinished work, and explicit preferences.\n" +
+		"Do not preserve temporary skill instructions.\n" +
+		"Keep it concise and structured.\n\nConversation:\n" + transcript
+
+	summary, err := summarizer.Run(ctx, prompt)
+	if err != nil {
+		return "", fmt.Errorf("generate summary: %w", err)
+	}
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		return "", errors.New("generate summary: empty response")
+	}
+	return summary, nil
+}
+
+func buildSummaryInput(messages []interfaces.Message) string {
+	var sb strings.Builder
+	for _, msg := range messages {
+		if msg.Role == interfaces.MessageRoleSystem {
+			continue
+		}
+		content := strings.TrimSpace(msg.Content)
+		if content == "" {
+			continue
+		}
+		sb.WriteString(string(msg.Role))
+		sb.WriteString(": ")
+		sb.WriteString(content)
+		sb.WriteString("\n\n")
+	}
+	return strings.TrimSpace(sb.String())
+}
+
+func isContextOverflowError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "maximum context length") ||
+		strings.Contains(msg, "context length exceeded") ||
+		strings.Contains(msg, "reduce the length")
+}
+
+func nextSummarySessionKey(stableKey string) string {
+	return fmt.Sprintf("%s#summary-%d", stableKey, time.Now().UnixNano())
 }
 
 // transcribeAudioInMessage resolves audio media refs, transcribes them, and

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -148,7 +148,11 @@ func buildAgentWithMemory(cfg *config.Config, tools []interfaces.Tool, mem inter
 }
 
 func buildSummaryAgent(cfg *config.Config) (agentRunner, error) {
-	return buildAgentWithMemory(cfg, nil, NewInMemoryMemory())
+	summaryCfg := *cfg
+	if summaryCfg.Agents.Defaults.Summary.Model != "" {
+		summaryCfg.Agents.Defaults.ModelName = summaryCfg.Agents.Defaults.Summary.Model
+	}
+	return buildAgentWithMemory(&summaryCfg, nil, NewInMemoryMemory())
 }
 
 // toAgentSDKMCPConfig converts sushiclaw MCPConfig to agent-sdk-go MCPConfiguration.
@@ -593,8 +597,31 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 	start := time.Now()
 	s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressTurnStarted})
 
+	if s.shouldSummarizeBeforeTurn(input) {
+		response, err := s.handoffToSummarySession(actx, msg.Channel, chatID, input)
+		if err == nil {
+			if response != "" && s.mgr.bus != nil {
+				_ = s.mgr.bus.PublishOutbound(ctx, bus.OutboundMessage{
+					Channel:    msg.Channel,
+					ChatID:     chatID,
+					SessionKey: sessionKey,
+					Content:    response,
+				})
+			}
+			s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressCompleted, Elapsed: time.Since(start)})
+			s.mgr.emitSummary(ctx, ProgressSummary{
+				Channel:       msg.Channel,
+				ChatID:        chatID,
+				Success:       true,
+				Duration:      time.Since(start),
+				ResponseBytes: len(response),
+			})
+			return
+		}
+	}
+
 	response, usage, toolCalls, err := s.runDetailedTurn(actx, input)
-	if err != nil && isContextOverflowError(err) {
+	if err != nil && s.mgr != nil && s.mgr.cfg != nil && s.mgr.cfg.Agents.Defaults.Summary.Enabled && isContextOverflowError(err) {
 		response, err = s.handoffToSummarySession(actx, msg.Channel, chatID, input)
 		usage = nil
 		toolCalls = 0
@@ -982,7 +1009,21 @@ func firstInt(m map[string]interface{}, keys ...string) (int, bool) {
 	return 0, false
 }
 
+func (s *Session) shouldSummarizeBeforeTurn(input string) bool {
+	if s == nil || s.mgr == nil || s.mgr.cfg == nil {
+		return false
+	}
+	summaryCfg := s.mgr.cfg.Agents.Defaults.Summary
+	if !summaryCfg.Enabled || summaryCfg.TokenTrigger <= 0 {
+		return false
+	}
+	return approximateTokenCount(input)+approximateSessionTokens(s) >= summaryCfg.TokenTrigger
+}
+
 func (s *Session) handoffToSummarySession(ctx context.Context, channel, chatID, input string) (string, error) {
+	if s == nil || s.mgr == nil || s.mgr.cfg == nil || !s.mgr.cfg.Agents.Defaults.Summary.Enabled {
+		return "", errors.New("session summarization is disabled")
+	}
 	messages, err := s.mem.GetMessages(ctx)
 	if err != nil {
 		return "", fmt.Errorf("load session history: %w", err)
@@ -1042,6 +1083,17 @@ func (s *Session) handoffToSummarySession(ctx context.Context, channel, chatID, 
 }
 
 func (s *Session) generateSummary(ctx context.Context, transcript string) (string, error) {
+	return s.generateSummaryWithDepth(ctx, transcript, 0)
+}
+
+func (s *Session) generateSummaryWithDepth(ctx context.Context, transcript string, depth int) (string, error) {
+	if strings.TrimSpace(transcript) == "" {
+		return "", errors.New("generate summary: empty transcript")
+	}
+	if depth > 4 {
+		return "", errors.New("generate summary: exceeded chunking depth")
+	}
+
 	factory := s.mgr.summaryFactory
 	if factory == nil {
 		factory = func() (agentRunner, error) { return buildSummaryAgent(s.mgr.cfg) }
@@ -1051,13 +1103,13 @@ func (s *Session) generateSummary(ctx context.Context, transcript string) (strin
 		return "", fmt.Errorf("build summary agent: %w", err)
 	}
 
-	prompt := "Summarize this prior conversation for future turns.\n" +
-		"Preserve user goals, decisions, constraints, facts, unfinished work, and explicit preferences.\n" +
-		"Do not preserve temporary skill instructions.\n" +
-		"Keep it concise and structured.\n\nConversation:\n" + transcript
+	prompt := structuredSummaryPrompt(transcript)
 
 	summary, err := summarizer.Run(ctx, prompt)
 	if err != nil {
+		if isContextOverflowError(err) {
+			return s.chunkedSummary(ctx, transcript, depth+1)
+		}
 		return "", fmt.Errorf("generate summary: %w", err)
 	}
 	summary = strings.TrimSpace(summary)
@@ -1065,6 +1117,24 @@ func (s *Session) generateSummary(ctx context.Context, transcript string) (strin
 		return "", errors.New("generate summary: empty response")
 	}
 	return summary, nil
+}
+
+func (s *Session) chunkedSummary(ctx context.Context, transcript string, depth int) (string, error) {
+	chunks := splitTranscriptForSummary(transcript)
+	if len(chunks) <= 1 {
+		return "", errors.New("generate summary: transcript still too large after chunking")
+	}
+
+	partials := make([]string, 0, len(chunks))
+	for i, chunk := range chunks {
+		partial, err := s.generateSummaryWithDepth(ctx, chunk, depth)
+		if err != nil {
+			return "", err
+		}
+		partials = append(partials, fmt.Sprintf("Chunk %d summary:\n%s", i+1, partial))
+	}
+
+	return s.generateSummaryWithDepth(ctx, strings.Join(partials, "\n\n"), depth)
 }
 
 func buildSummaryInput(messages []interfaces.Message) string {
@@ -1085,6 +1155,17 @@ func buildSummaryInput(messages []interfaces.Message) string {
 	return strings.TrimSpace(sb.String())
 }
 
+func structuredSummaryPrompt(transcript string) string {
+	return "Summarize this prior conversation for future turns.\n" +
+		"Return a compact structured summary with exactly these markdown headings:\n" +
+		"## Goals\n## Key Facts\n## Decisions\n## Preferences\n## Open Threads\n## Resources\n" +
+		"Rules:\n" +
+		"- Preserve user goals, decisions, constraints, explicit preferences, and unresolved tasks.\n" +
+		"- Do not preserve temporary skill instructions or internal orchestration details.\n" +
+		"- Keep each section concise and omit empty bullets when there is nothing to report.\n\n" +
+		"Conversation:\n" + transcript
+}
+
 func isContextOverflowError(err error) bool {
 	if err == nil {
 		return false
@@ -1097,6 +1178,53 @@ func isContextOverflowError(err error) bool {
 
 func nextSummarySessionKey(stableKey string) string {
 	return fmt.Sprintf("%s#summary-%d", stableKey, time.Now().UnixNano())
+}
+
+func approximateSessionTokens(s *Session) int {
+	msgs, err := s.mem.GetMessages(context.Background())
+	if err != nil {
+		return 0
+	}
+	total := 0
+	for _, msg := range msgs {
+		total += approximateTokenCount(msg.Content)
+	}
+	return total
+}
+
+func approximateTokenCount(text string) int {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return 0
+	}
+	return max(1, len([]rune(text))/4)
+}
+
+func splitTranscriptForSummary(transcript string) []string {
+	parts := strings.Split(transcript, "\n\n")
+	if len(parts) <= 1 {
+		runes := []rune(transcript)
+		if len(runes) < 2 {
+			return []string{transcript}
+		}
+		mid := len(runes) / 2
+		return []string{string(runes[:mid]), string(runes[mid:])}
+	}
+
+	mid := len(parts) / 2
+	left := strings.TrimSpace(strings.Join(parts[:mid], "\n\n"))
+	right := strings.TrimSpace(strings.Join(parts[mid:], "\n\n"))
+	var chunks []string
+	if left != "" {
+		chunks = append(chunks, left)
+	}
+	if right != "" {
+		chunks = append(chunks, right)
+	}
+	if len(chunks) == 0 {
+		return []string{transcript}
+	}
+	return chunks
 }
 
 // transcribeAudioInMessage resolves audio media refs, transcribes them, and

--- a/internal/agent/session_debug_test.go
+++ b/internal/agent/session_debug_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -25,9 +26,13 @@ type mockRunner struct {
 	detailedErr error
 	runResult   string
 	runErr      error
+	runFunc     func(string) (string, error)
 }
 
-func (m *mockRunner) Run(context.Context, string) (string, error) {
+func (m *mockRunner) Run(_ context.Context, input string) (string, error) {
+	if m.runFunc != nil {
+		return m.runFunc(input)
+	}
 	if m.runErr != nil {
 		return "", m.runErr
 	}
@@ -487,10 +492,21 @@ func TestSessionManagerContextOverflowCreatesNewSummarySession(t *testing.T) {
 	ctx := t.Context()
 	extBus := bus.NewMessageBus()
 	cfg := &config.Config{
-		Agents: config.AgentsConfig{Defaults: config.AgentDefaults{ModelName: "test-model"}},
+		Agents: config.AgentsConfig{Defaults: config.AgentDefaults{
+			ModelName: "test-model",
+			Summary: config.SummaryConfig{
+				Enabled:      true,
+				TokenTrigger: 1024,
+				Model:        "summary-model",
+			},
+		}},
 		ModelList: []config.ModelConfig{{
 			ModelName: "test-model",
 			Model:     "gpt-4o",
+			APIKey:    config.NewSecureString("test-key"),
+		}, {
+			ModelName: "summary-model",
+			Model:     "gpt-4o-mini",
 			APIKey:    config.NewSecureString("test-key"),
 		}},
 		Sessions: config.SessionsConfig{Directory: t.TempDir()},
@@ -556,6 +572,60 @@ func TestSessionManagerContextOverflowCreatesNewSummarySession(t *testing.T) {
 	assert.Equal(t, interfaces.MessageRoleAssistant, msgs[0].Role)
 	assert.Contains(t, msgs[0].Content, "Compact summary")
 	assert.Empty(t, session.activatedSkills)
+}
+
+func TestSessionManagerOverflowDoesNotSummarizeWhenDisabled(t *testing.T) {
+	overflowErr := errors.New("maximum context length exceeded")
+	extBus := bus.NewMessageBus()
+	sm := &SessionManager{bus: extBus, cfg: &config.Config{}, progress: &collectingProgress{}}
+	session := &Session{agent: &mockRunner{runErr: overflowErr}, mgr: sm, stableKey: "telegram:chat1"}
+
+	turnCtx, turnSeq, turnDone := session.startTurn(t.Context())
+	session.handleInbound(turnCtx, inbound("telegram", "chat1", "bad"), "telegram:chat1", turnSeq, turnDone)
+
+	msg := requireOutboundMessage(t, extBus)
+	assert.Contains(t, msg.Content, "Error: maximum context length exceeded")
+	assertNoOutboundMessage(t, extBus)
+}
+
+func TestGenerateSummaryFallsBackToChunkedReduction(t *testing.T) {
+	ctx := t.Context()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{Defaults: config.AgentDefaults{
+			ModelName: "test-model",
+			Summary:   config.SummaryConfig{Enabled: true, Model: "summary-model"},
+		}},
+		ModelList: []config.ModelConfig{{
+			ModelName: "test-model",
+			Model:     "gpt-4o",
+			APIKey:    config.NewSecureString("test-key"),
+		}, {
+			ModelName: "summary-model",
+			Model:     "gpt-4o-mini",
+			APIKey:    config.NewSecureString("test-key"),
+		}},
+	}
+
+	sm := &SessionManager{
+		cfg: cfg,
+		summaryFactory: func() (agentRunner, error) {
+			return &mockRunner{runFunc: func(input string) (string, error) {
+				if strings.Contains(input, "Conversation:\nuser: one") && strings.Contains(input, "assistant: two") {
+					return "", errors.New("maximum context length exceeded")
+				}
+				if strings.Contains(input, "Chunk 1 summary:") {
+					return "## Goals\n- combined\n## Key Facts\n- merged\n## Decisions\n- none\n## Preferences\n- none\n## Open Threads\n- follow up\n## Resources\n- none", nil
+				}
+				return "## Goals\n- part\n## Key Facts\n- item\n## Decisions\n- none\n## Preferences\n- none\n## Open Threads\n- none\n## Resources\n- none", nil
+			}}, nil
+		},
+	}
+	session := &Session{mgr: sm}
+
+	summary, err := session.generateSummary(ctx, "user: one\n\nassistant: two")
+	require.NoError(t, err)
+	assert.Contains(t, summary, "## Goals")
+	assert.Contains(t, summary, "combined")
 }
 
 func streamEvents(events ...interfaces.AgentStreamEvent) <-chan interfaces.AgentStreamEvent {

--- a/internal/agent/session_debug_test.go
+++ b/internal/agent/session_debug_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/logger"
 )
 
@@ -480,6 +481,81 @@ func (s *scriptedRunner) RunStream(ctx context.Context, input string) (<-chan in
 		return nil, errors.New("RunStream should not be called")
 	}
 	return s.runStream(ctx, input)
+}
+
+func TestSessionManagerContextOverflowCreatesNewSummarySession(t *testing.T) {
+	ctx := t.Context()
+	extBus := bus.NewMessageBus()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{Defaults: config.AgentDefaults{ModelName: "test-model"}},
+		ModelList: []config.ModelConfig{{
+			ModelName: "test-model",
+			Model:     "gpt-4o",
+			APIKey:    config.NewSecureString("test-key"),
+		}},
+		Sessions: config.SessionsConfig{Directory: t.TempDir()},
+	}
+
+	seed, err := NewSQLiteSessionMemory(ctx, filepath.Join(cfg.Sessions.Directory, "sessions.db"), "telegram:chat1")
+	require.NoError(t, err)
+	require.NoError(t, seed.AddMessage(ctx, interfaces.Message{Role: interfaces.MessageRoleUser, Content: "remember this"}))
+	require.NoError(t, seed.Close())
+
+	overflowErr := errors.New("maximum context length exceeded")
+	factoryCalls := 0
+	sm := &SessionManager{
+		cfg:      cfg,
+		bus:      extBus,
+		sessions: make(map[string]*Session),
+		summaryFactory: func() (agentRunner, error) {
+			return &mockRunner{runResult: "Compact summary"}, nil
+		},
+		agentFactory: func(mem interfaces.Memory) (agentRunner, error) {
+			factoryCalls++
+			if factoryCalls == 1 {
+				return &mockRunner{runErr: overflowErr}, nil
+			}
+			return &mockRunner{runResult: "retried"}, nil
+		},
+	}
+
+	session, err := sm.getOrCreateSession("telegram:chat1")
+	require.NoError(t, err)
+	session.activatedSkills["python"] = true
+
+	sm.Dispatch(ctx, bus.InboundMessage{
+		Channel: "telegram",
+		ChatID:  "chat1",
+		Content: "new request",
+	})
+
+	notice := requireOutboundMessage(t, extBus)
+	assert.Equal(t, "Summarizing the conversation to keep going...", notice.Content)
+	reply := requireOutboundMessage(t, extBus)
+	assert.Equal(t, "retried", reply.Content)
+
+	dbPath := filepath.Join(cfg.Sessions.Directory, "sessions.db")
+	stable, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
+	require.NoError(t, err)
+	defer func() { _ = stable.Close() }()
+	msgs, err := stable.GetMessages(ctx)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "remember this", msgs[0].Content)
+
+	activeKey, err := resolveActiveSessionKey(ctx, stable.db, "telegram:chat1")
+	require.NoError(t, err)
+	assert.NotEqual(t, "telegram:chat1", activeKey)
+
+	summary, err := NewSQLiteSessionMemory(ctx, dbPath, activeKey)
+	require.NoError(t, err)
+	defer func() { _ = summary.Close() }()
+	msgs, err = summary.GetMessages(ctx)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, interfaces.MessageRoleAssistant, msgs[0].Role)
+	assert.Contains(t, msgs[0].Content, "Compact summary")
+	assert.Empty(t, session.activatedSkills)
 }
 
 func streamEvents(events ...interfaces.AgentStreamEvent) <-chan interfaces.AgentStreamEvent {

--- a/internal/agent/session_heads_test.go
+++ b/internal/agent/session_heads_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveActiveSessionKeyDefaultsToStableKey(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+
+	store, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	activeKey, err := resolveActiveSessionKey(ctx, store.db, "telegram:chat1")
+	require.NoError(t, err)
+	assert.Equal(t, "telegram:chat1", activeKey)
+}
+
+func TestSetActiveSessionKeyPersistsHeadAndLineage(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+
+	store, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
+	require.NoError(t, err)
+	require.NoError(t, setActiveSessionKey(ctx, store.db, "telegram:chat1", "telegram:chat1#summary-1"))
+	require.NoError(t, store.Close())
+
+	reopened, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
+	require.NoError(t, err)
+	defer func() { _ = reopened.Close() }()
+
+	activeKey, err := resolveActiveSessionKey(ctx, reopened.db, "telegram:chat1")
+	require.NoError(t, err)
+	assert.Equal(t, "telegram:chat1#summary-1", activeKey)
+
+	lineage, err := listSessionLineageKeys(ctx, reopened.db, "telegram:chat1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"telegram:chat1", "telegram:chat1#summary-1"}, lineage)
+}
+
+func TestClearSessionLineageRemovesHeadAndTrackedBackingKeys(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "sessions.db")
+
+	store, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
+	require.NoError(t, err)
+	require.NoError(t, ensureSessionLineage(ctx, store.db, "telegram:chat1", "telegram:chat1"))
+	require.NoError(t, ensureSessionLineage(ctx, store.db, "telegram:chat1", "telegram:chat1#summary-1"))
+	require.NoError(t, setActiveSessionKey(ctx, store.db, "telegram:chat1", "telegram:chat1#summary-1"))
+
+	require.NoError(t, clearSessionLineage(ctx, store.db, "telegram:chat1"))
+
+	activeKey, err := resolveActiveSessionKey(ctx, store.db, "telegram:chat1")
+	require.NoError(t, err)
+	assert.Equal(t, "telegram:chat1", activeKey)
+
+	lineage, err := listSessionLineageKeys(ctx, store.db, "telegram:chat1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"telegram:chat1"}, lineage)
+}

--- a/internal/agent/session_integration_test.go
+++ b/internal/agent/session_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -199,6 +200,95 @@ func TestClearHistoryDeletesPersistedSession(t *testing.T) {
 	msgs, err := session.mem.GetMessages(context.Background())
 	require.NoError(t, err)
 	assert.Empty(t, msgs)
+}
+
+func TestSessionManagerUsesActiveSessionHead(t *testing.T) {
+	sessionsDir := t.TempDir()
+	dbPath := filepath.Join(sessionsDir, "sessions.db")
+	ctx := context.Background()
+
+	stable, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
+	require.NoError(t, err)
+	require.NoError(t, stable.AddMessage(ctx, interfaces.Message{Role: interfaces.MessageRoleUser, Content: "old history"}))
+	require.NoError(t, ensureSessionLineage(ctx, stable.db, "telegram:chat1", "telegram:chat1"))
+	require.NoError(t, stable.Close())
+
+	summary, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1#summary-1")
+	require.NoError(t, err)
+	require.NoError(t, summary.AddMessage(ctx, interfaces.Message{Role: interfaces.MessageRoleAssistant, Content: "Conversation summary"}))
+	require.NoError(t, setActiveSessionKey(ctx, summary.db, "telegram:chat1", "telegram:chat1#summary-1"))
+	require.NoError(t, summary.Close())
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{Defaults: config.AgentDefaults{ModelName: "test-model"}},
+		ModelList: []config.ModelConfig{{
+			ModelName: "test-model",
+			Model:     "gpt-4o",
+			APIKey:    config.NewSecureString("test-key"),
+		}},
+		Sessions: config.SessionsConfig{Directory: sessionsDir},
+	}
+
+	sm, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
+	require.NoError(t, err)
+
+	session, err := sm.getOrCreateSession("telegram:chat1")
+	require.NoError(t, err)
+
+	msgs, err := session.mem.GetMessages(ctx)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "Conversation summary", msgs[0].Content)
+}
+
+func TestClearHistoryDeletesSessionLineage(t *testing.T) {
+	sessionsDir := t.TempDir()
+	dbPath := filepath.Join(sessionsDir, "sessions.db")
+	ctx := context.Background()
+
+	stable, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
+	require.NoError(t, err)
+	require.NoError(t, stable.AddMessage(ctx, interfaces.Message{Role: interfaces.MessageRoleUser, Content: "old history"}))
+	require.NoError(t, ensureSessionLineage(ctx, stable.db, "telegram:chat1", "telegram:chat1"))
+	require.NoError(t, stable.Close())
+
+	summary, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1#summary-1")
+	require.NoError(t, err)
+	require.NoError(t, summary.AddMessage(ctx, interfaces.Message{Role: interfaces.MessageRoleAssistant, Content: "Conversation summary"}))
+	require.NoError(t, setActiveSessionKey(ctx, summary.db, "telegram:chat1", "telegram:chat1#summary-1"))
+	require.NoError(t, summary.Close())
+
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{Defaults: config.AgentDefaults{ModelName: "test-model"}},
+		ModelList: []config.ModelConfig{{
+			ModelName: "test-model",
+			Model:     "gpt-4o",
+			APIKey:    config.NewSecureString("test-key"),
+		}},
+		Sessions: config.SessionsConfig{Directory: sessionsDir},
+	}
+
+	sm, err := NewSessionManager(cfg, bus.NewMessageBus(), nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, sm.ClearHistory("telegram:chat1"))
+
+	reopenedStable, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
+	require.NoError(t, err)
+	defer reopenedStable.Close()
+	msgs, err := reopenedStable.GetMessages(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, msgs)
+
+	reopenedSummary, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1#summary-1")
+	require.NoError(t, err)
+	defer reopenedSummary.Close()
+	msgs, err = reopenedSummary.GetMessages(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, msgs)
+
+	activeKey, err := resolveActiveSessionKey(ctx, reopenedSummary.db, "telegram:chat1")
+	require.NoError(t, err)
+	assert.Equal(t, "telegram:chat1", activeKey)
 }
 
 // TestSessionManagerEviction verifies that stale sessions are evicted by the

--- a/internal/agent/session_integration_test.go
+++ b/internal/agent/session_integration_test.go
@@ -274,14 +274,14 @@ func TestClearHistoryDeletesSessionLineage(t *testing.T) {
 
 	reopenedStable, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1")
 	require.NoError(t, err)
-	defer reopenedStable.Close()
+	defer func() { _ = reopenedStable.Close() }()
 	msgs, err := reopenedStable.GetMessages(ctx)
 	require.NoError(t, err)
 	assert.Empty(t, msgs)
 
 	reopenedSummary, err := NewSQLiteSessionMemory(ctx, dbPath, "telegram:chat1#summary-1")
 	require.NoError(t, err)
-	defer reopenedSummary.Close()
+	defer func() { _ = reopenedSummary.Close() }()
 	msgs, err = reopenedSummary.GetMessages(ctx)
 	require.NoError(t, err)
 	assert.Empty(t, msgs)

--- a/internal/agent/sqlite_memory.go
+++ b/internal/agent/sqlite_memory.go
@@ -25,6 +25,17 @@ CREATE TABLE IF NOT EXISTS messages (
 	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_key, id);
+CREATE TABLE IF NOT EXISTS session_heads (
+	stable_key TEXT PRIMARY KEY,
+	active_key TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS session_lineage (
+	stable_key TEXT NOT NULL,
+	backing_key TEXT NOT NULL,
+	created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (stable_key, backing_key)
+);
+CREATE INDEX IF NOT EXISTS idx_session_lineage_stable_key ON session_lineage(stable_key, backing_key);
 `
 
 // SQLiteSessionMemory stores one session's conversation in a shared SQLite DB.
@@ -155,6 +166,85 @@ func (m *SQLiteSessionMemory) Close() error {
 func clearSQLiteSession(ctx context.Context, db *sql.DB, sessionKey string) error {
 	if _, err := db.ExecContext(ctx, `DELETE FROM messages WHERE session_key = ?`, sessionKey); err != nil {
 		return fmt.Errorf("clear session messages: %w", err)
+	}
+	return nil
+}
+
+func resolveActiveSessionKey(ctx context.Context, db *sql.DB, stableKey string) (string, error) {
+	var activeKey string
+	err := db.QueryRowContext(ctx, `SELECT active_key FROM session_heads WHERE stable_key = ?`, stableKey).Scan(&activeKey)
+	if err == nil {
+		return activeKey, nil
+	}
+	if err == sql.ErrNoRows {
+		return stableKey, nil
+	}
+	return "", fmt.Errorf("resolve active session key: %w", err)
+}
+
+func setActiveSessionKey(ctx context.Context, db *sql.DB, stableKey, activeKey string) error {
+	if err := ensureSessionLineage(ctx, db, stableKey, stableKey); err != nil {
+		return err
+	}
+	if err := ensureSessionLineage(ctx, db, stableKey, activeKey); err != nil {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, `
+INSERT INTO session_heads (stable_key, active_key)
+VALUES (?, ?)
+ON CONFLICT(stable_key) DO UPDATE SET active_key = excluded.active_key`,
+		stableKey, activeKey,
+	); err != nil {
+		return fmt.Errorf("set active session key: %w", err)
+	}
+	return nil
+}
+
+func ensureSessionLineage(ctx context.Context, db *sql.DB, stableKey, backingKey string) error {
+	if _, err := db.ExecContext(ctx, `
+INSERT OR IGNORE INTO session_lineage (stable_key, backing_key)
+VALUES (?, ?)`,
+		stableKey, backingKey,
+	); err != nil {
+		return fmt.Errorf("ensure session lineage: %w", err)
+	}
+	return nil
+}
+
+func listSessionLineageKeys(ctx context.Context, db *sql.DB, stableKey string) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT backing_key
+FROM session_lineage
+WHERE stable_key = ?
+ORDER BY created_at, backing_key`, stableKey)
+	if err != nil {
+		return nil, fmt.Errorf("list session lineage: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var keys []string
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, fmt.Errorf("scan session lineage: %w", err)
+		}
+		keys = append(keys, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list session lineage: %w", err)
+	}
+	if len(keys) == 0 {
+		return []string{stableKey}, nil
+	}
+	return keys, nil
+}
+
+func clearSessionLineage(ctx context.Context, db *sql.DB, stableKey string) error {
+	if _, err := db.ExecContext(ctx, `DELETE FROM session_heads WHERE stable_key = ?`, stableKey); err != nil {
+		return fmt.Errorf("clear session heads: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM session_lineage WHERE stable_key = ?`, stableKey); err != nil {
+		return fmt.Errorf("clear session lineage: %w", err)
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,12 +55,19 @@ type AgentsConfig struct {
 }
 
 type AgentDefaults struct {
-	ModelName           string  `json:"model_name"`
-	Workspace           string  `json:"workspace"`
-	RestrictToWorkspace bool    `json:"restrict_to_workspace"`
-	MaxTokens           int     `json:"max_tokens"`
-	Temperature         float64 `json:"temperature"`
-	MaxToolIterations   int     `json:"max_tool_iterations"`
+	ModelName           string        `json:"model_name"`
+	Workspace           string        `json:"workspace"`
+	RestrictToWorkspace bool          `json:"restrict_to_workspace"`
+	MaxTokens           int           `json:"max_tokens"`
+	Temperature         float64       `json:"temperature"`
+	MaxToolIterations   int           `json:"max_tool_iterations"`
+	Summary             SummaryConfig `json:"summary,omitempty"`
+}
+
+type SummaryConfig struct {
+	Enabled      bool   `json:"enabled"`
+	TokenTrigger int    `json:"token_trigger,omitempty"`
+	Model        string `json:"model,omitempty"`
 }
 
 type ModelConfig struct {

--- a/pkg/config/config_extra_test.go
+++ b/pkg/config/config_extra_test.go
@@ -134,8 +134,8 @@ func TestLoadConfig_ValidFile(t *testing.T) {
 	cfgPath := filepath.Join(tmpDir, "config.json")
 	data := []byte(`{
 		"version": 2,
-		"agents": {"defaults": {"model_name": "test-model", "workspace": "/tmp", "restrict_to_workspace": false, "max_tokens": 1000, "temperature": 0.5, "max_tool_iterations": 5}},
-		"model_list": [{"model_name": "test-model", "model": "gpt-4", "api_key": "test-key"}],
+		"agents": {"defaults": {"model_name": "test-model", "workspace": "/tmp", "restrict_to_workspace": false, "max_tokens": 1000, "temperature": 0.5, "max_tool_iterations": 5, "summary": {"enabled": true, "token_trigger": 32000, "model": "summary-model"}}},
+		"model_list": [{"model_name": "test-model", "model": "gpt-4", "api_key": "test-key"}, {"model_name": "summary-model", "model": "gpt-4o-mini", "api_key": "test-key"}],
 		"channels": {"telegram": {"enabled": true, "type": "telegram", "token": "bot-token"}},
 		"gateway": {"host": "0.0.0.0", "port": 8080, "log_level": "info"},
 		"tools": {"media_cleanup": {"enabled": true, "max_age": 60, "interval": 10}, "exec": {"enabled": false}}
@@ -147,6 +147,9 @@ func TestLoadConfig_ValidFile(t *testing.T) {
 	assert.Equal(t, 2, cfg.Version)
 	assert.Equal(t, "test-model", cfg.Agents.Defaults.ModelName)
 	assert.Equal(t, 5, cfg.Agents.Defaults.MaxToolIterations)
+	assert.True(t, cfg.Agents.Defaults.Summary.Enabled)
+	assert.Equal(t, 32000, cfg.Agents.Defaults.Summary.TokenTrigger)
+	assert.Equal(t, "summary-model", cfg.Agents.Defaults.Summary.Model)
 	assert.Equal(t, 8080, cfg.Gateway.Port)
 	assert.NotNil(t, cfg.Channels["telegram"])
 	assert.Equal(t, "telegram", cfg.Channels["telegram"].Name())


### PR DESCRIPTION
## Summary
- add session-head based summarization handoff so overflow creates a new backing session while leaving old session history untouched
- gate summarization behind config and use a dedicated summary model plus structured summary output
- harden summary generation with chunked map-reduce fallback when one-pass summarization would overflow

## Test plan
- make test
- make lint

Closes #149