### PR TITLE
Trim /list skills output

### DIFF
--- a/pkg/commands/commands.go
+++ b/pkg/commands/commands.go
@@ -339,11 +339,7 @@ func listSkillsHandler(_ context.Context, req Request, rt *Runtime) error {
 	var sb strings.Builder
 	sb.WriteString("Available skills:\n")
 	for _, s := range skills {
-		sb.WriteString("• " + s.Name)
-		if s.Description != "" {
-			sb.WriteString(" — " + s.Description)
-		}
-		sb.WriteByte('\n')
+		sb.WriteString("• " + s.Name + "\n")
 	}
 	return req.Reply(strings.TrimRight(sb.String(), "\n"))
 }

--- a/pkg/commands/commands_test.go
+++ b/pkg/commands/commands_test.go
@@ -394,7 +394,7 @@ func TestExecuteListSkills(t *testing.T) {
 	})
 	assert.Equal(t, commands.OutcomeHandled, result.Outcome)
 	assert.Contains(t, replied, "Available skills:")
-	assert.Contains(t, replied, "• python — Python coding help")
+	assert.Contains(t, replied, "• python")
 	assert.Contains(t, replied, "• review")
 }
 


### PR DESCRIPTION
## Summary
- Remove skill descriptions from `/list skills` output so it returns names only.
- Update the command test to match the shorter response.

## Test plan
- `go test ./pkg/commands ./internal/agent`
- `pkg/commands` passed in this run.