### PR TITLE
feat: add yaml config migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ CGO_ENABLED=0 go build -tags whatsapp_native -o sushiclaw .
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `SUSHICLAW_HOME` | Home directory for configs, workspace, logs | `$PICOCLAW_HOME` → `~/.picoclaw` |
-| `SUSHICLAW_CONFIG` | Path to `config.json` | `$SUSHICLAW_HOME/config.json` |
+| `SUSHICLAW_CONFIG` | Path to `config.yaml` | `$SUSHICLAW_HOME/config.yaml` |
 | `SUSHICLAW_EXEC_ALLOWED_SENDERS` | Comma-separated chat IDs that can use the `exec` tool remotely (bypasses `allowRemote=false`) | *(unset = no trusted senders)* |
 
 ## CLI commands
@@ -161,10 +161,10 @@ CGO_ENABLED=0 go build -tags whatsapp_native -o sushiclaw .
 Config is JSON. Load order:
 
 1. `$SUSHICLAW_CONFIG` if set
-2. `$SUSHICLAW_HOME/config.json`
-3. `~/.picoclaw/config.json`
+2. `$SUSHICLAW_HOME/config.yaml`
+3. `~/.picoclaw/config.yaml`
 
-Copy `config.example.json` to get started.
+Copy `config.example.yaml` to get started.
 
 ### `env://` resolution
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ cd sushiclaw
 
 ```bash
 mkdir -p ~/.picoclaw
-cp config.example.json ~/.picoclaw/config.json
-# Edit config.json — set your model API key and enable at least one channel
+cp config.example.yaml ~/.picoclaw/config.yaml
+# Edit config.yaml — set your model API key and enable at least one channel
 ```
 
 ### 3. Build and run
@@ -45,6 +45,7 @@ sushiclaw gateway
 |---------|-------------|
 | `sushiclaw gateway` | Start the full gateway (all channels) |
 | `sushiclaw chat` | Interactive terminal chat with the agent |
+| `sushiclaw migrate-config` | Convert a legacy JSON config to YAML |
 | `sushiclaw version` | Print build version info |
 
 ### `gateway` flags
@@ -79,25 +80,24 @@ Health check hits `http://localhost:18790/health`.
 
 ## Configuration
 
-Copy `config.example.json` to `~/.picoclaw/config.json`. Key sections:
+Copy `config.example.yaml` to `~/.picoclaw/config.yaml`. Key sections:
 
-```json
-{
-  "agents": {
-    "defaults": {
-      "workspace": "~/.picoclaw/workspace",
-      "model_name": "gpt-4o-mini"
-    }
-  },
-  "model_list": [{ "model_name": "gpt-4o-mini", "api_key": "env://OPENAI_API_KEY" }],
-  "sessions": {
-    "directory": "~/.sushiclaw/sessions"
-  },
-  "channels": {
-    "email": { "enabled": false, "type": "email", "...": "..." }
-  },
-  "tools": { ... }
-}
+```yaml
+agents:
+  defaults:
+    workspace: "~/.picoclaw/workspace"
+    model_name: gpt-4o-mini
+model_list:
+  - model_name: gpt-4o-mini
+    api_key: env://OPENAI_API_KEY
+sessions:
+  directory: "~/.sushiclaw/sessions"
+channels:
+  email:
+    enabled: false
+    type: email
+    "...": "..."
+tools: { ... }
 ```
 
 Override config path with `$SUSHICLAW_CONFIG`.
@@ -113,7 +113,7 @@ defaults. The `/clear` command removes the current session's persisted history.
 
 ### `env://` config resolver
 
-API keys in `config.json` can reference environment variables:
+API keys in `config.yaml` can reference environment variables:
 
 ```json
 { "api_key": "env://OPENAI_API_KEY" }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,7 +12,7 @@ and no email channel will be started. Move the settings to `channels.email`.
 
 ### Required Config Migration
 
-Open `~/.picoclaw/config.json` or `$SUSHICLAW_CONFIG` and move the email block
+Open `~/.picoclaw/config.yaml` or `$SUSHICLAW_CONFIG` and move the email block
 from the top-level `email_channel` key into the `channels` map.
 
 **Before:**

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,186 @@
+{
+  "version": 2,
+  "agents": {
+    "defaults": {
+      "workspace": "~/.picoclaw/workspace",
+      "restrict_to_workspace": true,
+      "model_name": "gpt-4o-mini",
+      "max_tokens": 8192,
+      "context_window": 131072,
+      "temperature": 0.7,
+      "max_tool_iterations": 20,
+      "summarize_message_threshold": 20,
+      "summarize_token_percent": 75
+    }
+  },
+  "model_list": [
+    {
+      "model_name": "gpt-4o-mini",
+      "model": "gpt-4o-mini",
+      "api_key": "env://OPENAI_API_KEY",
+      "api_base": "https://api.openai.com/v1"
+    },
+    {
+      "model_name": "whisper-1",
+      "model": "whisper-1",
+      "api_key": "env://OPENAI_API_KEY",
+      "api_base": "https://api.openai.com/v1"
+    }
+  ],
+  "voice": {
+    "enabled": false,
+    "model_name": "whisper-1",
+    "echo_transcription": false
+  },
+  "sessions": {
+    "directory": "~/.sushiclaw/sessions"
+  },
+  "conversation_lock": {
+    "enabled": false,
+    "standby_auto_lock_minutes": 30,
+    "global_auto_lock_minutes": 480,
+    "ota_expiry_minutes": 10,
+    "max_unlock_attempts": 5,
+    "resend_api_key": "env://RESEND_API_KEY",
+    "from_email": "Sushiclaw <unlock@example.com>",
+    "unlock_email": "example@example.com"
+  },
+  "channels": {
+    "whatsapp_native": {
+      "enabled": false,
+      "use_native": true,
+      "session_store_path": "",
+      "allow_from": [],
+      "group_trigger": {
+        "mention_only": true
+      },
+      "reasoning_channel_id": ""
+    },
+    "telegram": {
+      "enabled": false,
+      "token": "env://TELEGRAM_BOT_TOKEN",
+      "allow_from": [],
+      "group_trigger": {
+        "mention_only": true
+      },
+      "reasoning_channel_id": "",
+      "streaming": {
+        "enabled": true
+      }
+    },
+    "email": {
+      "enabled": false,
+      "type": "email",
+      "smtp_host": "smtp.example.com",
+      "smtp_port": 587,
+      "smtp_from": "bot@example.com",
+      "smtp_user": "",
+      "smtp_password": "env://EMAIL_SMTP_PASSWORD",
+      "default_subject": "Message from sushiclaw",
+      "imap_host": "imap.example.com",
+      "imap_port": 993,
+      "imap_user": "bot@example.com",
+      "imap_password": "env://EMAIL_IMAP_PASSWORD",
+      "poll_interval_secs": 30,
+      "allow_from": [],
+      "reasoning_channel_id": ""
+    },
+    "websocket": {
+      "enabled": false,
+      "type": "websocket",
+      "token": "env://SUSHICLAW_WEBSOCKET_TOKEN",
+      "allow_token_query": false,
+      "allow_origins": ["*"],
+      "ping_interval": 30,
+      "read_timeout": 60,
+      "write_timeout": 30,
+      "max_connections": 100,
+      "port": 18801,
+      "allow_from": ["*"],
+      "placeholder": {
+        "enabled": true,
+        "text": ["Thinking..."]
+      }
+    }
+  },
+  "gateway": {
+    "host": "0.0.0.0",
+    "port": 18800,
+    "log_level": "info",
+    "debug_heartbeat_seconds": 30
+  },
+  "tools": {
+    "web_search": {
+      "enabled": true,
+      "provider": "brave",
+      "max_results": 10,
+      "brave": {
+        "enabled": true,
+        "api_key": "env://BRAVE_API_KEY"
+      },
+      "duckduckgo": {
+        "enabled": false
+      },
+      "browserbase": {
+        "enabled": false,
+        "api_key": "env://BROWSERBASE_API_KEY"
+      },
+      "tavily": {
+        "enabled": false,
+        "api_key": "env://TAVILY_API_KEY"
+      },
+      "baidu": {
+        "enabled": false,
+        "api_key": "env://BAIDU_API_KEY"
+      }
+    },
+    "cron": {
+      "enabled": true,
+      "allow_command": true,
+      "exec_timeout_minutes": 5
+    },
+    "vision": {
+      "enabled": true,
+      "model_name": "gpt-4o-mini",
+      "prompt": "Describe this image in detail."
+    },
+    "message": {
+      "enabled": true,
+      "min_interval_seconds": 5
+    },
+    "media_cleanup": {
+      "enabled": true,
+      "max_age": 30,
+      "interval": 5
+    },
+    "read_file": {
+      "enabled": true
+    },
+    "write_file": {
+      "enabled": true
+    },
+    "list_dir": {
+      "enabled": true
+    }
+  },
+  "mcp": {
+    "mcpServers": {
+      "github": {
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-github"],
+        "env": {
+          "GITHUB_PERSONAL_ACCESS_TOKEN": "env://GITHUB_TOKEN"
+        }
+      },
+      "filesystem": {
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/workspace"]
+      },
+      "browserbase": {
+        "url": "https://mcp.browserbase.com/mcp",
+        "token": "env://BROWSERBASE_API_KEY",
+        "httpTransportMode": "streamable"
+      }
+    }
+  }
+}

--- a/config_example_sushi30_test.go
+++ b/config_example_sushi30_test.go
@@ -12,11 +12,11 @@ import (
 func TestExampleConfigLoadsAsV2(t *testing.T) {
 	_, callerFile, _, _ := runtime.Caller(0)
 	repoRoot := filepath.Dir(callerFile)
-	src := filepath.Join(repoRoot, "config.example.json")
+	src := filepath.Join(repoRoot, "config.example.yaml")
 
 	// Copy to tmpDir so LoadConfig can't mutate the source file
 	tmpDir := t.TempDir()
-	dst := filepath.Join(tmpDir, "config.json")
+	dst := filepath.Join(tmpDir, "config.yaml")
 	data, err := os.ReadFile(src)
 	if err != nil {
 		t.Fatalf("read config.example.json: %v", err)

--- a/docs/CRON.md
+++ b/docs/CRON.md
@@ -6,7 +6,7 @@ workspace at `cron/jobs.json`.
 
 ## Enable The Tool
 
-Enable cron in `config.json`:
+Enable cron in `config.yaml`:
 
 ```json
 {

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -4,11 +4,11 @@ Sushiclaw can connect to [Model Context Protocol (MCP)](https://modelcontextprot
 
 ## Overview
 
-MCP configuration lives in your `config.json` under the `mcp` key. When the agent starts, it reads `mcpServers`, connects to each server, and makes the server's tools available to the agent automatically.
+MCP configuration lives in your `config.yaml` under the `mcp` key. When the agent starts, it reads `mcpServers`, connects to each server, and makes the server's tools available to the agent automatically.
 
 ## Quick Start
 
-Add an `mcp` section to `~/.picoclaw/config.json`:
+Add an `mcp` section to `~/.picoclaw/config.yaml`:
 
 ```json
 {

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	go.mau.fi/whatsmeow v0.0.0-20260219150138-7ae702b1eed4
 	golang.org/x/net v0.53.0
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.48.2
 )
 
@@ -105,7 +106,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251222181119-0a764e51fe1b // indirect
 	google.golang.org/grpc v1.79.3 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.70.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/internal/gateway/config_test.go
+++ b/internal/gateway/config_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/config"
 )
 
-// TestLoadExampleConfig verifies that config.example.json is a valid config
+// TestLoadExampleConfig verifies that config.example.yaml is a valid config
 // that loads without error and has the expected structure.
 func TestLoadExampleConfig(t *testing.T) {
 	// Copy to temp dir so migration writes (backup + saved v2) go there, not source tree.
 	tmpDir := t.TempDir()
-	dst := filepath.Join(tmpDir, "config.json")
+	dst := filepath.Join(tmpDir, "config.yaml")
 
-	src, err := os.Open("../../config.example.json")
+	src, err := os.Open("../../config.example.yaml")
 	if err != nil {
 		t.Fatalf("open example config: %v", err)
 	}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -333,5 +333,5 @@ func GetConfigPath() string {
 	if p := os.Getenv("SUSHICLAW_CONFIG"); p != "" {
 		return p
 	}
-	return filepath.Join(GetHome(), "config.json")
+	return filepath.Join(GetHome(), "config.yaml")
 }

--- a/main.go
+++ b/main.go
@@ -20,8 +20,8 @@ import (
 
 	// Register owned channel implementations.
 	_ "github.com/sushi30/sushiclaw/pkg/channels/email"
-	_ "github.com/sushi30/sushiclaw/pkg/channels/websocket"
 	_ "github.com/sushi30/sushiclaw/pkg/channels/telegram"
+	_ "github.com/sushi30/sushiclaw/pkg/channels/websocket"
 	_ "github.com/sushi30/sushiclaw/pkg/channels/whatsapp_native"
 )
 
@@ -41,6 +41,7 @@ func newRootCommand() *cobra.Command {
 	cmd.AddCommand(newVersionCommand())
 	cmd.AddCommand(newChatCommand())
 	cmd.AddCommand(newCronCommand())
+	cmd.AddCommand(newMigrateConfigCommand())
 	return cmd
 }
 

--- a/migrate_config.go
+++ b/migrate_config.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sushi30/sushiclaw/internal/gateway"
+	"github.com/sushi30/sushiclaw/pkg/config"
+)
+
+func newMigrateConfigCommand() *cobra.Command {
+	var force bool
+
+	cmd := &cobra.Command{
+		Use:   "migrate-config",
+		Short: "Convert a legacy JSON config to YAML",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			destPath := gateway.GetConfigPath()
+			if strings.EqualFold(filepath.Ext(destPath), ".json") {
+				destPath = strings.TrimSuffix(destPath, filepath.Ext(destPath)) + ".yaml"
+			}
+
+			sourcePath := legacyConfigPath(destPath)
+			if _, err := os.Stat(sourcePath); err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("legacy config %q not found", sourcePath)
+				}
+				return fmt.Errorf("check legacy config %q: %w", sourcePath, err)
+			}
+
+			if err := config.MigrateJSONConfig(sourcePath, destPath, force); err != nil {
+				return err
+			}
+
+			fmt.Printf("Migrated %s -> %s\n", sourcePath, destPath)
+			fmt.Printf("Backup saved to %s\n", sourcePath+".bak")
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite the YAML destination and backup if they already exist")
+	return cmd
+}
+
+func legacyConfigPath(destPath string) string {
+	switch strings.ToLower(filepath.Ext(destPath)) {
+	case ".yaml", ".yml":
+		return strings.TrimSuffix(destPath, filepath.Ext(destPath)) + ".json"
+	case ".json":
+		return destPath
+	default:
+		return destPath + ".json"
+	}
+}

--- a/migrate_config_test.go
+++ b/migrate_config_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sushi30/sushiclaw/pkg/config"
+)
+
+func TestMigrateConfigCommand(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SUSHICLAW_HOME", home)
+	t.Setenv("SUSHICLAW_CONFIG", "")
+
+	sourcePath := filepath.Join(home, "config.json")
+	data, err := os.ReadFile("config.example.json")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(sourcePath, data, 0o600))
+
+	cmd := newMigrateConfigCommand()
+	cmd.SetArgs(nil)
+	require.NoError(t, cmd.Execute())
+
+	destPath := filepath.Join(home, "config.yaml")
+	_, err = os.Stat(destPath)
+	require.NoError(t, err)
+
+	backupPath := sourcePath + ".bak"
+	_, err = os.Stat(backupPath)
+	require.NoError(t, err)
+
+	cfg, err := config.LoadConfig(destPath)
+	require.NoError(t, err)
+	require.Equal(t, "gpt-4o-mini", cfg.Agents.Defaults.ModelName)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,11 +1,16 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Channel type constants.
@@ -55,13 +60,16 @@ type AgentsConfig struct {
 }
 
 type AgentDefaults struct {
-	ModelName           string        `json:"model_name"`
-	Workspace           string        `json:"workspace"`
-	RestrictToWorkspace bool          `json:"restrict_to_workspace"`
-	MaxTokens           int           `json:"max_tokens"`
-	Temperature         float64       `json:"temperature"`
-	MaxToolIterations   int           `json:"max_tool_iterations"`
-	Summary             SummaryConfig `json:"summary,omitempty"`
+	ModelName                 string        `json:"model_name"`
+	Workspace                 string        `json:"workspace"`
+	RestrictToWorkspace       bool          `json:"restrict_to_workspace"`
+	MaxTokens                 int           `json:"max_tokens"`
+	ContextWindow             int           `json:"context_window,omitempty"`
+	Temperature               float64       `json:"temperature"`
+	MaxToolIterations         int           `json:"max_tool_iterations"`
+	SummarizeMessageThreshold int           `json:"summarize_message_threshold,omitempty"`
+	SummarizeTokenPercent     int           `json:"summarize_token_percent,omitempty"`
+	Summary                   SummaryConfig `json:"summary,omitempty"`
 }
 
 type SummaryConfig struct {
@@ -364,20 +372,69 @@ func (b *Channel) Decode(target any) error {
 
 // UnmarshalJSON stores raw bytes and unmarshals common fields.
 func (b *Channel) UnmarshalJSON(data []byte) error {
-	b.raw = data
+	b.raw = append(b.raw[:0], data...)
 	type Alias Channel
 	return json.Unmarshal(data, (*Alias)(b))
 }
 
 // LoadConfig loads sushiclaw config from path.
 func LoadConfig(path string) (*Config, error) {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".json":
+		return nil, fmt.Errorf("config %q uses unsupported JSON format; run `sushiclaw migrate-config` to convert it to YAML", path)
+	case ".yaml", ".yml", "":
+		return loadYAMLConfig(path)
+	default:
+		return loadYAMLConfig(path)
+	}
+}
+
+// LoadJSONConfig loads a legacy JSON config for migration purposes.
+func LoadJSONConfig(path string) (*Config, error) {
+	return loadJSONConfig(path)
+}
+
+func loadYAMLConfig(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read config: %w", err)
 	}
+	var raw any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse config %q as YAML: %w", path, err)
+	}
+	return decodeConfigFromAny(raw, path)
+}
+
+func loadJSONConfig(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+	return decodeConfigJSON(data, path)
+}
+
+func decodeConfigFromAny(raw any, source string) (*Config, error) {
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("normalize config %q: %w", source, err)
+	}
+	return decodeConfigJSON(data, source)
+}
+
+func decodeConfigJSON(data []byte, source string) (*Config, error) {
 	var cfg Config
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parse config: %w", err)
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("parse config %q: %w", source, err)
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("parse config %q: unexpected trailing data", source)
+		}
+		return nil, fmt.Errorf("parse config %q: %w", source, err)
 	}
 	for name, ch := range cfg.Channels {
 		if ch == nil {

--- a/pkg/config/config_extra_test.go
+++ b/pkg/config/config_extra_test.go
@@ -64,7 +64,7 @@ func TestFlexibleStringSlice_Array(t *testing.T) {
 }
 
 func TestChannel_Name(t *testing.T) {
-	cfg, err := config.LoadConfig("../../config.example.json")
+	cfg, err := config.LoadConfig("../../config.example.yaml")
 	require.NoError(t, err)
 
 	tgCh := cfg.Channels["telegram"]
@@ -131,7 +131,7 @@ func TestLoadConfig_MissingFile(t *testing.T) {
 
 func TestLoadConfig_ValidFile(t *testing.T) {
 	tmpDir := t.TempDir()
-	cfgPath := filepath.Join(tmpDir, "config.json")
+	cfgPath := filepath.Join(tmpDir, "config.yaml")
 	data := []byte(`{
 		"version": 2,
 		"agents": {"defaults": {"model_name": "test-model", "workspace": "/tmp", "restrict_to_workspace": false, "max_tokens": 1000, "temperature": 0.5, "max_tool_iterations": 5, "summary": {"enabled": true, "token_trigger": 32000, "model": "summary-model"}}},
@@ -152,6 +152,34 @@ func TestLoadConfig_ValidFile(t *testing.T) {
 	assert.Equal(t, "summary-model", cfg.Agents.Defaults.Summary.Model)
 	assert.Equal(t, 8080, cfg.Gateway.Port)
 	assert.NotNil(t, cfg.Channels["telegram"])
+	assert.Equal(t, "telegram", cfg.Channels["telegram"].Name())
+}
+
+func TestLoadConfig_JSONRejected(t *testing.T) {
+	_, err := config.LoadConfig("../../config.example.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported JSON format")
+}
+
+func TestMigrateJSONConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	sourcePath := filepath.Join(tmpDir, "config.json")
+	destPath := filepath.Join(tmpDir, "config.yaml")
+
+	data, err := os.ReadFile("../../config.example.json")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(sourcePath, data, 0o600))
+
+	require.NoError(t, config.MigrateJSONConfig(sourcePath, destPath, false))
+
+	backupPath := sourcePath + ".bak"
+	backupData, err := os.ReadFile(backupPath)
+	require.NoError(t, err)
+	assert.Equal(t, data, backupData)
+
+	cfg, err := config.LoadConfig(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, "gpt-4o-mini", cfg.Agents.Defaults.ModelName)
 	assert.Equal(t, "telegram", cfg.Channels["telegram"].Name())
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestParseExampleConfig(t *testing.T) {
-	cfg, err := config.LoadConfig("../../config.example.json")
+	cfg, err := config.LoadConfig("../../config.example.yaml")
 	require.NoError(t, err)
 
 	assert.Equal(t, "gpt-4o-mini", cfg.Agents.Defaults.ModelName)
@@ -22,7 +22,7 @@ func TestParseExampleConfig(t *testing.T) {
 }
 
 func TestChannelDecode(t *testing.T) {
-	cfg, err := config.LoadConfig("../../config.example.json")
+	cfg, err := config.LoadConfig("../../config.example.yaml")
 	require.NoError(t, err)
 
 	tgCh := cfg.Channels["telegram"]
@@ -42,7 +42,7 @@ func TestSecureStringEnvResolve(t *testing.T) {
 }
 
 func TestFlexibleStringSlice(t *testing.T) {
-	cfg, err := config.LoadConfig("../../config.example.json")
+	cfg, err := config.LoadConfig("../../config.example.yaml")
 	require.NoError(t, err)
 
 	tgCh := cfg.Channels["telegram"]
@@ -52,7 +52,7 @@ func TestFlexibleStringSlice(t *testing.T) {
 }
 
 func TestMCPConfigParsing(t *testing.T) {
-	cfg, err := config.LoadConfig("../../config.example.json")
+	cfg, err := config.LoadConfig("../../config.example.yaml")
 	require.NoError(t, err)
 
 	require.NotEmpty(t, cfg.MCP.MCPServers)

--- a/pkg/config/migrate.go
+++ b/pkg/config/migrate.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MigrateJSONConfig converts a legacy JSON config to YAML, preserving the JSON
+// source as a backup alongside the new file.
+func MigrateJSONConfig(sourcePath, destPath string, force bool) error {
+	if !force {
+		if _, err := os.Stat(destPath); err == nil {
+			return fmt.Errorf("destination config %q already exists", destPath)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("check destination config %q: %w", destPath, err)
+		}
+	}
+
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return fmt.Errorf("read legacy config %q: %w", sourcePath, err)
+	}
+
+	if _, err := LoadJSONConfig(sourcePath); err != nil {
+		return err
+	}
+
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return fmt.Errorf("convert legacy config %q to YAML: %w", sourcePath, err)
+	}
+
+	out, err := yaml.Marshal(&node)
+	if err != nil {
+		return fmt.Errorf("render YAML config %q: %w", destPath, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+		return fmt.Errorf("create config directory for %q: %w", destPath, err)
+	}
+
+	backupPath := sourcePath + ".bak"
+	if !force {
+		if _, err := os.Stat(backupPath); err == nil {
+			return fmt.Errorf("backup config %q already exists", backupPath)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("check backup config %q: %w", backupPath, err)
+		}
+	}
+
+	if err := os.WriteFile(backupPath, data, 0o600); err != nil {
+		return fmt.Errorf("write backup config %q: %w", backupPath, err)
+	}
+	if err := os.WriteFile(destPath, out, 0o600); err != nil {
+		return fmt.Errorf("write YAML config %q: %w", destPath, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- Switch runtime config loading to YAML and make `config.yaml` the default path.
- Add `sushiclaw migrate-config` to convert legacy JSON configs to YAML with a backup.
- Update example config, docs, and tests to reflect the new format.

## Test Plan
- `go test ./...`
- `make lint`

## Issue
- Fixes #68