### PR TITLE
Fix cron session routing and OpenRouter limit handling

### DIFF
--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -567,6 +567,7 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 	actx := exec.WithChatID(ctx, chatID)
 	actx = toolctx.WithChannel(actx, msg.Channel)
 	actx = toolctx.WithSenderID(actx, msg.SenderID)
+	actx = toolctx.WithInboundContext(actx, msg.Context)
 
 	input := msg.Content
 	if len(msg.Media) > 0 {
@@ -639,7 +640,7 @@ func (s *Session) handleInbound(ctx context.Context, msg bus.InboundMessage, ses
 				Channel:    msg.Channel,
 				ChatID:     chatID,
 				SessionKey: sessionKey,
-				Content:    fmt.Sprintf("Error: %v", err),
+				Content:    userFacingRunError(err),
 			}))
 		}
 		s.mgr.emitProgress(ctx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressFailed, Error: err, Elapsed: elapsed})
@@ -759,6 +760,27 @@ func (sm *SessionManager) buildSessionAgent(mem interfaces.Memory) (agentRunner,
 		return sm.agentFactory(mem)
 	}
 	return buildAgentWithMemory(sm.cfg, sm.tools, mem)
+}
+
+func userFacingRunError(err error) string {
+	if err == nil {
+		return "Error: unknown failure"
+	}
+	if isOpenRouterLimitError(err) {
+		return "This request hit OpenRouter's context or token limit. The turn was not completed. Clear or shorten the session history and try again."
+	}
+	return fmt.Sprintf("Error: %v", err)
+}
+
+func isOpenRouterLimitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "context_length_exceeded") ||
+		strings.Contains(msg, "max_tokens_exceeded") ||
+		strings.Contains(msg, "token_limit_exceeded") ||
+		strings.Contains(msg, "string_too_long")
 }
 
 func (s *Session) runStreamingTurn(

--- a/internal/agent/session_debug_test.go
+++ b/internal/agent/session_debug_test.go
@@ -269,6 +269,39 @@ func TestSessionManagerTurnSummaryLogsUsageAndDuration(t *testing.T) {
 	assert.Contains(t, logs, "response_bytes")
 }
 
+func TestSessionManagerOpenRouterLimitErrorsNotifyUser(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "context length exceeded", err: errors.New("openrouter: context_length_exceeded")},
+		{name: "max tokens exceeded", err: errors.New("provider returned max_tokens_exceeded while generating response")},
+		{name: "token limit exceeded", err: errors.New("token_limit_exceeded")},
+		{name: "string too long", err: errors.New("string_too_long")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			extBus := bus.NewMessageBus()
+			progress := &collectingProgress{}
+			sm := &SessionManager{bus: extBus, progress: progress}
+			session := &Session{agent: &mockRunner{detailedErr: tc.err}, mgr: sm}
+
+			turnCtx, turnSeq, turnDone := session.startTurn(t.Context())
+			session.handleInbound(turnCtx, inbound("telegram", "chat1", "bad"), "telegram:chat1", turnSeq, turnDone)
+
+			msg := requireOutboundMessage(t, extBus)
+			assert.Equal(t, bus.MessageKindSystem, msg.Context.Raw["message_kind"])
+			assert.Equal(t, "[system] This request hit OpenRouter's context or token limit. The turn was not completed. Clear or shorten the session history and try again.", msg.Content)
+			assertNoOutboundMessage(t, extBus)
+			require.Len(t, progress.summaries, 1)
+			assert.False(t, progress.summaries[0].Success)
+			assert.ErrorIs(t, progress.summaries[0].Error, tc.err)
+			assertHasEvent(t, progress.events, ProgressFailed)
+		})
+	}
+}
+
 func TestSessionManagerStreamingStartupFallbackUsesDetailedUsage(t *testing.T) {
 	startErr := errors.New("no streaming")
 	progress := &collectingProgress{}

--- a/main.go
+++ b/main.go
@@ -14,14 +14,15 @@ import (
 	"github.com/sushi30/sushiclaw/internal/envresolve"
 	"github.com/sushi30/sushiclaw/internal/gateway"
 	"github.com/sushi30/sushiclaw/internal/version"
+	"github.com/sushi30/sushiclaw/pkg/bus"
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/cron"
 	"github.com/sushi30/sushiclaw/pkg/logger"
 
 	// Register owned channel implementations.
 	_ "github.com/sushi30/sushiclaw/pkg/channels/email"
-	_ "github.com/sushi30/sushiclaw/pkg/channels/websocket"
 	_ "github.com/sushi30/sushiclaw/pkg/channels/telegram"
+	_ "github.com/sushi30/sushiclaw/pkg/channels/websocket"
 	_ "github.com/sushi30/sushiclaw/pkg/channels/whatsapp_native"
 )
 
@@ -114,6 +115,7 @@ func newCronAddCommand() *cobra.Command {
 				Message:   message,
 				Channel:   channel,
 				ChatID:    chatID,
+				Context:   bus.NewOutboundContext(channel, chatID, ""),
 				CronExpr:  cronExpr,
 				Deliver:   deliver,
 				Command:   command,

--- a/pkg/cron/models.go
+++ b/pkg/cron/models.go
@@ -1,19 +1,24 @@
 package cron
 
-import "time"
+import (
+	"time"
+
+	"github.com/sushi30/sushiclaw/pkg/bus"
+)
 
 // Job represents a scheduled cron job.
 type Job struct {
-	Name         string    `json:"name"`
-	Message      string    `json:"message"`
-	Channel      string    `json:"channel"`
-	ChatID       string    `json:"chat_id"`
-	SenderID     string    `json:"sender_id"`
-	AtSeconds    *int      `json:"at_seconds,omitempty"`
-	EverySeconds *int      `json:"every_seconds,omitempty"`
-	CronExpr     string    `json:"cron_expr,omitempty"`
-	Deliver      bool      `json:"deliver"`
-	Command      string    `json:"command,omitempty"`
-	Enabled      bool      `json:"enabled"`
-	CreatedAt    time.Time `json:"created_at"`
+	Name         string             `json:"name"`
+	Message      string             `json:"message"`
+	Channel      string             `json:"channel"`
+	ChatID       string             `json:"chat_id"`
+	SenderID     string             `json:"sender_id"`
+	Context      bus.InboundContext `json:"context,omitempty"`
+	AtSeconds    *int               `json:"at_seconds,omitempty"`
+	EverySeconds *int               `json:"every_seconds,omitempty"`
+	CronExpr     string             `json:"cron_expr,omitempty"`
+	Deliver      bool               `json:"deliver"`
+	Command      string             `json:"command,omitempty"`
+	Enabled      bool               `json:"enabled"`
+	CreatedAt    time.Time          `json:"created_at"`
 }

--- a/pkg/cron/scheduler.go
+++ b/pkg/cron/scheduler.go
@@ -246,11 +246,18 @@ func (s *Scheduler) executeJob(job Job) {
 
 	logger.InfoCF("cron", "Executing job", map[string]any{
 		"name":    current.Name,
-		"channel": current.Channel,
-		"chat_id": current.ChatID,
+		"channel": current.targetContext().Channel,
+		"chat_id": current.targetContext().ChatID,
 	})
 
 	ctx := context.Background()
+	target := current.targetContext()
+	if target.Channel == "" || target.ChatID == "" {
+		logger.WarnCF("cron", "Skipping cron job with missing routing context", map[string]any{
+			"job": current.Name,
+		})
+		return
+	}
 
 	if current.Command != "" {
 		s.executeCommandJob(ctx, *current)
@@ -266,20 +273,16 @@ func (s *Scheduler) executeJob(job Job) {
 }
 
 func (s *Scheduler) agentTurn(ctx context.Context, job Job) {
-	// Cron agent turns share the target chat's session (channel:chatID).
-	// If the session was evicted due to inactivity, getOrCreateSession
-	// lazily builds a fresh one, so the cron job always runs.
+	target := job.targetContext()
+	// Cron agent turns run in a dedicated per-job session so recurring jobs
+	// build their own relevant history instead of inheriting unrelated chat turns.
 	msg := bus.InboundMessage{
-		Context: bus.InboundContext{
-			Channel:  job.Channel,
-			ChatID:   job.ChatID,
-			SenderID: job.SenderID,
-		},
+		Context: target,
 		Sender: bus.SenderInfo{
-			CanonicalID: job.SenderID,
+			CanonicalID: target.SenderID,
 		},
 		Content:    job.Message,
-		SessionKey: job.Channel + ":" + job.ChatID,
+		SessionKey: cronSessionKey(job),
 	}
 	if err := s.bus.PublishInbound(ctx, msg); err != nil {
 		logger.ErrorCF("cron", "Failed to publish inbound cron job", map[string]any{
@@ -290,10 +293,11 @@ func (s *Scheduler) agentTurn(ctx context.Context, job Job) {
 }
 
 func (s *Scheduler) deliverMessage(ctx context.Context, job Job) {
+	target := job.targetContext()
 	msg := bus.OutboundMessage{
-		Channel: job.Channel,
-		ChatID:  job.ChatID,
-		Context: bus.NewOutboundContext(job.Channel, job.ChatID, ""),
+		Channel: target.Channel,
+		ChatID:  target.ChatID,
+		Context: target,
 		Content: job.Message,
 	}
 	msg = bus.MarkSystemOutboundMessage(msg)
@@ -328,11 +332,13 @@ func (s *Scheduler) executeCommandJob(ctx context.Context, job Job) {
 		content = fmt.Sprintf("Error: %v\nOutput: %s", err, output)
 	}
 
+	target := job.targetContext()
 	msg := bus.OutboundMessage{
-		Channel: job.Channel,
-		ChatID:  job.ChatID,
-		Context: bus.NewOutboundContext(job.Channel, job.ChatID, ""),
-		Content: content,
+		Channel:    target.Channel,
+		ChatID:     target.ChatID,
+		Context:    target,
+		Content:    content,
+		SessionKey: target.Channel + ":" + target.ChatID,
 	}
 	msg = bus.MarkSystemOutboundMessage(msg)
 	if err := s.bus.PublishOutbound(ctx, msg); err != nil {
@@ -341,4 +347,23 @@ func (s *Scheduler) executeCommandJob(ctx context.Context, job Job) {
 			"error": err.Error(),
 		})
 	}
+}
+
+func (j Job) targetContext() bus.InboundContext {
+	ctx := j.Context
+	if ctx.Channel == "" {
+		ctx.Channel = j.Channel
+	}
+	if ctx.ChatID == "" {
+		ctx.ChatID = j.ChatID
+	}
+	if ctx.SenderID == "" {
+		ctx.SenderID = j.SenderID
+	}
+	return bus.NormalizeInboundMessage(bus.InboundMessage{Context: ctx}).Context
+}
+
+func cronSessionKey(job Job) string {
+	target := job.targetContext()
+	return fmt.Sprintf("cron:%s:%s:%s", job.Name, target.Channel, target.ChatID)
 }

--- a/pkg/cron/scheduler_test.go
+++ b/pkg/cron/scheduler_test.go
@@ -1,0 +1,177 @@
+package cron
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/config"
+)
+
+func TestSchedulerDeliverMessageUsesStoredContext(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newExecutionTestScheduler(t, false)
+	job := Job{
+		Name:    "deliver",
+		Message: "drink water",
+		Context: bus.InboundContext{
+			Channel:          "telegram",
+			ChatID:           "-100123/42",
+			ReplyToMessageID: "77",
+			Raw: map[string]string{
+				"parent_peer_kind": "topic",
+				"parent_peer_id":   "42",
+			},
+		},
+		Deliver: true,
+		Enabled: true,
+	}
+	require.NoError(t, scheduler.store.Save([]Job{job}))
+
+	scheduler.executeJob(job)
+
+	msg := requireOutboundMessage(t, scheduler.bus.OutboundChan())
+	expectedCtx := job.Context
+	if expectedCtx.Raw == nil {
+		expectedCtx.Raw = map[string]string{}
+	}
+	expectedCtx.Raw["message_kind"] = bus.MessageKindSystem
+	require.Equal(t, bus.MessageKindSystem, msg.Context.Raw["message_kind"])
+	require.Equal(t, "[system] drink water", msg.Content)
+	require.Equal(t, expectedCtx, msg.Context)
+	require.Equal(t, job.Context.Channel, msg.Channel)
+	require.Equal(t, job.Context.ChatID, msg.ChatID)
+	require.Equal(t, job.Context.ReplyToMessageID, msg.ReplyToMessageID)
+}
+
+func TestSchedulerAgentTurnUsesStoredContext(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newExecutionTestScheduler(t, false)
+	job := Job{
+		Name:    "agent-turn",
+		Message: "check in",
+		Context: bus.InboundContext{
+			Channel:   "telegram",
+			ChatID:    "-100123/42",
+			ChatType:  "group",
+			SenderID:  "user-1",
+			MessageID: "99",
+		},
+		Enabled: true,
+	}
+	require.NoError(t, scheduler.store.Save([]Job{job}))
+
+	scheduler.executeJob(job)
+
+	msg := requireInboundMessage(t, scheduler.bus.InboundChan())
+	require.Equal(t, "check in", msg.Content)
+	require.Equal(t, job.Context, msg.Context)
+	require.Equal(t, "cron:agent-turn:telegram:-100123/42", msg.SessionKey)
+}
+
+func TestSchedulerCommandJobUsesStoredContextForOutput(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newExecutionTestScheduler(t, true)
+	job := Job{
+		Name:    "command",
+		Command: "printf hello",
+		Context: bus.InboundContext{
+			Channel: "telegram",
+			ChatID:  "-100123/42",
+			Raw: map[string]string{
+				"parent_peer_kind": "topic",
+				"parent_peer_id":   "42",
+			},
+		},
+		Enabled: true,
+	}
+	require.NoError(t, scheduler.store.Save([]Job{job}))
+
+	scheduler.executeJob(job)
+
+	msg := requireOutboundMessage(t, scheduler.bus.OutboundChan())
+	expectedCtx := job.Context
+	if expectedCtx.Raw == nil {
+		expectedCtx.Raw = map[string]string{}
+	}
+	expectedCtx.Raw["message_kind"] = bus.MessageKindSystem
+	require.Equal(t, bus.MessageKindSystem, msg.Context.Raw["message_kind"])
+	require.Equal(t, "[system] hello", msg.Content)
+	require.Equal(t, expectedCtx, msg.Context)
+	require.Equal(t, job.Context.Channel, msg.Channel)
+	require.Equal(t, job.Context.ChatID, msg.ChatID)
+}
+
+func newExecutionTestScheduler(t *testing.T, execEnabled bool) *Scheduler {
+	t.Helper()
+
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace: filepath.Join(tmp, "workspace"),
+			},
+		},
+		Tools: config.ToolsConfig{
+			Exec: config.ExecToolConfig{Enabled: execEnabled},
+		},
+	}
+
+	messageBus := bus.NewMessageBus()
+	scheduler, err := NewScheduler(cfg, messageBus)
+	require.NoError(t, err)
+	t.Cleanup(scheduler.Stop)
+	return scheduler
+}
+
+func requireOutboundMessage(t *testing.T, ch <-chan bus.OutboundMessage) bus.OutboundMessage {
+	t.Helper()
+
+	select {
+	case msg := <-ch:
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for outbound message")
+		return bus.OutboundMessage{}
+	}
+}
+
+func requireInboundMessage(t *testing.T, ch <-chan bus.InboundMessage) bus.InboundMessage {
+	t.Helper()
+
+	select {
+	case msg := <-ch:
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for inbound message")
+		return bus.InboundMessage{}
+	}
+}
+
+func TestSchedulerSkipsLegacyJobsWithoutContext(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newExecutionTestScheduler(t, false)
+	job := Job{
+		Name:    "legacy",
+		Message: "hello",
+		Enabled: true,
+	}
+	require.NoError(t, scheduler.store.Save([]Job{job}))
+
+	scheduler.executeJob(job)
+
+	select {
+	case msg := <-scheduler.bus.OutboundChan():
+		t.Fatalf("unexpected outbound message: %#v", msg)
+	case msg := <-scheduler.bus.InboundChan():
+		t.Fatalf("unexpected inbound message: %#v", msg)
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/pkg/cron/tool.go
+++ b/pkg/cron/tool.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Ingenimax/agent-sdk-go/pkg/interfaces"
+	"github.com/sushi30/sushiclaw/pkg/bus"
 	"github.com/sushi30/sushiclaw/pkg/config"
 	"github.com/sushi30/sushiclaw/pkg/tools/toolctx"
 )
@@ -189,6 +190,18 @@ func (t *CronTool) addJob(ctx context.Context, params map[string]any) (string, e
 		Enabled:      true,
 		CreatedAt:    time.Now(),
 	}
+	if inboundCtx, ok := toolctx.InboundContextFromContext[bus.InboundContext](ctx); ok {
+		job.Context = inboundCtx
+	}
+	if job.Context.Channel == "" || job.Context.ChatID == "" {
+		job.Context = bus.NewOutboundContext(job.Channel, job.ChatID, "")
+	}
+	if job.Context.SenderID == "" {
+		job.Context.SenderID = job.SenderID
+	}
+	job.Channel = job.Context.Channel
+	job.ChatID = job.Context.ChatID
+	job.SenderID = job.Context.SenderID
 
 	if err := t.scheduler.AddJob(job); err != nil {
 		return "", err

--- a/pkg/cron/tool_test.go
+++ b/pkg/cron/tool_test.go
@@ -1,0 +1,69 @@
+package cron
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sushi30/sushiclaw/pkg/bus"
+	"github.com/sushi30/sushiclaw/pkg/config"
+	"github.com/sushi30/sushiclaw/pkg/tools/toolctx"
+)
+
+func TestCronToolAddStoresInboundContext(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newTestScheduler(t)
+	tool := NewCronTool(scheduler, scheduler.cfg)
+
+	inboundCtx := bus.InboundContext{
+		Channel:          "telegram",
+		ChatID:           "-100123/42",
+		ChatType:         "group",
+		SenderID:         "user-1",
+		MessageID:        "99",
+		ReplyToMessageID: "77",
+		Raw: map[string]string{
+			"parent_peer_kind": "topic",
+			"parent_peer_id":   "42",
+		},
+	}
+
+	ctx := context.Background()
+	ctx = toolctx.WithChatID(ctx, inboundCtx.ChatID)
+	ctx = toolctx.WithChannel(ctx, inboundCtx.Channel)
+	ctx = toolctx.WithSenderID(ctx, inboundCtx.SenderID)
+	ctx = toolctx.WithInboundContext(ctx, inboundCtx)
+
+	_, err := tool.Execute(ctx, `{"action":"add","name":"daily","message":"hello","cron_expr":"0 9 * * *","deliver":true}`)
+	require.NoError(t, err)
+
+	jobs, err := scheduler.ListJobs()
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+
+	require.Equal(t, inboundCtx.Channel, jobs[0].Channel)
+	require.Equal(t, inboundCtx.ChatID, jobs[0].ChatID)
+	require.Equal(t, inboundCtx.SenderID, jobs[0].SenderID)
+	require.Equal(t, inboundCtx, jobs[0].Context)
+}
+
+func newTestScheduler(t *testing.T) *Scheduler {
+	t.Helper()
+
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		Agents: config.AgentsConfig{
+			Defaults: config.AgentDefaults{
+				Workspace: filepath.Join(tmp, "workspace"),
+			},
+		},
+	}
+
+	scheduler, err := NewScheduler(cfg, bus.NewMessageBus())
+	require.NoError(t, err)
+	t.Cleanup(scheduler.Stop)
+	return scheduler
+}

--- a/pkg/tools/toolctx/context.go
+++ b/pkg/tools/toolctx/context.go
@@ -5,6 +5,7 @@ import "context"
 type chatIDKey struct{}
 type channelKey struct{}
 type senderIDKey struct{}
+type inboundContextKey struct{}
 
 // WithChatID returns a context with the chat ID set.
 func WithChatID(ctx context.Context, chatID string) context.Context {
@@ -37,4 +38,19 @@ func WithSenderID(ctx context.Context, senderID string) context.Context {
 func SenderIDFromContext(ctx context.Context) string {
 	v, _ := ctx.Value(senderIDKey{}).(string)
 	return v
+}
+
+// WithInboundContext returns a context with the inbound message context set.
+func WithInboundContext(ctx context.Context, inboundCtx any) context.Context {
+	return context.WithValue(ctx, inboundContextKey{}, inboundCtx)
+}
+
+// InboundContextFromContext returns the inbound message context from the context, if any.
+func InboundContextFromContext[T any](ctx context.Context) (T, bool) {
+	v, ok := ctx.Value(inboundContextKey{}).(T)
+	var zero T
+	if !ok {
+		return zero, false
+	}
+	return v, true
 }


### PR DESCRIPTION
## Summary
- Persist full inbound routing context for cron jobs and route scheduled agent turns through a dedicated per-job session.
- Add regression coverage for cron tool persistence, scheduler delivery, and OpenRouter limit-error notifications.
- Map OpenRouter context/token limit errors to a user-facing message instead of surfacing the raw provider error.

## Test plan
- `make test`
- `make lint`
- `go test ./...`

Fixes #131