### PR TITLE
Fix cron scheduling robustness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,14 @@ All channels and the agent share a single `MessageBus`. The gateway runs one gor
 processing (filter → executor/agent) and the channel manager runs one goroutine for outbound
 dispatch (placeholder editing, typing stops, reaction undos, normal sends).
 
+### Context propagation
+
+Long-running services and goroutines should inherit a `context.Context` from their parent execution
+path so gateway shutdown can cancel in-flight work cleanly. Do not use `context.Background()` inside
+services except when creating the root process context or in tests/helpers that have no parent
+context. Any non-root use of `context.Background()` must include a comment explaining why it cannot
+inherit a parent context.
+
 ## Build commands
 
 ```bash

--- a/config.example.json
+++ b/config.example.json
@@ -137,7 +137,8 @@
     "cron": {
       "enabled": true,
       "allow_command": true,
-      "exec_timeout_minutes": 5
+      "exec_timeout_minutes": 5,
+      "timezone": "Europe/Amsterdam"
     },
     "vision": {
       "enabled": true,

--- a/docs/CRON.md
+++ b/docs/CRON.md
@@ -14,7 +14,8 @@ Enable cron in `config.json`:
     "cron": {
       "enabled": true,
       "allow_command": false,
-      "exec_timeout_minutes": 5
+      "exec_timeout_minutes": 5,
+      "timezone": "Europe/Amsterdam"
     }
   }
 }
@@ -31,6 +32,10 @@ Cron jobs support three schedule types:
 - `every_seconds`: run repeatedly at an interval.
 - `cron_expr`: run on a standard cron expression.
 
+`cron_expr` uses local wall-clock time in the job `timezone`. If no timezone is supplied when the
+job is created, the scheduler uses `tools.cron.timezone`, then falls back to `UTC`. Do not convert
+requested local times to UTC before writing the cron expression.
+
 Jobs can run in three modes:
 
 - Agent turn: sends the saved prompt back through the agent, so the model can reason and use tools.
@@ -39,6 +44,10 @@ Jobs can run in three modes:
 
 The agent fills in the channel, chat ID, and sender ID from the conversation where the job is
 created.
+
+The scheduler persists execution state in `cron/jobs.json`: next run, running marker, last run
+status, last error, duration, and consecutive errors. On gateway restart it marks stale running jobs
+as interrupted and catches up a bounded number of missed jobs.
 
 ## Example Prompts
 
@@ -76,6 +85,14 @@ Disable the weekly-review cron job.
 Remove the weekly-review cron job.
 ```
 
+```text
+Run the weekly-review cron job now.
+```
+
+```text
+Show cron status.
+```
+
 If command jobs are enabled:
 
 ```text
@@ -91,6 +108,7 @@ Use `/list cron` to list scheduled cron jobs without asking the agent to use the
 ```
 
 The response shows each job name, whether it is disabled, how it runs, and its schedule.
+It also includes next run, last status, and last error when available.
 
 ## CLI
 

--- a/docs/CRON.md
+++ b/docs/CRON.md
@@ -1,8 +1,12 @@
 # Cron Jobs
 
-sushiclaw can schedule future agent turns, direct channel messages, or optional shell commands through
-the `cron` tool. The scheduler runs inside `sushiclaw gateway` and stores jobs in the configured
-workspace at `cron/jobs.json`.
+sushiclaw can schedule future agent turns, direct channel messages, or optional
+shell commands through the `cron` tool. The scheduler runs inside
+`sushiclaw gateway` and stores jobs in the configured workspace at
+`cron/jobs.json`.
+
+See [the cron architecture doc](architecture/CRON.md) for the runtime
+architecture and state-flow diagrams.
 
 ## Enable The Tool
 
@@ -21,8 +25,8 @@ Enable cron in `config.json`:
 }
 ```
 
-`allow_command` controls whether cron jobs may run shell commands. Keep it disabled unless the
-configured workspace and allowed senders are trusted.
+`allow_command` controls whether cron jobs may run shell commands. Keep it
+disabled unless the configured workspace and allowed senders are trusted.
 
 ## How Jobs Run
 
@@ -32,22 +36,27 @@ Cron jobs support three schedule types:
 - `every_seconds`: run repeatedly at an interval.
 - `cron_expr`: run on a standard cron expression.
 
-`cron_expr` uses local wall-clock time in the job `timezone`. If no timezone is supplied when the
-job is created, the scheduler uses `tools.cron.timezone`, then falls back to `UTC`. Do not convert
-requested local times to UTC before writing the cron expression.
+`cron_expr` uses local wall-clock time in the job `timezone`. If no timezone
+is supplied when the job is created, the scheduler uses
+`tools.cron.timezone`, then falls back to `UTC`. Do not convert requested
+local times to UTC before writing the cron expression.
 
 Jobs can run in three modes:
 
-- Agent turn: sends the saved prompt back through the agent, so the model can reason and use tools.
-- Direct delivery: sends the saved message directly to the original channel without an agent turn.
-- Command: runs a shell command and sends the command output back to the original channel.
+- Agent turn: sends the saved prompt back through the agent, so the model can
+  reason and use tools.
+- Direct delivery: sends the saved message directly to the original channel
+  without an agent turn.
+- Command: runs a shell command and sends the command output back to the
+  original channel.
 
-The agent fills in the channel, chat ID, and sender ID from the conversation where the job is
-created.
+The agent fills in the channel, chat ID, and sender ID from the conversation
+where the job is created.
 
-The scheduler persists execution state in `cron/jobs.json`: next run, running marker, last run
-status, last error, duration, and consecutive errors. On gateway restart it marks stale running jobs
-as interrupted and catches up a bounded number of missed jobs.
+The scheduler persists execution state in `cron/jobs.json`: next run, running
+marker, last run status, last error, duration, and consecutive errors. On
+gateway restart it marks stale running jobs as interrupted and catches up a
+bounded number of missed jobs.
 
 ## Example Prompts
 
@@ -66,11 +75,13 @@ Schedule a direct message every 30 minutes that says "drink water".
 ```
 
 ```text
-At 18:00 on weekdays, run an agent check-in: summarize my open priorities and ask what changed.
+At 18:00 on weekdays, run an agent check-in: summarize my open priorities and
+ask what changed.
 ```
 
 ```text
-Create a cron job named weekly-review for Mondays at 08:30 that asks me to review last week's notes.
+Create a cron job named weekly-review for Mondays at 08:30 that asks me to
+review last week's notes.
 ```
 
 ```text
@@ -101,24 +112,27 @@ Every hour, run `git -C /home/imri/workspace status --short` and send me the out
 
 ## Slash Commands
 
-Use `/list cron` to list scheduled cron jobs without asking the agent to use the tool:
+Use `/list cron` to list scheduled cron jobs without asking the agent to use
+the tool:
 
 ```text
 /list cron
 ```
 
-The response shows each job name, whether it is disabled, how it runs, and its schedule.
-It also includes next run, last status, and last error when available.
+The response shows each job name, whether it is disabled, how it runs, and its
+schedule. It also includes next run, last status, and last error when
+available.
 
 ## CLI
 
 Cron jobs can also be managed from the binary:
 
 ```bash
-sushiclaw cron add --name daily-check --message "What should I focus on today?" --cron "0 9 * * *" --channel telegram --chat-id 12345
+sushiclaw cron add --name daily-check --message "What should I focus on
+today?" --cron "0 9 * * *" --channel telegram --chat-id 12345
 sushiclaw cron list
 sushiclaw cron remove daily-check
 ```
 
-CLI-created jobs are persisted immediately. Restart a running gateway after adding jobs through the
-CLI so the scheduler loads them.
+CLI-created jobs are persisted immediately. Restart a running gateway after
+adding jobs through the CLI so the scheduler loads them.

--- a/docs/architecture/CRON.md
+++ b/docs/architecture/CRON.md
@@ -1,0 +1,108 @@
+# Cron Architecture
+
+This document describes how `sushiclaw` cron jobs work in the current MVP
+implementation.
+
+## Overview
+
+Cron runs inside `sushiclaw gateway`, not as a separate daemon. The gateway
+loads jobs from the workspace, keeps scheduler state in memory, and persists
+job state back to `cron/jobs.json`.
+
+Each job stores:
+
+- Schedule fields: `at_seconds`, `every_seconds`, or `cron_expr`
+- Routing fields: `channel`, `chat_id`, `sender_id`, and optional saved
+  `context`
+- Runtime state: `next_run_at`, `running_at`, `last_run_at`, `last_status`,
+  `last_error`
+
+The scheduler supports three execution modes:
+
+- Agent turn: send the saved message back through the agent session
+- Direct delivery: send the saved message directly to the channel
+- Command: run a shell command and send the output back as a system message
+
+Cron expressions are interpreted as local wall-clock time in the job
+timezone. If no timezone is supplied, the scheduler uses the configured cron
+timezone, then falls back to `UTC`.
+
+## Components
+
+- `pkg/cron/store.go` loads and saves the job list
+- `pkg/cron/scheduler.go` computes next runs, arms timers, executes jobs, and
+  persists results
+- `pkg/cron/tool.go` exposes the agent-facing `cron` tool
+- `internal/agent/session.go` provides a synchronous cron execution path for
+  agent turns
+- `internal/gateway/gateway.go` wires the scheduler into the gateway and
+  starts it with the rest of the runtime
+
+## Adding A Job
+
+When the agent or CLI adds a cron job, the scheduler:
+
+1. Validates the job shape and required fields
+2. Normalizes the routing context from the originating conversation
+3. Resolves a timezone for cron expressions
+4. Computes the first `next_run_at`
+5. Persists the job to `cron/jobs.json`
+6. Re-arms the single scheduler timer for the earliest due job
+
+```mermaid
+flowchart TD
+  U[User request] --> A[Cron tool]
+  A --> V[Validate input]
+  V --> C[Capture routing context]
+  C --> T[Resolve timezone]
+  T --> N[Compute next run]
+  N --> S[Persist job state]
+  S --> R[Re-arm scheduler timer]
+  R --> X[Job becomes visible in /list cron]
+```
+
+## State Management
+
+The scheduler keeps job state in the store so restarts do not lose progress.
+The state lifecycle is:
+
+1. Load jobs at startup
+2. Recompute `next_run_at` for enabled jobs
+3. Mark stale `running_at` jobs as interrupted on restart
+4. Arm a timer for the nearest job
+5. Claim the next due job by setting `running_at`
+6. Execute the job outside the store lock
+7. Persist `last_status`, `last_error`, `last_run_at`, and the next `next_run_at`
+8. Repeat
+
+```mermaid
+stateDiagram-v2
+  [*] --> Loaded
+  Loaded --> Scheduled: compute next_run_at
+  Scheduled --> Due: timer fires
+  Due --> Running: claim job / set running_at
+  Running --> Succeeded: execution ok
+  Running --> Failed: execution error
+  Succeeded --> Scheduled: persist result / recompute next run
+  Failed --> Scheduled: persist result / recompute next run
+  Scheduled --> Interrupted: process restart with running_at set
+  Interrupted --> Scheduled: mark interrupted / recompute next run
+```
+
+## Failure Handling
+
+- Invalid schedule expressions are recorded as schedule errors and surfaced
+  in the job state
+- Missing routing context causes the run to be skipped and reported as an error
+- Agent turn failures are returned synchronously so cron can mark the job failed
+- Command failures are returned after the command output is captured and sent
+- One-shot `at_seconds` jobs are disabled after a successful run
+
+## Practical Result
+
+This design gives the MVP the important properties it was missing:
+
+- jobs survive restarts
+- the next run is visible and persisted
+- a stuck or crashed run is visible in state
+- cron can report success or failure instead of silently queueing work

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/channels"
 	"github.com/sushi30/sushiclaw/pkg/commands"
 	"github.com/sushi30/sushiclaw/pkg/config"
+	cronpkg "github.com/sushi30/sushiclaw/pkg/cron"
 	"github.com/sushi30/sushiclaw/pkg/llm/openrouter"
 	"github.com/sushi30/sushiclaw/pkg/logger"
 	"github.com/sushi30/sushiclaw/pkg/media"
@@ -519,6 +520,98 @@ func (sm *SessionManager) Dispatch(ctx context.Context, msg bus.InboundMessage) 
 	}
 	turnCtx, turnSeq, turnDone := s.startTurn(ctx)
 	s.handleInbound(turnCtx, msg, key, turnSeq, turnDone)
+}
+
+// RunCronAgentTurn executes an agent turn synchronously for the cron scheduler.
+// Cron needs a concrete success/failure result; publishing onto the inbound bus
+// only proves that a message was queued, not that the agent completed.
+func (sm *SessionManager) RunCronAgentTurn(ctx context.Context, msg bus.InboundMessage) (cronpkg.AgentRunResult, error) {
+	key := computeSessionKey(msg)
+	s, err := sm.getOrCreateSession(key)
+	if err != nil {
+		if sm.bus != nil {
+			_ = sm.bus.PublishOutbound(ctx, bus.MarkSystemOutboundMessage(bus.OutboundMessage{
+				Channel: msg.Channel,
+				ChatID:  msg.ChatID,
+				Context: msg.Context,
+				Content: fmt.Sprintf("Cron agent turn failed before start: %v", err),
+			}))
+		}
+		return cronpkg.AgentRunResult{}, err
+	}
+	turnCtx, turnSeq, turnDone := s.startTurn(ctx)
+	defer s.finishTurn(turnSeq, turnDone)
+
+	chatID := msg.ChatID
+	actx := exec.WithChatID(turnCtx, chatID)
+	actx = toolctx.WithChannel(actx, msg.Channel)
+	actx = toolctx.WithSenderID(actx, msg.SenderID)
+	actx = toolctx.WithInboundContext(actx, msg.Context)
+
+	logger.DebugCF("agent", "Processing cron message", map[string]any{
+		"chat_id": chatID,
+		"sender":  msg.Sender.CanonicalID,
+		"preview": truncate(msg.Content, 50),
+	})
+	start := time.Now()
+	sm.emitProgress(turnCtx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressTurnStarted})
+	response, usage, toolCalls, err := s.runDetailedTurn(actx, msg.Content)
+	elapsed := time.Since(start)
+	responseBytes := len(response)
+	if err != nil {
+		if s.turnCanceled(turnCtx, turnSeq, err) {
+			return cronpkg.AgentRunResult{}, err
+		}
+		logger.ErrorCF("agent", "Cron agent run failed", map[string]any{"error": err.Error()})
+		s.logTurnSummary(msg.Channel, chatID, elapsed, usage, toolCalls, responseBytes, err)
+		if sm.bus != nil {
+			_ = sm.bus.PublishOutbound(turnCtx, bus.MarkSystemOutboundMessage(bus.OutboundMessage{
+				Channel:    msg.Channel,
+				ChatID:     chatID,
+				Context:    msg.Context,
+				SessionKey: key,
+				Content:    userFacingRunError(err),
+			}))
+		}
+		sm.emitProgress(turnCtx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressFailed, Error: err, Elapsed: elapsed})
+		sm.emitSummary(turnCtx, ProgressSummary{
+			Channel:       msg.Channel,
+			ChatID:        chatID,
+			Success:       false,
+			ToolCalls:     toolCalls,
+			Usage:         usage,
+			Duration:      elapsed,
+			ResponseBytes: responseBytes,
+			Error:         err,
+		})
+		return cronpkg.AgentRunResult{Response: response, ToolCalls: toolCalls, ResponseBytes: responseBytes}, err
+	}
+	if s.turnCanceled(turnCtx, turnSeq, nil) {
+		return cronpkg.AgentRunResult{}, context.Canceled
+	}
+	if response != "" && sm.bus != nil {
+		if err := sm.bus.PublishOutbound(turnCtx, bus.OutboundMessage{
+			Channel:    msg.Channel,
+			ChatID:     chatID,
+			Context:    msg.Context,
+			SessionKey: key,
+			Content:    response,
+		}); err != nil {
+			return cronpkg.AgentRunResult{Response: response, ToolCalls: toolCalls, ResponseBytes: responseBytes}, err
+		}
+	}
+	s.logTurnSummary(msg.Channel, chatID, elapsed, usage, toolCalls, responseBytes, nil)
+	sm.emitProgress(turnCtx, ProgressEvent{Channel: msg.Channel, ChatID: chatID, Kind: ProgressCompleted, Elapsed: elapsed})
+	sm.emitSummary(turnCtx, ProgressSummary{
+		Channel:       msg.Channel,
+		ChatID:        chatID,
+		Success:       true,
+		ToolCalls:     toolCalls,
+		Usage:         usage,
+		Duration:      elapsed,
+		ResponseBytes: responseBytes,
+	})
+	return cronpkg.AgentRunResult{Response: response, ToolCalls: toolCalls, ResponseBytes: responseBytes}, nil
 }
 
 func computeSessionKey(msg bus.InboundMessage) string {

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -182,20 +182,21 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 		fmt.Println("Warning: no channels enabled")
 	}
 
-	if err = cm.StartAll(context.Background()); err != nil {
+	// Root gateway context; child services inherit this so shutdown cancels work.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err = cm.StartAll(ctx); err != nil {
 		return fmt.Errorf("error starting channels: %w", err)
 	}
 
 	if cronScheduler != nil {
-		cronScheduler.Start()
+		cronScheduler.Start(ctx)
 		logger.InfoC("gateway", "Cron scheduler started")
 	}
 
 	fmt.Printf("Gateway started\n")
 	fmt.Println("Press Ctrl+C to stop")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	rt.SetDebug = dm.Set
 	lockController.Register(rt)
@@ -307,11 +308,13 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	<-sigChan
 
 	logger.Info("Shutting down...")
+	cancel()
 
 	if cronScheduler != nil {
 		cronScheduler.Stop()
 	}
 
+	// Shutdown has its own timeout because the root gateway context is already canceled.
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 	defer shutdownCancel()
 	_ = cm.StopAll(shutdownCtx)

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -153,6 +153,9 @@ func Run(debug bool, homePath, configPath string, allowEmptyStartup bool) error 
 	if sessionMgr != nil {
 		sessionMgr.Start()
 		defer sessionMgr.Stop()
+		if cronScheduler != nil {
+			cronScheduler.SetAgentRunner(sessionMgr)
+		}
 	}
 
 	if sessionMgr != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -145,9 +145,10 @@ type ExecToolConfig struct {
 }
 
 type CronToolConfig struct {
-	Enabled            bool `json:"enabled"`
-	AllowCommand       bool `json:"allow_command"`
-	ExecTimeoutMinutes int  `json:"exec_timeout_minutes"`
+	Enabled            bool   `json:"enabled"`
+	AllowCommand       bool   `json:"allow_command"`
+	ExecTimeoutMinutes int    `json:"exec_timeout_minutes"`
+	Timezone           string `json:"timezone,omitempty"`
 }
 
 type MediaCleanupCfg struct {

--- a/pkg/cron/format.go
+++ b/pkg/cron/format.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // FormatJobs renders cron jobs for chat and CLI surfaces.
@@ -30,8 +31,29 @@ func FormatJobs(jobs []Job) string {
 			fmt.Fprintf(&sb, " every %ds", *j.EverySeconds)
 		} else if j.CronExpr != "" {
 			fmt.Fprintf(&sb, " cron: %s", j.CronExpr)
+			if j.Timezone != "" {
+				fmt.Fprintf(&sb, " tz: %s", j.Timezone)
+			}
+		}
+		if j.State.NextRunAt != nil {
+			fmt.Fprintf(&sb, " next: %s", formatJobTime(*j.State.NextRunAt, j.Timezone))
+		}
+		if j.State.LastStatus != "" {
+			fmt.Fprintf(&sb, " last: %s", j.State.LastStatus)
+		}
+		if j.State.LastError != "" {
+			fmt.Fprintf(&sb, " error: %s", j.State.LastError)
 		}
 		sb.WriteByte('\n')
 	}
 	return strings.TrimRight(sb.String(), "\n")
+}
+
+func formatJobTime(t time.Time, timezone string) string {
+	if timezone != "" {
+		if loc, err := time.LoadLocation(timezone); err == nil {
+			return t.In(loc).Format(time.RFC3339)
+		}
+	}
+	return t.UTC().Format(time.RFC3339)
 }

--- a/pkg/cron/models.go
+++ b/pkg/cron/models.go
@@ -17,8 +17,33 @@ type Job struct {
 	AtSeconds    *int               `json:"at_seconds,omitempty"`
 	EverySeconds *int               `json:"every_seconds,omitempty"`
 	CronExpr     string             `json:"cron_expr,omitempty"`
+	Timezone     string             `json:"timezone,omitempty"`
 	Deliver      bool               `json:"deliver"`
 	Command      string             `json:"command,omitempty"`
 	Enabled      bool               `json:"enabled"`
 	CreatedAt    time.Time          `json:"created_at"`
+	State        JobState           `json:"state,omitempty"`
 }
+
+// JobState is persisted scheduler bookkeeping. It makes cron observable across
+// restarts instead of relying on process-local timers.
+type JobState struct {
+	NextRunAt         *time.Time `json:"next_run_at,omitempty"`
+	RunningAt         *time.Time `json:"running_at,omitempty"`
+	LastRunAt         *time.Time `json:"last_run_at,omitempty"`
+	LastStatus        string     `json:"last_status,omitempty"`
+	LastError         string     `json:"last_error,omitempty"`
+	LastDurationMS    int64      `json:"last_duration_ms,omitempty"`
+	ConsecutiveErrors int        `json:"consecutive_errors,omitempty"`
+}
+
+type StoreFile struct {
+	Version int   `json:"version"`
+	Jobs    []Job `json:"jobs"`
+}
+
+const (
+	StatusOK      = "ok"
+	StatusError   = "error"
+	StatusSkipped = "skipped"
+)

--- a/pkg/cron/scheduler.go
+++ b/pkg/cron/scheduler.go
@@ -42,6 +42,7 @@ type Scheduler struct {
 	bus         *bus.MessageBus
 	cfg         *config.Config
 	agentRunner AgentRunner
+	ctx         context.Context
 	started     bool
 	stopped     bool
 	mu          sync.Mutex
@@ -76,12 +77,16 @@ func (s *Scheduler) SetAgentRunner(r AgentRunner) {
 }
 
 // Start begins the cron runner.
-func (s *Scheduler) Start() {
+func (s *Scheduler) Start(ctx context.Context) {
 	s.mu.Lock()
 	if s.started {
 		s.mu.Unlock()
 		return
 	}
+	if ctx == nil {
+		ctx = context.TODO()
+	}
+	s.ctx = ctx
 	s.started = true
 	s.stopped = false
 	s.mu.Unlock()
@@ -246,6 +251,10 @@ func (s *Scheduler) Status() (string, error) {
 }
 
 func (s *Scheduler) RunJob(name string, force bool) error {
+	ctx, ok := s.executionContext()
+	if !ok {
+		return fmt.Errorf("cron scheduler is not started")
+	}
 	job, ok, err := s.claimJob(name, time.Now(), force)
 	if err != nil {
 		return err
@@ -253,13 +262,17 @@ func (s *Scheduler) RunJob(name string, force bool) error {
 	if !ok {
 		return fmt.Errorf("job %q is not due", name)
 	}
-	go s.executeClaimedJob(job)
+	go s.executeClaimedJob(ctx, job)
 	return nil
 }
 
 func (s *Scheduler) tick() {
 	now := time.Now()
 	for {
+		ctx, ok := s.executionContext()
+		if !ok {
+			break
+		}
 		job, ok, err := s.claimNextDueJob(now)
 		if err != nil {
 			logger.ErrorCF("cron", "Failed to claim due job", map[string]any{"error": err.Error()})
@@ -268,7 +281,7 @@ func (s *Scheduler) tick() {
 		if !ok {
 			break
 		}
-		go s.executeClaimedJob(job)
+		go s.executeClaimedJob(ctx, job)
 	}
 
 	s.mu.Lock()
@@ -335,16 +348,16 @@ func (s *Scheduler) claimJob(name string, now time.Time, force bool) (Job, bool,
 	return Job{}, false, fmt.Errorf("job %q not found", name)
 }
 
-func (s *Scheduler) executeClaimedJob(job Job) {
+func (s *Scheduler) executeClaimedJob(ctx context.Context, job Job) {
 	start := time.Now()
-	err := s.runJob(context.Background(), job)
+	err := s.runJob(ctx, job)
 	status := StatusOK
 	errText := ""
 	if err != nil {
 		status = StatusError
 		errText = err.Error()
 		logger.ErrorCF("cron", "Cron job failed", map[string]any{"job": job.Name, "error": errText})
-		s.notifyFailure(context.Background(), job, errText)
+		s.notifyFailure(ctx, job, errText)
 	}
 	s.finishJob(job.Name, status, errText, start, time.Now())
 }
@@ -352,7 +365,7 @@ func (s *Scheduler) executeClaimedJob(job Job) {
 // executeJob is retained for focused tests and manual execution paths.
 func (s *Scheduler) executeJob(job Job) {
 	start := time.Now()
-	err := s.runJob(context.Background(), job)
+	err := s.runJob(context.TODO(), job)
 	status := StatusOK
 	errText := ""
 	if err != nil {
@@ -425,6 +438,15 @@ func (s *Scheduler) finishJob(name, status, errText string, startedAt, endedAt t
 		logger.ErrorCF("cron", "Failed to save job result", map[string]any{"job": name, "error": err.Error()})
 		return
 	}
+	fields := map[string]any{
+		"job":         name,
+		"status":      status,
+		"duration_ms": endedAt.Sub(startedAt).Milliseconds(),
+	}
+	if errText != "" {
+		fields["error"] = errText
+	}
+	logger.DebugCF("cron", "Cron job finished", fields)
 	s.armTimerLocked(time.Now())
 }
 
@@ -541,6 +563,10 @@ func (s *Scheduler) markInterruptedRuns() {
 }
 
 func (s *Scheduler) runMissedJobs() {
+	ctx, ok := s.executionContext()
+	if !ok {
+		return
+	}
 	for i := 0; i < defaultStartupCatchupLimit; i++ {
 		job, ok, err := s.claimNextDueJob(time.Now())
 		if err != nil {
@@ -551,10 +577,27 @@ func (s *Scheduler) runMissedJobs() {
 			return
 		}
 		delay := time.Duration(i) * defaultStartupCatchupStagger
-		time.AfterFunc(delay, func() {
-			s.executeClaimedJob(job)
-		})
+		go func(job Job, delay time.Duration) {
+			timer := time.NewTimer(delay)
+			defer timer.Stop()
+			select {
+			case <-ctx.Done():
+				now := time.Now()
+				s.finishJob(job.Name, StatusError, ctx.Err().Error(), now, now)
+			case <-timer.C:
+				s.executeClaimedJob(ctx, job)
+			}
+		}(job, delay)
 	}
+}
+
+func (s *Scheduler) executionContext() (context.Context, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopped || s.ctx == nil {
+		return nil, false
+	}
+	return s.ctx, true
 }
 
 func (s *Scheduler) recomputeNextRunsLocked(jobs []Job, now time.Time, recomputeExisting bool) bool {

--- a/pkg/cron/scheduler.go
+++ b/pkg/cron/scheduler.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -14,18 +15,39 @@ import (
 	"github.com/sushi30/sushiclaw/pkg/tools/exec"
 )
 
-// Scheduler manages the lifecycle and execution of cron jobs.
-type Scheduler struct {
-	store   *Store
-	cron    *cron.Cron
-	timers  map[string]*time.Timer
-	entries map[string]cron.EntryID
-	bus     *bus.MessageBus
-	cfg     *config.Config
-	mu      sync.RWMutex
+const (
+	defaultTimezone               = "UTC"
+	startupInterruptedError       = "cron: job interrupted by gateway restart"
+	defaultStartupCatchupLimit    = 5
+	defaultStartupCatchupStagger  = 5 * time.Second
+	defaultSchedulerMaxTimerDelay = time.Minute
+)
+
+// AgentRunner executes cron agent turns synchronously so the scheduler can
+// persist success/failure instead of only enqueueing an inbound message.
+type AgentRunner interface {
+	RunCronAgentTurn(ctx context.Context, msg bus.InboundMessage) (AgentRunResult, error)
 }
 
-// NewScheduler loads existing jobs and schedules enabled ones.
+type AgentRunResult struct {
+	Response      string
+	ToolCalls     int
+	ResponseBytes int
+}
+
+// Scheduler manages the lifecycle and execution of cron jobs.
+type Scheduler struct {
+	store       *Store
+	timer       *time.Timer
+	bus         *bus.MessageBus
+	cfg         *config.Config
+	agentRunner AgentRunner
+	started     bool
+	stopped     bool
+	mu          sync.Mutex
+}
+
+// NewScheduler loads existing jobs and prepares the scheduler.
 func NewScheduler(cfg *config.Config, messageBus *bus.MessageBus) (*Scheduler, error) {
 	storePath := cfg.WorkspacePath() + "/cron/jobs.json"
 	store := NewStore(storePath)
@@ -35,35 +57,51 @@ func NewScheduler(cfg *config.Config, messageBus *bus.MessageBus) (*Scheduler, e
 	}
 
 	s := &Scheduler{
-		store:   store,
-		cron:    cron.New(),
-		timers:  make(map[string]*time.Timer),
-		entries: make(map[string]cron.EntryID),
-		bus:     messageBus,
-		cfg:     cfg,
+		store: store,
+		bus:   messageBus,
+		cfg:   cfg,
 	}
-
-	for _, job := range jobs {
-		if job.Enabled {
-			s.scheduleJob(job)
+	if changed := s.recomputeNextRunsLocked(jobs, time.Now(), true); changed {
+		if err := s.store.Save(jobs); err != nil {
+			return nil, fmt.Errorf("persist cron state: %w", err)
 		}
 	}
-
 	return s, nil
+}
+
+func (s *Scheduler) SetAgentRunner(r AgentRunner) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.agentRunner = r
 }
 
 // Start begins the cron runner.
 func (s *Scheduler) Start() {
-	s.cron.Start()
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return
+	}
+	s.started = true
+	s.stopped = false
+	s.mu.Unlock()
+
+	s.markInterruptedRuns()
+	s.runMissedJobs()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.armTimerLocked(time.Now())
 }
 
 // Stop halts the cron runner and cancels pending timers.
 func (s *Scheduler) Stop() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.cron.Stop()
-	for _, t := range s.timers {
-		t.Stop()
+	s.stopped = true
+	if s.timer != nil {
+		s.timer.Stop()
+		s.timer = nil
 	}
 }
 
@@ -81,13 +119,27 @@ func (s *Scheduler) AddJob(job Job) error {
 			return fmt.Errorf("job %q already exists", job.Name)
 		}
 	}
+	if job.CreatedAt.IsZero() {
+		job.CreatedAt = time.Now()
+	}
+	if job.Timezone == "" && job.CronExpr != "" {
+		job.Timezone = s.defaultTimezone()
+	}
+	if job.Enabled {
+		next, err := s.computeNextRun(job, time.Now())
+		if err != nil {
+			job.State.LastStatus = StatusError
+			job.State.LastError = "schedule error: " + err.Error()
+			job.State.ConsecutiveErrors++
+		} else {
+			job.State.NextRunAt = next
+		}
+	}
 	jobs = append(jobs, job)
 	if err := s.store.Save(jobs); err != nil {
 		return err
 	}
-	if job.Enabled {
-		s.scheduleJob(job)
-	}
+	s.armTimerLocked(time.Now())
 	return nil
 }
 
@@ -114,37 +166,34 @@ func (s *Scheduler) RemoveJob(name string) error {
 	if err := s.store.Save(jobs); err != nil {
 		return err
 	}
-	s.unscheduleJob(name)
+	s.armTimerLocked(time.Now())
 	return nil
 }
 
 // EnableJob enables and schedules a job.
 func (s *Scheduler) EnableJob(name string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	jobs, err := s.store.Load()
-	if err != nil {
-		return err
-	}
-	for i := range jobs {
-		if jobs[i].Name == name {
-			if jobs[i].Enabled {
-				return nil
-			}
-			jobs[i].Enabled = true
-			if err := s.store.Save(jobs); err != nil {
-				return err
-			}
-			s.scheduleJob(jobs[i])
-			return nil
+	return s.updateJob(name, func(job *Job) error {
+		job.Enabled = true
+		next, err := s.computeNextRun(*job, time.Now())
+		if err != nil {
+			return err
 		}
-	}
-	return fmt.Errorf("job %q not found", name)
+		job.State.NextRunAt = next
+		return nil
+	})
 }
 
 // DisableJob disables and unschedules a job.
 func (s *Scheduler) DisableJob(name string) error {
+	return s.updateJob(name, func(job *Job) error {
+		job.Enabled = false
+		job.State.NextRunAt = nil
+		job.State.RunningAt = nil
+		return nil
+	})
+}
+
+func (s *Scheduler) updateJob(name string, fn func(*Job) error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -153,129 +202,234 @@ func (s *Scheduler) DisableJob(name string) error {
 		return err
 	}
 	for i := range jobs {
-		if jobs[i].Name == name {
-			if !jobs[i].Enabled {
-				return nil
-			}
-			jobs[i].Enabled = false
-			if err := s.store.Save(jobs); err != nil {
-				return err
-			}
-			s.unscheduleJob(name)
-			return nil
+		if jobs[i].Name != name {
+			continue
 		}
+		if err := fn(&jobs[i]); err != nil {
+			return err
+		}
+		if err := s.store.Save(jobs); err != nil {
+			return err
+		}
+		s.armTimerLocked(time.Now())
+		return nil
 	}
 	return fmt.Errorf("job %q not found", name)
 }
 
 // ListJobs returns all persisted jobs.
 func (s *Scheduler) ListJobs() ([]Job, error) {
-	return s.store.Load()
-}
-
-func (s *Scheduler) scheduleJob(job Job) {
-	if !job.Enabled {
-		return
-	}
-
-	// Priority: at_seconds > every_seconds > cron_expr
-	switch {
-	case job.AtSeconds != nil:
-		runAt := job.CreatedAt.Add(time.Duration(*job.AtSeconds) * time.Second)
-		now := time.Now()
-		if now.After(runAt) {
-			go s.executeJob(job)
-			_ = s.RemoveJob(job.Name)
-			return
-		}
-		d := runAt.Sub(now)
-		s.timers[job.Name] = time.AfterFunc(d, func() {
-			s.executeJob(job)
-			_ = s.RemoveJob(job.Name)
-		})
-	case job.EverySeconds != nil:
-		schedule := cron.Every(time.Duration(*job.EverySeconds) * time.Second)
-		id := s.cron.Schedule(schedule, cron.FuncJob(func() {
-			s.executeJob(job)
-		}))
-		s.entries[job.Name] = id
-	case job.CronExpr != "":
-		id, err := s.cron.AddFunc(job.CronExpr, func() {
-			s.executeJob(job)
-		})
-		if err != nil {
-			logger.ErrorCF("cron", "Invalid cron expression", map[string]any{
-				"job":   job.Name,
-				"expr":  job.CronExpr,
-				"error": err.Error(),
-			})
-			return
-		}
-		s.entries[job.Name] = id
-	}
-}
-
-func (s *Scheduler) unscheduleJob(name string) {
-	if timer, ok := s.timers[name]; ok {
-		timer.Stop()
-		delete(s.timers, name)
-	}
-	if entryID, ok := s.entries[name]; ok {
-		s.cron.Remove(entryID)
-		delete(s.entries, name)
-	}
-}
-
-func (s *Scheduler) executeJob(job Job) {
-	// Reload to respect disable/remove that happened after scheduling.
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	jobs, err := s.store.Load()
 	if err != nil {
-		logger.ErrorCF("cron", "Failed to reload job", map[string]any{"error": err.Error()})
-		return
+		return nil, err
 	}
-	var current *Job
-	for i := range jobs {
-		if jobs[i].Name == job.Name {
-			current = &jobs[i]
-			break
+	if changed := s.recomputeNextRunsLocked(jobs, time.Now(), false); changed {
+		if err := s.store.Save(jobs); err != nil {
+			return nil, err
 		}
 	}
-	if current == nil || !current.Enabled {
-		return
-	}
-
-	logger.InfoCF("cron", "Executing job", map[string]any{
-		"name":    current.Name,
-		"channel": current.targetContext().Channel,
-		"chat_id": current.targetContext().ChatID,
-	})
-
-	ctx := context.Background()
-	target := current.targetContext()
-	if target.Channel == "" || target.ChatID == "" {
-		logger.WarnCF("cron", "Skipping cron job with missing routing context", map[string]any{
-			"job": current.Name,
-		})
-		return
-	}
-
-	if current.Command != "" {
-		s.executeCommandJob(ctx, *current)
-		return
-	}
-
-	if current.Deliver {
-		s.deliverMessage(ctx, *current)
-		return
-	}
-
-	s.agentTurn(ctx, *current)
+	return jobs, nil
 }
 
-func (s *Scheduler) agentTurn(ctx context.Context, job Job) {
+func (s *Scheduler) Status() (string, error) {
+	jobs, err := s.ListJobs()
+	if err != nil {
+		return "", err
+	}
+	next := nextWake(jobs)
+	if next == nil {
+		return fmt.Sprintf("Cron scheduler enabled. Jobs: %d. No next run scheduled.", len(jobs)), nil
+	}
+	return fmt.Sprintf("Cron scheduler enabled. Jobs: %d. Next run: %s.", len(jobs), next.UTC().Format(time.RFC3339)), nil
+}
+
+func (s *Scheduler) RunJob(name string, force bool) error {
+	job, ok, err := s.claimJob(name, time.Now(), force)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("job %q is not due", name)
+	}
+	go s.executeClaimedJob(job)
+	return nil
+}
+
+func (s *Scheduler) tick() {
+	now := time.Now()
+	for {
+		job, ok, err := s.claimNextDueJob(now)
+		if err != nil {
+			logger.ErrorCF("cron", "Failed to claim due job", map[string]any{"error": err.Error()})
+			break
+		}
+		if !ok {
+			break
+		}
+		go s.executeClaimedJob(job)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.armTimerLocked(time.Now())
+}
+
+func (s *Scheduler) claimNextDueJob(now time.Time) (Job, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	jobs, err := s.store.Load()
+	if err != nil {
+		return Job{}, false, err
+	}
+	s.recomputeNextRunsLocked(jobs, now, false)
+	for i := range jobs {
+		if !isDue(jobs[i], now, false) || jobs[i].State.RunningAt != nil {
+			continue
+		}
+		runningAt := now.UTC()
+		jobs[i].State.RunningAt = &runningAt
+		jobs[i].State.LastError = ""
+		job := jobs[i]
+		if err := s.store.Save(jobs); err != nil {
+			return Job{}, false, err
+		}
+		return job, true, nil
+	}
+	if err := s.store.Save(jobs); err != nil {
+		return Job{}, false, err
+	}
+	return Job{}, false, nil
+}
+
+func (s *Scheduler) claimJob(name string, now time.Time, force bool) (Job, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	jobs, err := s.store.Load()
+	if err != nil {
+		return Job{}, false, err
+	}
+	s.recomputeNextRunsLocked(jobs, now, false)
+	for i := range jobs {
+		if jobs[i].Name != name {
+			continue
+		}
+		if jobs[i].State.RunningAt != nil {
+			return Job{}, false, fmt.Errorf("job %q is already running", name)
+		}
+		if !isDue(jobs[i], now, force) {
+			return Job{}, false, nil
+		}
+		runningAt := now.UTC()
+		jobs[i].State.RunningAt = &runningAt
+		jobs[i].State.LastError = ""
+		job := jobs[i]
+		if err := s.store.Save(jobs); err != nil {
+			return Job{}, false, err
+		}
+		return job, true, nil
+	}
+	return Job{}, false, fmt.Errorf("job %q not found", name)
+}
+
+func (s *Scheduler) executeClaimedJob(job Job) {
+	start := time.Now()
+	err := s.runJob(context.Background(), job)
+	status := StatusOK
+	errText := ""
+	if err != nil {
+		status = StatusError
+		errText = err.Error()
+		logger.ErrorCF("cron", "Cron job failed", map[string]any{"job": job.Name, "error": errText})
+		s.notifyFailure(context.Background(), job, errText)
+	}
+	s.finishJob(job.Name, status, errText, start, time.Now())
+}
+
+// executeJob is retained for focused tests and manual execution paths.
+func (s *Scheduler) executeJob(job Job) {
+	start := time.Now()
+	err := s.runJob(context.Background(), job)
+	status := StatusOK
+	errText := ""
+	if err != nil {
+		status = StatusError
+		errText = err.Error()
+	}
+	s.finishJob(job.Name, status, errText, start, time.Now())
+}
+
+func (s *Scheduler) runJob(ctx context.Context, job Job) error {
 	target := job.targetContext()
-	// Cron agent turns run in a dedicated per-job session so recurring jobs
-	// build their own relevant history instead of inheriting unrelated chat turns.
+	logger.InfoCF("cron", "Executing job", map[string]any{
+		"name":    job.Name,
+		"channel": target.Channel,
+		"chat_id": target.ChatID,
+	})
+	if target.Channel == "" || target.ChatID == "" {
+		return fmt.Errorf("missing routing context")
+	}
+	if job.Command != "" {
+		return s.executeCommandJob(ctx, job)
+	}
+	if job.Deliver {
+		return s.deliverMessage(ctx, job)
+	}
+	return s.agentTurn(ctx, job)
+}
+
+func (s *Scheduler) finishJob(name, status, errText string, startedAt, endedAt time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	jobs, err := s.store.Load()
+	if err != nil {
+		logger.ErrorCF("cron", "Failed to persist job result", map[string]any{"job": name, "error": err.Error()})
+		return
+	}
+	now := endedAt.UTC()
+	for i := range jobs {
+		if jobs[i].Name != name {
+			continue
+		}
+		jobs[i].State.RunningAt = nil
+		jobs[i].State.LastRunAt = &now
+		jobs[i].State.LastStatus = status
+		jobs[i].State.LastError = errText
+		jobs[i].State.LastDurationMS = endedAt.Sub(startedAt).Milliseconds()
+		if status == StatusOK {
+			jobs[i].State.ConsecutiveErrors = 0
+		} else {
+			jobs[i].State.ConsecutiveErrors++
+		}
+		if jobs[i].AtSeconds != nil && status == StatusOK {
+			jobs[i].Enabled = false
+			jobs[i].State.NextRunAt = nil
+		} else if jobs[i].Enabled {
+			next, err := s.computeNextRun(jobs[i], endedAt)
+			if err != nil {
+				jobs[i].State.LastStatus = StatusError
+				jobs[i].State.LastError = "schedule error: " + err.Error()
+				jobs[i].State.ConsecutiveErrors++
+				jobs[i].State.NextRunAt = nil
+			} else {
+				jobs[i].State.NextRunAt = next
+			}
+		}
+		break
+	}
+	if err := s.store.Save(jobs); err != nil {
+		logger.ErrorCF("cron", "Failed to save job result", map[string]any{"job": name, "error": err.Error()})
+		return
+	}
+	s.armTimerLocked(time.Now())
+}
+
+func (s *Scheduler) agentTurn(ctx context.Context, job Job) error {
+	target := job.targetContext()
 	msg := bus.InboundMessage{
 		Context: target,
 		Sender: bus.SenderInfo{
@@ -284,15 +438,14 @@ func (s *Scheduler) agentTurn(ctx context.Context, job Job) {
 		Content:    job.Message,
 		SessionKey: cronSessionKey(job),
 	}
-	if err := s.bus.PublishInbound(ctx, msg); err != nil {
-		logger.ErrorCF("cron", "Failed to publish inbound cron job", map[string]any{
-			"job":   job.Name,
-			"error": err.Error(),
-		})
+	if s.agentRunner != nil {
+		_, err := s.agentRunner.RunCronAgentTurn(ctx, msg)
+		return err
 	}
+	return s.bus.PublishInbound(ctx, msg)
 }
 
-func (s *Scheduler) deliverMessage(ctx context.Context, job Job) {
+func (s *Scheduler) deliverMessage(ctx context.Context, job Job) error {
 	target := job.targetContext()
 	msg := bus.OutboundMessage{
 		Channel: target.Channel,
@@ -301,20 +454,12 @@ func (s *Scheduler) deliverMessage(ctx context.Context, job Job) {
 		Content: job.Message,
 	}
 	msg = bus.MarkSystemOutboundMessage(msg)
-	if err := s.bus.PublishOutbound(ctx, msg); err != nil {
-		logger.ErrorCF("cron", "Failed to publish outbound cron job", map[string]any{
-			"job":   job.Name,
-			"error": err.Error(),
-		})
-	}
+	return s.bus.PublishOutbound(ctx, msg)
 }
 
-func (s *Scheduler) executeCommandJob(ctx context.Context, job Job) {
+func (s *Scheduler) executeCommandJob(ctx context.Context, job Job) error {
 	if !s.cfg.Tools.IsToolEnabled("exec") {
-		logger.WarnCF("cron", "Exec tool disabled, skipping command job", map[string]any{
-			"job": job.Name,
-		})
-		return
+		return fmt.Errorf("exec tool disabled")
 	}
 
 	timeout := time.Duration(s.cfg.Tools.Cron.ExecTimeoutMinutes) * time.Minute
@@ -341,12 +486,241 @@ func (s *Scheduler) executeCommandJob(ctx context.Context, job Job) {
 		SessionKey: target.Channel + ":" + target.ChatID,
 	}
 	msg = bus.MarkSystemOutboundMessage(msg)
+	if publishErr := s.bus.PublishOutbound(ctx, msg); publishErr != nil {
+		return publishErr
+	}
+	return err
+}
+
+func (s *Scheduler) notifyFailure(ctx context.Context, job Job, errText string) {
+	target := job.targetContext()
+	if target.Channel == "" || target.ChatID == "" {
+		return
+	}
+	msg := bus.MarkSystemOutboundMessage(bus.OutboundMessage{
+		Channel: target.Channel,
+		ChatID:  target.ChatID,
+		Context: target,
+		Content: fmt.Sprintf("Cron job %q failed: %s", job.Name, errText),
+	})
 	if err := s.bus.PublishOutbound(ctx, msg); err != nil {
-		logger.ErrorCF("cron", "Failed to publish command job output", map[string]any{
-			"job":   job.Name,
-			"error": err.Error(),
+		logger.ErrorCF("cron", "Failed to publish cron failure notification", map[string]any{"job": job.Name, "error": err.Error()})
+	}
+}
+
+func (s *Scheduler) markInterruptedRuns() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	jobs, err := s.store.Load()
+	if err != nil {
+		logger.ErrorCF("cron", "Failed to load jobs on startup", map[string]any{"error": err.Error()})
+		return
+	}
+	now := time.Now().UTC()
+	changed := false
+	for i := range jobs {
+		if jobs[i].State.RunningAt == nil {
+			continue
+		}
+		jobs[i].State.LastRunAt = jobs[i].State.RunningAt
+		jobs[i].State.RunningAt = nil
+		jobs[i].State.LastStatus = StatusError
+		jobs[i].State.LastError = startupInterruptedError
+		jobs[i].State.ConsecutiveErrors++
+		changed = true
+	}
+	if s.recomputeNextRunsLocked(jobs, now, false) {
+		changed = true
+	}
+	if changed {
+		if err := s.store.Save(jobs); err != nil {
+			logger.ErrorCF("cron", "Failed to save startup cron state", map[string]any{"error": err.Error()})
+		}
+	}
+}
+
+func (s *Scheduler) runMissedJobs() {
+	for i := 0; i < defaultStartupCatchupLimit; i++ {
+		job, ok, err := s.claimNextDueJob(time.Now())
+		if err != nil {
+			logger.ErrorCF("cron", "Failed startup catch-up claim", map[string]any{"error": err.Error()})
+			return
+		}
+		if !ok {
+			return
+		}
+		delay := time.Duration(i) * defaultStartupCatchupStagger
+		time.AfterFunc(delay, func() {
+			s.executeClaimedJob(job)
 		})
 	}
+}
+
+func (s *Scheduler) recomputeNextRunsLocked(jobs []Job, now time.Time, recomputeExisting bool) bool {
+	changed := false
+	for i := range jobs {
+		if !jobs[i].Enabled {
+			if jobs[i].State.NextRunAt != nil {
+				jobs[i].State.NextRunAt = nil
+				changed = true
+			}
+			continue
+		}
+		if jobs[i].CronExpr != "" && jobs[i].Timezone == "" {
+			jobs[i].Timezone = defaultTimezone
+			changed = true
+		}
+		if jobs[i].State.RunningAt != nil {
+			continue
+		}
+		if jobs[i].State.NextRunAt != nil && !recomputeExisting {
+			continue
+		}
+		next, err := s.computeNextRun(jobs[i], now)
+		if err != nil {
+			jobs[i].State.LastStatus = StatusError
+			jobs[i].State.LastError = "schedule error: " + err.Error()
+			jobs[i].State.ConsecutiveErrors++
+			jobs[i].State.NextRunAt = nil
+			changed = true
+			continue
+		}
+		if !sameTimePtr(jobs[i].State.NextRunAt, next) {
+			jobs[i].State.NextRunAt = next
+			changed = true
+		}
+	}
+	return changed
+}
+
+func (s *Scheduler) computeNextRun(job Job, now time.Time) (*time.Time, error) {
+	switch {
+	case job.AtSeconds != nil:
+		if job.State.LastStatus == StatusOK && job.State.LastRunAt != nil {
+			return nil, nil
+		}
+		runAt := job.CreatedAt.Add(time.Duration(*job.AtSeconds) * time.Second).UTC()
+		return &runAt, nil
+	case job.EverySeconds != nil:
+		every := time.Duration(*job.EverySeconds) * time.Second
+		if every <= 0 {
+			return nil, fmt.Errorf("every_seconds must be positive")
+		}
+		anchor := job.CreatedAt
+		if anchor.IsZero() {
+			anchor = now
+		}
+		if job.State.LastRunAt != nil {
+			next := job.State.LastRunAt.Add(every).UTC()
+			if next.After(now) {
+				return &next, nil
+			}
+		}
+		elapsed := now.Sub(anchor)
+		if elapsed < 0 {
+			next := anchor.UTC()
+			return &next, nil
+		}
+		steps := int64(math.Floor(float64(elapsed)/float64(every))) + 1
+		next := anchor.Add(time.Duration(steps) * every).UTC()
+		return &next, nil
+	case job.CronExpr != "":
+		loc, err := time.LoadLocation(resolveTimezone(job.Timezone))
+		if err != nil {
+			return nil, err
+		}
+		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+		schedule, err := parser.Parse(job.CronExpr)
+		if err != nil {
+			return nil, err
+		}
+		next := schedule.Next(now.In(loc)).UTC()
+		if next.IsZero() {
+			return nil, fmt.Errorf("no future run")
+		}
+		return &next, nil
+	default:
+		return nil, fmt.Errorf("missing schedule")
+	}
+}
+
+func (s *Scheduler) armTimerLocked(now time.Time) {
+	if s.stopped || !s.started {
+		return
+	}
+	jobs, err := s.store.Load()
+	if err != nil {
+		logger.ErrorCF("cron", "Failed to load jobs for timer", map[string]any{"error": err.Error()})
+		return
+	}
+	if s.recomputeNextRunsLocked(jobs, now, false) {
+		if err := s.store.Save(jobs); err != nil {
+			logger.ErrorCF("cron", "Failed to persist next runs", map[string]any{"error": err.Error()})
+			return
+		}
+	}
+	next := nextWake(jobs)
+	if s.timer != nil {
+		s.timer.Stop()
+		s.timer = nil
+	}
+	if next == nil {
+		return
+	}
+	delay := time.Until(*next)
+	if delay < 0 {
+		delay = 0
+	}
+	if delay > defaultSchedulerMaxTimerDelay {
+		delay = defaultSchedulerMaxTimerDelay
+	}
+	s.timer = time.AfterFunc(delay, s.tick)
+}
+
+func (s *Scheduler) defaultTimezone() string {
+	if s.cfg != nil && s.cfg.Tools.Cron.Timezone != "" {
+		return s.cfg.Tools.Cron.Timezone
+	}
+	return defaultTimezone
+}
+
+func resolveTimezone(tz string) string {
+	if tz == "" {
+		return defaultTimezone
+	}
+	return tz
+}
+
+func isDue(job Job, now time.Time, force bool) bool {
+	if force {
+		return job.Enabled
+	}
+	if !job.Enabled || job.State.NextRunAt == nil {
+		return false
+	}
+	return !job.State.NextRunAt.After(now)
+}
+
+func nextWake(jobs []Job) *time.Time {
+	var next *time.Time
+	for i := range jobs {
+		if !jobs[i].Enabled || jobs[i].State.RunningAt != nil || jobs[i].State.NextRunAt == nil {
+			continue
+		}
+		if next == nil || jobs[i].State.NextRunAt.Before(*next) {
+			t := *jobs[i].State.NextRunAt
+			next = &t
+		}
+	}
+	return next
+}
+
+func sameTimePtr(a, b *time.Time) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.Equal(*b)
 }
 
 func (j Job) targetContext() bus.InboundContext {

--- a/pkg/cron/scheduler_test.go
+++ b/pkg/cron/scheduler_test.go
@@ -175,3 +175,51 @@ func TestSchedulerSkipsLegacyJobsWithoutContext(t *testing.T) {
 	case <-time.After(200 * time.Millisecond):
 	}
 }
+
+func TestSchedulerCronExpressionUsesJobTimezone(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newExecutionTestScheduler(t, false)
+	now := time.Date(2026, time.May, 5, 5, 59, 0, 0, time.UTC)
+	job := Job{
+		Name:      "morning",
+		CronExpr:  "5 8 * * *",
+		Timezone:  "Europe/Amsterdam",
+		Enabled:   true,
+		CreatedAt: now,
+	}
+
+	next, err := scheduler.computeNextRun(job, now)
+	require.NoError(t, err)
+	require.NotNil(t, next)
+	require.Equal(t, time.Date(2026, time.May, 5, 6, 5, 0, 0, time.UTC), *next)
+}
+
+func TestSchedulerFinishJobPersistsStatusAndNextRun(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newExecutionTestScheduler(t, false)
+	every := 60
+	start := time.Date(2026, time.May, 5, 6, 0, 0, 0, time.UTC)
+	job := Job{
+		Name:         "heartbeat",
+		Message:      "tick",
+		Channel:      "telegram",
+		ChatID:       "123",
+		SenderID:     "123",
+		EverySeconds: &every,
+		Enabled:      true,
+		CreatedAt:    start,
+	}
+	require.NoError(t, scheduler.store.Save([]Job{job}))
+
+	scheduler.finishJob(job.Name, StatusOK, "", start, start.Add(2*time.Second))
+
+	jobs, err := scheduler.store.Load()
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	require.Equal(t, StatusOK, jobs[0].State.LastStatus)
+	require.NotNil(t, jobs[0].State.LastRunAt)
+	require.NotNil(t, jobs[0].State.NextRunAt)
+	require.Equal(t, start.Add(62*time.Second), *jobs[0].State.NextRunAt)
+}

--- a/pkg/cron/scheduler_test.go
+++ b/pkg/cron/scheduler_test.go
@@ -1,6 +1,7 @@
 package cron
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -222,4 +223,63 @@ func TestSchedulerFinishJobPersistsStatusAndNextRun(t *testing.T) {
 	require.NotNil(t, jobs[0].State.LastRunAt)
 	require.NotNil(t, jobs[0].State.NextRunAt)
 	require.Equal(t, start.Add(62*time.Second), *jobs[0].State.NextRunAt)
+}
+
+func TestSchedulerRunJobUsesStartContext(t *testing.T) {
+	t.Parallel()
+
+	scheduler := newExecutionTestScheduler(t, false)
+	started := make(chan struct{})
+	done := make(chan struct{})
+	scheduler.SetAgentRunner(blockingAgentRunner{
+		started: started,
+		done:    done,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	scheduler.Start(ctx)
+
+	job := Job{
+		Name:    "agent",
+		Message: "check",
+		Context: bus.InboundContext{
+			Channel:  "telegram",
+			ChatID:   "123",
+			SenderID: "123",
+		},
+		Enabled:   true,
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, scheduler.AddJob(job))
+	require.NoError(t, scheduler.RunJob(job.Name, true))
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
+type blockingAgentRunner struct {
+	started chan struct{}
+	done    chan struct{}
+}
+
+func (r blockingAgentRunner) RunCronAgentTurn(ctx context.Context, _ bus.InboundMessage) (AgentRunResult, error) {
+	close(r.started)
+	<-ctx.Done()
+	close(r.done)
+	return AgentRunResult{}, ctx.Err()
 }

--- a/pkg/cron/store.go
+++ b/pkg/cron/store.go
@@ -29,6 +29,10 @@ func (s *Store) Load() ([]Job, error) {
 	if err != nil {
 		return nil, err
 	}
+	var store StoreFile
+	if err := json.Unmarshal(data, &store); err == nil && store.Version > 0 {
+		return store.Jobs, nil
+	}
 	var jobs []Job
 	if err := json.Unmarshal(data, &jobs); err != nil {
 		return nil, err
@@ -44,7 +48,7 @@ func (s *Store) Save(jobs []Job) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
-	data, err := json.MarshalIndent(jobs, "", "  ")
+	data, err := json.MarshalIndent(StoreFile{Version: 1, Jobs: jobs}, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/pkg/cron/store_test.go
+++ b/pkg/cron/store_test.go
@@ -52,3 +52,16 @@ func TestStoreAtomicWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, stat.IsDir())
 }
+
+func TestStoreLoadsLegacyArrayShape(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "jobs.json")
+	require.NoError(t, os.WriteFile(path, []byte(`[{"name":"legacy","message":"hello","enabled":true}]`), 0644))
+
+	store := NewStore(path)
+	jobs, err := store.Load()
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	require.Equal(t, "legacy", jobs[0].Name)
+	require.True(t, jobs[0].Enabled)
+}

--- a/pkg/cron/tool.go
+++ b/pkg/cron/tool.go
@@ -33,7 +33,7 @@ func (t *CronTool) Name() string { return "cron" }
 
 // Description returns the tool description.
 func (t *CronTool) Description() string {
-	return "Manage scheduled cron jobs. Actions: add, list, remove, enable, disable."
+	return "Manage scheduled cron jobs. Actions: add, list, status, run, remove, enable, disable. Cron expressions are local wall-clock time in timezone; do not convert requested local times to UTC first."
 }
 
 // Parameters returns the tool parameters.
@@ -41,7 +41,7 @@ func (t *CronTool) Parameters() map[string]interfaces.ParameterSpec {
 	return map[string]interfaces.ParameterSpec{
 		"action": {
 			Type:        "string",
-			Description: "Action to perform: add, list, remove, enable, disable",
+			Description: "Action to perform: add, list, status, run, remove, enable, disable",
 			Required:    true,
 		},
 		"name": {
@@ -66,12 +66,22 @@ func (t *CronTool) Parameters() map[string]interfaces.ParameterSpec {
 		},
 		"cron_expr": {
 			Type:        "string",
-			Description: "Standard cron expression",
+			Description: "Standard 5-field cron expression in local wall-clock time for timezone, e.g. 5 8 * * * means 08:05 in that timezone",
+			Required:    false,
+		},
+		"timezone": {
+			Type:        "string",
+			Description: "IANA timezone for cron_expr, e.g. Europe/Amsterdam. Defaults to configured cron timezone.",
 			Required:    false,
 		},
 		"deliver": {
 			Type:        "boolean",
 			Description: "Deliver directly without agent processing",
+			Required:    false,
+		},
+		"force": {
+			Type:        "boolean",
+			Description: "For action=run, run even when the job is not currently due. Defaults to true.",
 			Required:    false,
 		},
 		"command": {
@@ -102,6 +112,10 @@ func (t *CronTool) Execute(ctx context.Context, args string) (string, error) {
 		return t.addJob(ctx, params)
 	case "list":
 		return t.listJobs()
+	case "status":
+		return t.scheduler.Status()
+	case "run":
+		return t.runJob(params)
 	case "remove":
 		return t.removeJob(params)
 	case "enable":
@@ -156,6 +170,7 @@ func (t *CronTool) addJob(ctx context.Context, params map[string]any) (string, e
 		}
 	}
 	cronExpr, _ := params["cron_expr"].(string)
+	timezone, _ := params["timezone"].(string)
 
 	if atSeconds == nil && everySeconds == nil && cronExpr == "" {
 		return "", fmt.Errorf("one of at_seconds, every_seconds, or cron_expr is required")
@@ -185,6 +200,7 @@ func (t *CronTool) addJob(ctx context.Context, params map[string]any) (string, e
 		AtSeconds:    atSeconds,
 		EverySeconds: everySeconds,
 		CronExpr:     cronExpr,
+		Timezone:     timezone,
 		Deliver:      deliver,
 		Command:      command,
 		Enabled:      true,
@@ -202,11 +218,27 @@ func (t *CronTool) addJob(ctx context.Context, params map[string]any) (string, e
 	job.Channel = job.Context.Channel
 	job.ChatID = job.Context.ChatID
 	job.SenderID = job.Context.SenderID
+	if job.CronExpr != "" && job.Timezone == "" {
+		job.Timezone = t.cfg.Tools.Cron.Timezone
+		if job.Timezone == "" {
+			job.Timezone = "UTC"
+		}
+	}
 
 	if err := t.scheduler.AddJob(job); err != nil {
 		return "", err
 	}
 
+	jobs, _ := t.scheduler.ListJobs()
+	for _, saved := range jobs {
+		if saved.Name == name && saved.State.NextRunAt != nil {
+			local := saved.State.NextRunAt.UTC()
+			if loc, err := time.LoadLocation(saved.Timezone); err == nil {
+				local = saved.State.NextRunAt.In(loc)
+			}
+			return fmt.Sprintf("Job %q added successfully. Next run: %s (%s UTC)", name, local.Format(time.RFC3339), saved.State.NextRunAt.UTC().Format(time.RFC3339)), nil
+		}
+	}
 	return fmt.Sprintf("Job %q added successfully", name), nil
 }
 
@@ -227,6 +259,26 @@ func (t *CronTool) removeJob(params map[string]any) (string, error) {
 		return "", err
 	}
 	return fmt.Sprintf("Job %q removed", name), nil
+}
+
+func (t *CronTool) runJob(params map[string]any) (string, error) {
+	name, _ := params["name"].(string)
+	if name == "" {
+		return "", fmt.Errorf("name is required for run")
+	}
+	force := true
+	if v, ok := params["force"]; ok {
+		switch val := v.(type) {
+		case bool:
+			force = val
+		case string:
+			force = strings.ToLower(val) == "true"
+		}
+	}
+	if err := t.scheduler.RunJob(name, force); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Job %q run started", name), nil
 }
 
 func (t *CronTool) enableJob(params map[string]any) (string, error) {


### PR DESCRIPTION
## Summary
- Rework cron into a persisted scheduler with explicit next-run and run-state tracking.
- Add timezone-aware cron evaluation, startup catch-up, and failure reporting for agent/direct/command jobs.
- Extend the cron tool and docs with `status`, `run`, and clearer wall-clock scheduling behavior.

## Test plan
- `make lint`
- `make test`
- `go test ./...`

## Known gaps
- None captured during implementation.