### PR TITLE
Stop preloading workspace memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,12 +196,13 @@ The agent loads markdown files from `agents.defaults.workspace` at startup to bu
 |------|---------|
 | `AGENT.md` | Agent name, role, mission, capabilities |
 | `IDENTITY.md` | Identity, profile details, stable preferences |
-| `MEMORY.md` | Durable notes, long-lived facts, session-independent context |
 | `SOUL.md` | Personality and communication style |
 | `USER.md` | Legacy alias for `IDENTITY.md` in older workspaces |
 
 `internal/agent/context.go` (`ContextBuilder`) assembles these into a single system prompt with
 mtime-based caching. Skills in `workspace/skills/*/SKILL.md` are also enumerated and included.
+`workspace/memory/MEMORY.md` may exist, but it is intentionally not preloaded into context; the
+agent is instructed to inspect it explicitly with file or search tools when durable notes are relevant.
 
 ## Agent behavior
 

--- a/README.md
+++ b/README.md
@@ -243,11 +243,12 @@ The agent loads workspace markdown entrypoints from `agents.defaults.workspace` 
 |------|---------|
 | `AGENT.md` | Agent name, role, mission, capabilities |
 | `IDENTITY.md` | Identity, profile details, stable preferences |
-| `MEMORY.md` | Durable notes, long-lived facts, session-independent context |
 | `SOUL.md` | Personality and communication style |
 | `USER.md` | Legacy alias for `IDENTITY.md` in older workspaces |
 
 Edit these to shape how the agent behaves and presents itself.
+
+`memory/MEMORY.md` may exist in a workspace, but it is not loaded into the prompt automatically. The agent is told to inspect it explicitly with file or search tools when durable notes are relevant.
 
 ### Skills
 

--- a/internal/agent/context.go
+++ b/internal/agent/context.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ContextBuilder assembles the agent system prompt from workspace files:
-// AGENT.md, IDENTITY.md, MEMORY.md, SOUL.md, USER.md, and skills/*/SKILL.md.
+// AGENT.md, IDENTITY.md, SOUL.md, USER.md, and skills/*/SKILL.md.
 // Prompts are cached and invalidated when source file mtimes change.
 type ContextBuilder struct {
 	workspace string
@@ -82,10 +82,6 @@ func (b *ContextBuilder) buildPrompt() (string, error) {
 		sections = append(sections, soul)
 	}
 
-	if memory, ok := b.readFileIfExists(filepath.Join(b.workspace, "memory", "MEMORY.md")); ok {
-		sections = append(sections, "## Memory\n\n"+memory)
-	}
-
 	if summary := b.skillsSummary(filepath.Join(b.workspace, "skills")); summary != "" {
 		sections = append(sections, summary)
 	}
@@ -142,7 +138,6 @@ func (b *ContextBuilder) captureBaseline() (map[string]time.Time, map[string]boo
 	paths := []string{
 		filepath.Join(b.workspace, "AGENT.md"),
 		filepath.Join(b.workspace, "IDENTITY.md"),
-		filepath.Join(b.workspace, "memory", "MEMORY.md"),
 		filepath.Join(b.workspace, "SOUL.md"),
 		filepath.Join(b.workspace, "USER.md"),
 	}
@@ -237,9 +232,10 @@ func workspaceEntrypointsSection() string {
 
 - ` + "`AGENT.md`" + `: authoritative source for role, mission, capabilities, tool scope, and other assistant-level behavior.
 - ` + "`IDENTITY.md`" + `: authoritative source for identity, profile details, naming, and stable preferences.
-- ` + "`MEMORY.md`" + `: authoritative source for durable notes, long-lived facts, and session-independent context.
 - ` + "`SOUL.md`" + `: authoritative source for personality, tone, and communication style.
 - ` + "`USER.md`" + `: legacy alias for ` + "`IDENTITY.md`" + `; use only when a workspace has not been migrated yet.
+
+` + "`memory/MEMORY.md`" + ` may exist, but it is intentionally not preloaded into context. When durable notes or prior context would help answer a user request, inspect it explicitly with available file or search tools such as ` + "`rg`" + `.
 
 When a user asks you to change how the assistant behaves, infer the correct entrypoint from the requested change and edit that file directly. Do not ask the user which workspace file to touch.`)
 }

--- a/internal/agent/context_test.go
+++ b/internal/agent/context_test.go
@@ -60,7 +60,7 @@ Calm and concise.
 	assert.Contains(t, prompt, "Fallback identity content.")
 }
 
-func TestBuildSystemPromptIncludesMemoryEntryPoint(t *testing.T) {
+func TestBuildSystemPromptIgnoresMemoryEntryPoint(t *testing.T) {
 	workspace := t.TempDir()
 	writeWorkspaceFile(t, workspace, "AGENT.md", `You are the test agent.`)
 	writeWorkspaceFile(t, workspace, "IDENTITY.md", `Preferred identity content.`)
@@ -76,8 +76,10 @@ Remember to keep responses brief.
 	prompt, err := agent.NewContextBuilder(workspace).BuildSystemPromptWithCache()
 	require.NoError(t, err)
 
-	assert.Contains(t, prompt, "## Memory")
-	assert.Contains(t, prompt, "Remember to keep responses brief.")
+	assert.Contains(t, prompt, "`memory/MEMORY.md` may exist")
+	assert.Contains(t, prompt, "inspect it explicitly")
+	assert.NotContains(t, prompt, "## Memory")
+	assert.NotContains(t, prompt, "Remember to keep responses brief.")
 }
 
 func writeWorkspaceFile(t *testing.T, workspace, name, content string) {

--- a/workspace/AGENT.md
+++ b/workspace/AGENT.md
@@ -66,4 +66,4 @@ When the user asks to start a dev server:
 - Remain effective on constrained hardware
 - Improve through feedback and continued iteration
 
-Read `IDENTITY.md` for identity and stable preferences, `MEMORY.md` for long-lived notes, and `SOUL.md` for personality and communication style.
+Read `IDENTITY.md` for identity and stable preferences, and `SOUL.md` for personality and communication style.


### PR DESCRIPTION
## Summary
- Stop loading workspace/memory/MEMORY.md into the generated system prompt.
- Keep MEMORY.md discoverable by instructing the agent to inspect it explicitly with file/search tools when durable notes are relevant.
- Update docs and regression coverage for the new behavior.

## Test plan
- `make test`
- `make lint`